### PR TITLE
Allow providers to file results on behalf of other providers

### DIFF
--- a/src/main/java/ca/openosp/openo/lab/ca/on/CommonLabResultData.java
+++ b/src/main/java/ca/openosp/openo/lab/ca/on/CommonLabResultData.java
@@ -414,7 +414,7 @@ public class CommonLabResultData {
 				if (!skipCommentOnUpdate) {
 					String currentComment = Optional.ofNullable(providerLabRoutingModel.getComment()).orElse("").trim();
 					if (!comment.isEmpty() && !comment.equalsIgnoreCase(currentComment)) {
-						providerLabRoutingModel.setComment(comment.replaceAll(currentComment, currentComment));
+						providerLabRoutingModel.setComment(comment);
 					}
 				}
                 

--- a/src/main/java/ca/openosp/openo/lab/pageUtil/FileLabs2Action.java
+++ b/src/main/java/ca/openosp/openo/lab/pageUtil/FileLabs2Action.java
@@ -147,7 +147,10 @@ public class FileLabs2Action extends ActionSupport {
         boolean fileUpToLabNo = Boolean.valueOf(request.getParameter("fileUpToLabNo"));
         boolean onBehalfOfOtherProvider = Boolean.valueOf(request.getParameter("onBehalfOfOtherProvider"));
 
-        if (providerNo == null || flaggedLab == null) { return null; }
+        if (providerNo == null || flaggedLab == null || labType == null) { return null; }
+        flaggedLab = flaggedLab.trim();
+        labType = labType.trim();
+        if (flaggedLab.isEmpty() || labType.isEmpty()) { return null; }
 
         labManager.fileLabsForProviderUpToFlaggedLab(loggedInInfo, providerNo, flaggedLab, labType, comment, fileUpToLabNo, onBehalfOfOtherProvider);
 

--- a/src/main/java/ca/openosp/openo/managers/LabManager.java
+++ b/src/main/java/ca/openosp/openo/managers/LabManager.java
@@ -49,4 +49,6 @@ public interface LabManager {
     public List<ProviderLabRoutingModel> findByLabNoAndLabTypeAndProviderNo(LoggedInInfo loggedInInfo, Integer labId, String labType, String providerNo);
 
     public void fileLabsForProviderUpToFlaggedLab(LoggedInInfo loggedInInfo, String providerNo, String flaggedLabId, String labType, String comment, boolean fileUpToLabNo, boolean onBehalfOfOtherProvider);
+
+    public List<ProviderLabRoutingModel> getProviderLabRouting(LoggedInInfo loggedInInfo, int labNo, String labType, String provider);
 }

--- a/src/main/java/ca/openosp/openo/managers/LabManagerImpl.java
+++ b/src/main/java/ca/openosp/openo/managers/LabManagerImpl.java
@@ -203,6 +203,8 @@ public class LabManagerImpl implements LabManager {
             // Update report status and remove it from the queue
             CommonLabResultData.updateReportStatus(labId, providerNo, ProviderLabRoutingDao.STATUS.F.name().charAt(0),comment, labType, skipCommentOnUpdate);
             CommonLabResultData.removeFromQueue(labId);
+            LogAction.addLogSynchronous(loggedInInfo, "LabManager.fileLabsForProviderUpToFlaggedLab",
+                    "labId=" + labId + ", filedForProviderNo=" + providerNo + ", onBehalf=" + onBehalfOfOtherProvider);
         }
     }
 

--- a/src/main/java/ca/openosp/openo/managers/LabManagerImpl.java
+++ b/src/main/java/ca/openosp/openo/managers/LabManagerImpl.java
@@ -245,6 +245,11 @@ public class LabManagerImpl implements LabManager {
         }
     }
 
+    public List<ProviderLabRoutingModel> getProviderLabRouting(LoggedInInfo loggedInInfo, int labNo, String labType, String provider) {
+        checkPrivilege(loggedInInfo, "r");
+        return providerLabRoutingDao.findByLabNoAndLabTypeAndProviderNo(labNo, labType, provider);
+    }
+
     private void checkPrivilege(LoggedInInfo loggedInInfo, String privilege) {
         if (!securityInfoManager.hasPrivilege(loggedInInfo, "_lab", privilege, null)) {
             throw new RuntimeException("missing required sec object (_lab)");

--- a/src/main/java/ca/openosp/openo/managers/LabManagerImpl.java
+++ b/src/main/java/ca/openosp/openo/managers/LabManagerImpl.java
@@ -48,7 +48,9 @@ import ca.openosp.openo.commn.model.PatientLabRouting;
 import ca.openosp.openo.commn.model.ProviderLabRoutingModel;
 import ca.openosp.openo.utility.LoggedInInfo;
 import ca.openosp.openo.managers.ProviderManager2;
+import ca.openosp.openo.utility.MiscUtils;
 import ca.openosp.openo.utility.PDFGenerationException;
+import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -63,6 +65,7 @@ import ca.openosp.openo.util.StringUtils;
 @Service
 public class LabManagerImpl implements LabManager {
 
+    private static final Logger logger = MiscUtils.getLogger();
     private static final String TEMP_PDF_DIRECTORY = "hl7PDF";
     private static final String DEFAULT_FILE_SUFFIX = ".pdf";
 
@@ -173,10 +176,23 @@ public class LabManagerImpl implements LabManager {
     public void fileLabsForProviderUpToFlaggedLab(LoggedInInfo loggedInInfo, String providerNo, String flaggedLabId, String labType, String comment, boolean fileUpToLabNo, boolean onBehalfOfOtherProvider) {
         checkPrivilege(loggedInInfo, "w");
 
+        int parsedFlaggedLabId;
+        try {
+            parsedFlaggedLabId = Integer.parseInt(flaggedLabId.trim());
+        } catch (NumberFormatException e) {
+            logger.error("fileLabsForProviderUpToFlaggedLab: invalid flaggedLabId='" + flaggedLabId + "'");
+            return;
+        }
+
         CommonLabResultData commonLabResultData = new CommonLabResultData();
 
         // Gets lab IDs in order from oldest to latest (e.g., v1, v2, ..., vn)
         String labs = commonLabResultData.getMatchingLabs(flaggedLabId, labType);
+
+        if (labs == null || labs.trim().isEmpty()) {
+            logger.warn("fileLabsForProviderUpToFlaggedLab: no matching labs for flaggedLabId=" + flaggedLabId + ", labType=" + labType);
+            return;
+        }
 
         // The UI disables the checkbox, but this guards against crafted requests.
         if (onBehalfOfOtherProvider && !providerManager2.isHl7AllowOthersFileForYou(loggedInInfo, providerNo)) {
@@ -187,7 +203,7 @@ public class LabManagerImpl implements LabManager {
         List<Integer> filteredLabs = Arrays.stream(labs.split(","))
                 .map(String::trim)
                 .map(Integer::parseInt)
-                .filter(labId -> !fileUpToLabNo || labId <= Integer.parseInt(flaggedLabId))
+                .filter(labId -> !fileUpToLabNo || labId <= parsedFlaggedLabId)
                 .collect(Collectors.toList());
 
         for (Integer labId : filteredLabs) {

--- a/src/main/java/ca/openosp/openo/managers/LabManagerImpl.java
+++ b/src/main/java/ca/openosp/openo/managers/LabManagerImpl.java
@@ -51,6 +51,7 @@ import ca.openosp.openo.managers.ProviderManager2;
 import ca.openosp.openo.utility.MiscUtils;
 import ca.openosp.openo.utility.PDFGenerationException;
 import org.apache.logging.log4j.Logger;
+import org.owasp.encoder.Encode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -191,7 +192,7 @@ public class LabManagerImpl implements LabManager {
         try {
             parsedFlaggedLabId = Integer.parseInt(flaggedLabId.trim());
         } catch (NumberFormatException e) {
-            logger.error("fileLabsForProviderUpToFlaggedLab: invalid flaggedLabId='" + flaggedLabId + "'");
+            logger.error("fileLabsForProviderUpToFlaggedLab: invalid flaggedLabId='" + Encode.forJava(flaggedLabId) + "'");
             return;
         }
 
@@ -201,7 +202,7 @@ public class LabManagerImpl implements LabManager {
         String labs = commonLabResultData.getMatchingLabs(flaggedLabId, labType);
 
         if (labs == null || labs.trim().isEmpty()) {
-            logger.warn("fileLabsForProviderUpToFlaggedLab: no matching labs for flaggedLabId=" + flaggedLabId + ", labType=" + labType);
+            logger.warn("fileLabsForProviderUpToFlaggedLab: no matching labs for flaggedLabId=" + Encode.forJava(flaggedLabId) + ", labType=" + Encode.forJava(labType));
             return;
         }
 

--- a/src/main/java/ca/openosp/openo/managers/LabManagerImpl.java
+++ b/src/main/java/ca/openosp/openo/managers/LabManagerImpl.java
@@ -150,6 +150,17 @@ public class LabManagerImpl implements LabManager {
         return path;
     }
 
+    /**
+     * Returns all {@link ProviderLabRoutingModel} records that match the given lab number,
+     * lab type, and provider number.
+     *
+     * @param loggedInInfo LoggedInInfo the currently logged-in user; used to enforce {@code _lab} read privilege
+     * @param labId        Integer the unique lab segment ID to look up
+     * @param labType      String the lab type (e.g. {@code "HL7"}, {@code "MDS"})
+     * @param providerNo   String the provider number to filter routing records by
+     * @return List&lt;ProviderLabRoutingModel&gt; matching routing records; empty list if none exist
+     * @throws RuntimeException if the logged-in user lacks {@code _lab} read privilege
+     */
     @Override
     public List<ProviderLabRoutingModel> findByLabNoAndLabTypeAndProviderNo(LoggedInInfo loggedInInfo, Integer labId, String labType, String providerNo) {
         checkPrivilege(loggedInInfo, "r");

--- a/src/main/java/ca/openosp/openo/managers/LabManagerImpl.java
+++ b/src/main/java/ca/openosp/openo/managers/LabManagerImpl.java
@@ -47,6 +47,7 @@ import ca.openosp.openo.commn.model.Hl7TextMessage;
 import ca.openosp.openo.commn.model.PatientLabRouting;
 import ca.openosp.openo.commn.model.ProviderLabRoutingModel;
 import ca.openosp.openo.utility.LoggedInInfo;
+import ca.openosp.openo.managers.ProviderManager2;
 import ca.openosp.openo.utility.PDFGenerationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -82,6 +83,9 @@ public class LabManagerImpl implements LabManager {
 
     @Autowired
     SecurityInfoManager securityInfoManager;
+
+    @Autowired
+    ProviderManager2 providerManager2;
 
     public List<Hl7TextMessage> getHl7Messages(LoggedInInfo loggedInInfo, Integer demographicNo, int offset, int limit) {
         checkPrivilege(loggedInInfo, "r");
@@ -173,6 +177,11 @@ public class LabManagerImpl implements LabManager {
 
         // Gets lab IDs in order from oldest to latest (e.g., v1, v2, ..., vn)
         String labs = commonLabResultData.getMatchingLabs(flaggedLabId, labType);
+
+        // The UI disables the checkbox, but this guards against crafted requests.
+        if (onBehalfOfOtherProvider && !providerManager2.isHl7AllowOthersFileForYou(loggedInInfo, providerNo)) {
+            throw new SecurityException("Provider " + providerNo + " has not allowed others to file on their behalf");
+        }
 
         // Filter labs: if fileUpToLabNo is true, include only those <= flaggedLabId
         List<Integer> filteredLabs = Arrays.stream(labs.split(","))

--- a/src/main/java/ca/openosp/openo/managers/ProviderManager2.java
+++ b/src/main/java/ca/openosp/openo/managers/ProviderManager2.java
@@ -763,7 +763,7 @@ public class ProviderManager2 {
         return propertyDao.isActiveBooleanProperty(Property.PROPERTY_KEY.provider_linking_rules);
     }
 
-	// If no property is found, it returns true by default.
+	// If no property is found, it returns false by default.
 	public boolean isHl7OfferFileForOthers(LoggedInInfo loggedInInfo, String providerNo) {
 		if (!securityInfoManager.hasPrivilege(loggedInInfo, "_lab", SecurityInfoManager.READ, null)) {
 			throw new RuntimeException("missing required security object _lab");
@@ -773,7 +773,7 @@ public class ProviderManager2 {
 				.stream()
 				.findFirst()
 				.map(p -> "true".equals(p.getValue()))
-				.orElse(true); // default to true
+				.orElse(false); // default to false
 	}
 
 	public boolean isHl7AllowOthersFileForYou(LoggedInInfo loggedInInfo, String providerNo) {

--- a/src/main/java/ca/openosp/openo/mds/pageUtil/ReportStatusUpdate2Action.java
+++ b/src/main/java/ca/openosp/openo/mds/pageUtil/ReportStatusUpdate2Action.java
@@ -28,6 +28,7 @@ package ca.openosp.openo.mds.pageUtil;
 
 import java.io.IOException;
 import java.util.Calendar;
+import java.util.List;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -41,6 +42,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.logging.log4j.Logger;
 import ca.openosp.openo.commn.dao.PatientLabRoutingDao;
 import ca.openosp.openo.commn.model.PatientLabRouting;
+import ca.openosp.openo.commn.model.ProviderLabRoutingModel;
+import ca.openosp.openo.managers.LabManager;
 import ca.openosp.openo.managers.SecurityInfoManager;
 import ca.openosp.openo.utility.LoggedInInfo;
 import ca.openosp.openo.utility.MiscUtils;
@@ -62,6 +65,7 @@ public class ReportStatusUpdate2Action extends ActionSupport {
     private static Logger logger = MiscUtils.getLogger();
 
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
+    private LabManager labManager = SpringUtils.getBean(LabManager.class);
 
     public ReportStatusUpdate2Action() {
     }
@@ -77,8 +81,8 @@ public class ReportStatusUpdate2Action extends ActionSupport {
     }
 
     public String executemain() {
-
-        if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_lab", "w", null)) {
+        LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_lab", "w", null)) {
             throw new SecurityException("missing required sec object (_lab)");
         }
 
@@ -102,6 +106,10 @@ public class ReportStatusUpdate2Action extends ActionSupport {
                 int i = 0;
                 int idNum = Integer.parseInt(id[i]);
                 while (idNum != labNo) {
+                    List<ProviderLabRoutingModel> providerLabRoutingModels = labManager.findByLabNoAndLabTypeAndProviderNo(loggedInInfo, labNo, lab_type, providerNo);
+                    if (providerLabRoutingModels.size() != 0 && "A".equals(providerLabRoutingModels.get(0).getStatus())) {
+                        continue;
+                    }
                     CommonLabResultData.updateReportStatus(idNum, providerNo, 'F', "", lab_type);
                     i++;
                     idNum = Integer.parseInt(id[i]);

--- a/src/main/webapp/lab/CA/ALL/labDisplay.jsp
+++ b/src/main/webapp/lab/CA/ALL/labDisplay.jsp
@@ -796,36 +796,85 @@ request.setAttribute("missingTests", missingTests);
         }
 
         /* Change the background color of the dropdown button when the dropdown content is shown */
-.dropdown:hover .dropbtn {background-color: #3e8e41;}
+        .dropdown:hover .dropbtn {background-color: #3e8e41;}
 
-#labVersionInfoModal .modal-title {
-    font-size: 18px;
-    font-weight: bold;
-    margin-bottom: 15px;
-}
+        #labVersionInfoModal .modal-title {
+            font-size: 18px;
+            font-weight: bold;
+            margin-bottom: 15px;
+        }
 
-#labVersionInfoModal .info-section {
-    margin-bottom: 20px;
-}
+        #labVersionInfoModal .info-section {
+            margin-bottom: 20px;
+        }
 
-#labVersionInfoModal .info-section p {
-    margin: 5px 0;
-    color: #555;
-}
+        #labVersionInfoModal .info-section p {
+            margin: 5px 0;
+            color: #555;
+        }
 
-#labVersionInfoModal .test-list {
-    margin-left: 10px;
-}
+        #labVersionInfoModal .test-list {
+            margin-left: 10px;
+        }
 
-#labVersionInfoModal .test-item {
-    display: flex;
-    justify-content: space-between;
-    margin: 5px 0;
-}
+        #labVersionInfoModal .test-item {
+            display: flex;
+            justify-content: space-between;
+            margin: 5px 0;
+        }
 
-#labVersionInfoModal .status {
-    font-weight: bold;
-}
+        #labVersionInfoModal .status {
+            font-weight: bold;
+        }
+
+        /* White background and shadow for fileDialog and combinedAckFileDialog */
+        .ui-dialog:has(#fileDialog),
+        .ui-dialog:has(#combinedAckFileDialog) {
+            box-shadow: 0 4px 24px rgba(0, 0, 0, 0.25);
+        }
+
+        /* Center Submit/Cancel buttons for both dialogs */
+        /* .ui-dialog:has(#fileDialog) .ui-dialog-buttonpane, */
+        .ui-dialog:has(#combinedAckFileDialog) .ui-dialog-buttonpane {
+            text-align: center;
+        }
+        /* .ui-dialog:has(#fileDialog) .ui-dialog-buttonset, */
+        .ui-dialog:has(#combinedAckFileDialog) .ui-dialog-buttonset {
+            float: none;
+            display: inline-block;
+        }
+
+        /* Primary color for Submit button in combinedAckFileDialog */
+        #combinedAckOkButton.ui-button {
+            background: #0d6efd;
+            border-color: #0d6efd;
+            color: #fff;
+        }
+        #combinedAckOkButton.ui-button:hover {
+            background: #0b5ed7;
+            border-color: #0a58ca;
+        }
+
+        /* Accordion border on expanded content panel */
+        #combinedAckAccordion .ui-accordion-content {
+            border: 1px solid #dee2e6;
+        }
+
+        /* Keep accordion header color unchanged when active/focused */
+        #combinedAckAccordion .ui-accordion-header,
+        #combinedAckAccordion .ui-accordion-header.ui-state-active,
+        #combinedAckAccordion .ui-accordion-header:hover {
+            color: inherit;
+            background: #e9ecef;
+            border-color: #dee2e6;
+        }
+
+        /* Prevent icon from turning white on active/hover (designed for dark backgrounds) */
+        #combinedAckAccordion .ui-accordion-header.ui-state-active .ui-icon,
+        #combinedAckAccordion .ui-accordion-header:hover .ui-icon {
+            filter: brightness(0);
+        }
+
     </style>
 
     <script language="JavaScript">
@@ -1049,25 +1098,77 @@ request.setAttribute("missingTests", missingTests);
        	}
 
         jQuery(document).ready(function() {
+            // "Acknowledge/File Document" modal checkbox handler (Acknowledge button flow).
+            // Keeps "Select All" in sync with individual provider checkboxes.
+            // The OK button is always enabled — the provider can acknowledge without selecting anyone.
+            jQuery(document).on('change', '.combinedAckProviderCheckbox, #combinedAckSelectAllCheckbox', function() {
+                if (this.id === 'combinedAckSelectAllCheckbox') {
+                    jQuery(".combinedAckProviderCheckbox:not(.combined-disabled-checkbox)").prop('checked', this.checked);
+                }
+            });
+
+            // "File Document" dialog checkbox handler ("File for..." button flow).
+            // Keeps "Select All" in sync with individual provider checkboxes.
+            // The OK button stays disabled until at least one provider is checked,
+            // because filing requires an explicit provider target.
             jQuery(document).on('change', '.ackProviderCheckbox, #ackSelectAllCheckbox', function() {
                 if (this.id === 'ackSelectAllCheckbox') {
-                    // When "Select All" changes, update all checkboxes
                     jQuery(".ackProviderCheckbox:not(.disabled-checkbox)").prop('checked', this.checked);
                 }
-                jQuery("#ackYesButton").button("option", "disabled", jQuery(".ackProviderCheckbox:checked").length === 0);
+                const hasChecked = jQuery(".ackProviderCheckbox:checked").length > 0;
+                jQuery("#fileDialogOkButton").button("option", "disabled", !hasChecked);
+            });
+
+            // Accordion for "File Document" section in combinedAckFileDialog.
+            // Expanded by default when the lab is linked to other providers (isHl7OfferFileForOthers=true), collapsed otherwise.
+            jQuery("#combinedAckAccordion").accordion({
+                collapsible: true,
+                active: jQuery("#isHl7OfferFileForOthers").val() === "true" ? 0 : false,
+                heightStyle: "content"
+            });
+
+            // Submit the dialog when Enter is pressed in the comment input.
+            jQuery("#combinedAckComment").on("keydown", function(e) {
+                if (e.key === "Enter") {
+                    e.preventDefault();
+                    jQuery("#combinedAckOkButton").trigger("click");
+                }
             });
         });
 
-        // Global flag to track if "file on behalf" was triggered
-        var doFileOnBehalfOfProviders = false;
-
-        // Opens the modal dialog asking if the user wants to file on behalf of others.
+        // Entry point for both the "Acknowledge" button (isFileOnly=false) and
+        // the "File for..." button (isFileOnly=true). Routes to the correct dialog.
+        //
+        // isFileOnly=true  — "File for..." button:
+        //   The logged-in provider has already acknowledged. Opens the "File Document"
+        //   dialog (#fileDialog) so they can file on behalf of other providers.
+        //
+        // isFileOnly=false — "Acknowledge" button:
+        //   If skipComment=true: acknowledges directly via #tempAckBtn without any prompt.
+        //   Otherwise (skipComment=false): opens the combined "Acknowledge/File Document"
+        //   modal so the provider can enter a comment. When isHl7OfferFileForOthers=true,
+        //   the modal also allows optionally filing for other linked providers.
         function openFileDialog(isFileOnly) {
-            if ((jQuery(".ackProviderCheckbox:not(.disabled-checkbox)").length === 0 && !isFileOnly) || jQuery("#isHl7OfferFileForOthers").val() === "false") {
+            if (isFileOnly) {
+                openFileOnlyDialog();
+                return;
+            }
+            if (jQuery("#skipAckComment").val() === "true") {
                 jQuery('#tempAckBtn').click();
                 return;
             }
+            openCombinedAckFileDialog(false);
+        }
 
+        // Opens the "File Document" dialog (#fileDialog) for the "File for..." button flow.
+        // Reached only when the logged-in provider has already acknowledged the lab and at
+        // least one other linked provider has not yet filed or acknowledged.
+        //
+        // The provider selects one or more providers from the list and confirms. FileLabs.do
+        // is called for each selected provider in parallel, then the page reloads to reflect
+        // the updated filing status. The OK button starts disabled and enables only once
+        // at least one provider is checked.
+        function openFileOnlyDialog() {
             jQuery("#fileDialog").dialog({
                 autoOpen: false,
                 modal: true,
@@ -1079,40 +1180,121 @@ request.setAttribute("missingTests", missingTests);
                         text: "No",
                         click: function() {
                             jQuery("#fileDialog").dialog("close");
-                            if (!isFileOnly) { jQuery("#tempAckBtn").click(); }
                         }
                     },
                     {
                         text: "Yes",
-                        id: "ackYesButton",
+                        id: "fileDialogOkButton",
                         click: function() {
-                            doFileOnBehalfOfProviders = true;
+                            const selectedProviders = jQuery(".ackProviderCheckbox:checked").map(function() {
+                                return jQuery(this).val();
+                            }).get();
                             jQuery("#fileDialog").dialog("close");
-
-                            if (isFileOnly) {
-                                fileOnBehalfOfMultipleProviders().then(() => location.reload());
-                            } else {
-                                const skipAckComment = jQuery("#skipAckComment").val() === 'true';
-                                if (skipAckComment) {
-                                    handleLab('acknowledgeForm_'+jQuery("#segmentID").val(),jQuery("#segmentID").val(), 'ackLabAndFileForOther');
-                                } else {
-                                    getComment('ackLabAndFileForOther', jQuery("#segmentID").val());
-                                }
-                            }
+                            fileOnBehalfOfMultipleProviders(selectedProviders).then(function() {
+                                location.reload();
+                            });
                         },
-                        disabled: true // Initially disabled
+                        disabled: true
                     }
                 ]
             }).dialog("open");
         }
 
-        // Sends file requests for all selected providers.
-        function fileOnBehalfOfMultipleProviders() {
-            const selectedProviders = jQuery(".ackProviderCheckbox:checked").map(function() {
-                return jQuery(this).val();
-            }).get();
+        // Opens the "Acknowledge/File Document" modal (#combinedAckFileDialog).
+        // Used when the logged-in provider clicks "Acknowledge" and has opted in to
+        // offer filing for others (isHl7OfferFileForOthers=true).
+        //
+        // Combines two actions into a single step:
+        //   1. Enter an acknowledgement comment (pre-populated if one already exists).
+        //   2. Optionally select other linked providers to file the result on their behalf.
+        //
+        // OK button behaviour:
+        //   - Providers selected: files for each via FileLabs.do, then acknowledges.
+        //   - No providers selected: acknowledges with the entered comment directly.
+        //   - Cancel: closes the modal without acknowledging or filing.
+        function openCombinedAckFileDialog(isFileOnly) {
+            const segmentId = jQuery("#segmentID").val();
 
-            if (selectedProviders.length === 0) {
+            // Pre-populate the comment field with any comment the provider has already saved for this lab.
+            const textEl = document.getElementById(providerNo + "_" + segmentId + "commentText");
+            jQuery("#combinedAckComment").val(textEl ? textEl.innerHTML : "");
+
+            // Persist isFileOnly on the dialog element so the checkbox change handler can read it
+            // without it needing to be in scope as a closure variable.
+            jQuery("#combinedAckFileDialog").data("isFileOnly", isFileOnly);
+
+            jQuery("#combinedAckFileDialog").dialog({
+                autoOpen: false,
+                modal: true,
+                height: 'auto',
+                minWidth: 700,
+                resizable: true,
+                buttons: [
+                    {
+                        text: "Submit",
+                        id: "combinedAckOkButton",
+                        click: function() {
+                            const selectedProviders = jQuery(".combinedAckProviderCheckbox:checked").map(function() {
+                                return jQuery(this).val();
+                            }).get();
+                            const comment = jQuery("#combinedAckComment").val();
+
+                            jQuery("#combinedAckFileDialog").dialog("close");
+
+                            if (selectedProviders.length > 0) {
+                                // File on behalf of selected providers, then acknowledge if needed.
+                                fileOnBehalfOfMultipleProviders(selectedProviders).then(function() {
+                                    if (!isFileOnly) {
+                                        acknowledgeWithComment(comment, segmentId);
+                                    } else {
+                                        location.reload();
+                                    }
+                                });
+                            } else if (!isFileOnly) {
+                                // No providers selected — just acknowledge with the entered comment.
+                                acknowledgeWithComment(comment, segmentId);
+                            }
+                        },
+                        // Require at least one provider when filing only; always enabled when acknowledging.
+                        disabled: isFileOnly
+                    },
+                    {
+                        text: "Cancel",
+                        click: function() {
+                            jQuery("#combinedAckFileDialog").dialog("close");
+                        }
+                    }
+                ]
+            }).dialog("open");
+
+            jQuery("#combinedAckComment").focus();
+        }
+
+        // Writes the acknowledgement comment into the lab's hidden form field and triggers
+        // the acknowledge action. Called from the combined modal after the provider confirms.
+        function acknowledgeWithComment(comment, segmentId) {
+            const ackForm = document.forms['acknowledgeForm_' + segmentId];
+            if (ackForm && ackForm.comment) {
+                ackForm.comment.value = comment;
+            }
+            handleLab('acknowledgeForm_' + segmentId, segmentId, 'ackLab');
+        }
+
+        // Files the lab result on behalf of each provider in selectedProviders by calling
+        // FileLabs.do for each one. Called from both the "File Document" dialog (#fileDialog)
+        // and the "Acknowledge/File Document" modal (#combinedAckFileDialog).
+        //
+        // For each provider, an auto-generated comment is recorded that includes the logged-in
+        // provider's name, the target provider's name, and a timestamp.
+        //
+        // All requests run in parallel via Promise.allSettled, so a failure for one provider
+        // does not block the others. Individual failures are logged to the console.
+        // The returned promise always resolves, allowing the caller to proceed with the next
+        // step (acknowledge or page reload) regardless of individual filing outcomes.
+        //
+        // @param {string[]} selectedProviders - provider numbers to file the lab on behalf of
+        function fileOnBehalfOfMultipleProviders(selectedProviders) {
+            if (!selectedProviders || selectedProviders.length === 0) {
                 return Promise.reject(new Error("No providers selected"));
             }
 
@@ -1122,7 +1304,7 @@ request.setAttribute("missingTests", missingTests);
             const loggedInProviderName = jQuery("#loggedInProviderName").val();
 
             const ajaxCalls = selectedProviders.map(providerNo => {
-                const providerName = jQuery(".ackProviderName[data-provider-no='" + providerNo + "']").val();
+                const providerName = jQuery(".combinedAckProviderName[data-provider-no='" + providerNo + "'], .ackProviderName[data-provider-no='" + providerNo + "']").first().val();
                 const comment = createFilingComment(providerName, loggedInProviderName);
                 const url = "${e:forJavaScript(pageContext.servletContext.contextPath)}" + "/oscarMDS/FileLabs.do";
 
@@ -1156,11 +1338,14 @@ request.setAttribute("missingTests", missingTests);
                 if (failed.length > 0) {
                     console.error("Some AJAX calls failed:", failed);
                 }
-
-                doFileOnBehalfOfProviders = false;
             });
         }
 
+        // Generates the auto-filing comment recorded when a lab is filed on behalf of another provider.
+        // Produces: "Filed by <loggedInProviderName> on behalf of <providerName> on YYYY.MM.DD @ H:MMam/pm"
+        //
+        // @param {string} providerName         - name of the provider being filed for
+        // @param {string} loggedInProviderName - name of the provider performing the filing
         function createFilingComment(providerName, loggedInProviderName) {
             const now = new Date();
             const yyyy = now.getFullYear();
@@ -1195,23 +1380,34 @@ request.setAttribute("missingTests", missingTests);
         }
 
         boolean notBeenAcked = ackList.size() == 0;
+        // True when the logged-in provider has already acknowledged this lab result.
+        // Controls which action button is rendered: "Acknowledge" (false) or "File for..." (true).
         boolean ackFlag = false;
-        boolean isLabNotFiledOrAckFlag = false; // Flag is true if any provider has NOT filed OR NOT acknowledged the lab
+
+        // True when at least one OTHER linked provider has not yet filed or acknowledged this lab.
+        // When both ackFlag and this flag are true, the "File for..." button is shown so the
+        // logged-in provider can file the result on behalf of those providers.
+        boolean isLabNotFiledOrAckFlag = false;
+
         String labStatus = "";
         if (ackList != null) {
             for (int i = 0; i < ackList.size(); i++) {
                 ReportStatus reportStatus = ackList.get(i);
+
+                // Resolve each provider's hl7AllowOthersFileForYou preference up front so the
+                // filing dialogs can disable providers who have opted out of being filed for by others.
                 reportStatus.setHl7AllowOthersFileForYou(providerManager.isHl7AllowOthersFileForYou(loggedInInfo, reportStatus.getOscarProviderNo()));
+
                 if (providerNo.equals(reportStatus.getOscarProviderNo())) {
+                    // Found the logged-in provider's entry — capture their current lab status.
                     labStatus = reportStatus.getStatus();
                     if (labStatus.equals("A")) {
-                        ackFlag = true;//lab has been ack by this providers.
-                        break;
+                        ackFlag = true;
                     }
-                }
-
-                if ("N".equals(reportStatus.getStatus())) {
-                    isLabNotFiledOrAckFlag = true; // Flag is true if any provider has NOT filed OR NOT acknowledged the lab
+                } else if ("N".equals(reportStatus.getStatus())) {
+                    // A different linked provider has not yet filed or acknowledged this lab.
+                    // Once the logged-in provider acknowledges, the "File for..." button will appear.
+                    isLabNotFiledOrAckFlag = true;
                 }
             }
         }
@@ -1224,6 +1420,11 @@ request.setAttribute("missingTests", missingTests);
         String label = "";
         if (hl7Lab != null && hl7Lab.getLabel() != null) label = hl7Lab.getLabel();
 
+        // JS expression fired by #tempAckBtn in the fallback acknowledge flow
+        // (when isHl7OfferFileForOthers=false). Behaviour depends on the provider's
+        // lab_ack_comment preference (skipComment):
+        //   true  → acknowledge immediately without prompting for a comment (handleLab).
+        //   false → open a JS prompt() to collect a comment before acknowledging (getComment).
         String ackLabFunc;
         if (skipComment) {
             ackLabFunc = "handleLab('acknowledgeForm_" + segmentID + "','" + segmentID + "','ackLab');";
@@ -1307,13 +1508,26 @@ request.setAttribute("missingTests", missingTests);
 <input type="hidden" id="loggedInProviderName" value="${e:forHtml(loggedInProviderName)}" />
 <input type="hidden" id="isHl7OfferFileForOthers" value="${e:forHtml(isHl7OfferFileForOthers)}" />
 
-<!-- Hidden dialog that appears when a locum MD clicks "Acknowledge" -->
+<!--
+    Hidden button used by the legacy fallback acknowledge flow (isHl7OfferFileForOthers=false).
+    Its onclick is set server-side to ackLabFunc, which either prompts for an acknowledgement
+    comment via getComment() or acknowledges directly via handleLab(), depending on the
+    provider's lab_ack_comment preference (skipComment).
+-->
+<button id="tempAckBtn" onclick="${e:forHtml(ackLabFunc)}" style="display:none;"></button>
+
+<!--
+    "File Document" dialog (#fileDialog) — opened by the "File for..." button.
+    Reached when the logged-in provider has already acknowledged the lab and at least
+    one other linked provider has not yet filed or acknowledged.
+    Lists eligible providers; those who have opted out appear greyed out and cannot be selected.
+    Managed by openFileOnlyDialog() in the script block above.
+-->
 <div id="fileDialog" title="File Document" style="display: none;">
 
-    <!-- Hidden button used to trigger temp acknowledgment logic if no providers are found -->
-    <button id="tempAckBtn" onclick="${e:forHtml(ackLabFunc)}" style="display:none;"></button>
-
-    <!-- Flag to determine if skip comment logic should be applied -->
+    <!-- skipAckComment: mirrors the server-side skipComment flag. When "true", the legacy
+         #tempAckBtn flow acknowledges without prompting for a comment. Unused in the
+         combined modal flow. -->
     <input id="skipAckComment" type="hidden" value="${e:forHtml(skipComment)}" />
 
     <!-- Form that lists providers to file on behalf of -->
@@ -1327,7 +1541,9 @@ request.setAttribute("missingTests", missingTests);
         <c:forEach var="report" items="${ackList}" varStatus="status">
             <c:choose>
                 <c:when test="${report.oscarProviderNo == sessionScope.user}">
-                    <!-- Save logged-in provider details -->
+                    <!-- The logged-in provider's details are also stored as top-level hidden inputs
+                         outside this dialog (see #loggedInProviderNo / #loggedInProviderName above).
+                         These inner values mirror those and are retained for historical reasons. -->
                     <input type="hidden" id="loggedInProviderNo" value="${e:forHtml(report.oscarProviderNo)}" />
                     <input type="hidden" id="loggedInProviderName" value="${e:forHtml(report.providerName)}" />
                 </c:when>
@@ -1359,7 +1575,70 @@ request.setAttribute("missingTests", missingTests);
                 </c:otherwise>
             </c:choose>
         </c:forEach>
-        <p>Tip: In your user preferences, you can hide this prompt or prevent others from filing results on your behalf. See "Set HL7 Lab Result Preferences".</p>
+        <p>Tip: In your user preferences, you can prevent others from filing results on your behalf.  See "Set HL7 Lab Result Preferences"</p>
+    </form>
+</div>
+
+<!--
+    "Acknowledge/File Document" modal (#combinedAckFileDialog) — opened by the "Acknowledge" button
+    when the provider has opted in to offer filing for others (isHl7OfferFileForOthers=true).
+    Lets the provider complete two actions in one step:
+      - Enter or confirm an acknowledgement comment.
+      - Optionally select other linked providers to file the result on their behalf.
+    Managed by openCombinedAckFileDialog() in the script block above.
+-->
+<div id="combinedAckFileDialog" title="Acknowledge/File Document" style="display: none;">
+    <form id="combinedFileForm">
+        <label for="combinedAckComment" style="display: block; margin-bottom: 4px;"><b>Please enter a comment (max 255 characters):</b></label>
+        <input type="text" id="combinedAckComment" maxlength="255" style="width: 99%; margin-bottom: 10px;" />
+
+        <c:set var="eligibleProviderCount" value="0" />
+        <c:forEach var="report" items="${ackList}">
+            <c:if test="${report.oscarProviderNo != sessionScope.user && report.status != 'F' && report.status != 'A'}">
+                <c:set var="eligibleProviderCount" value="${eligibleProviderCount + 1}" />
+            </c:if>
+        </c:forEach>
+        <c:if test="${eligibleProviderCount > 0}">
+        <div id="combinedAckAccordion">
+            <span>(Optional) File Document On Behalf of Others</span>
+            <div>
+                <p>This result is linked to other providers who have not acknowledged or filed it yet.</p>
+                <p>Do you want to "file" this result on their behalf?</p>
+                <p>Important - doing so will mean they likely will not see this result. Only proceed if you are sure they will not need to see this result.</p>
+
+                <input type="checkbox" id="combinedAckSelectAllCheckbox" />
+                <label for="combinedAckSelectAllCheckbox"><b>Select All</b></label><br/>
+
+                <c:forEach var="report" items="${ackList}" varStatus="status">
+                    <c:if test="${report.oscarProviderNo != sessionScope.user && report.status != 'F' && report.status != 'A'}">
+                        <c:set var="isDisabled" value="${!report.isHl7AllowOthersFileForYou()}" />
+                        <c:set var="combinedProviderId" value="combinedAckProvider${status.index}" />
+                        <c:set var="combinedProviderNo" value="${e:forHtml(report.oscarProviderNo)}" />
+                        <c:set var="combinedProviderName" value="${e:forHtml(report.providerName)}" />
+
+                        <input type="checkbox"
+                            name="combinedProviders"
+                            id="${combinedProviderId}"
+                            value="${combinedProviderNo}"
+                            class="combinedAckProviderCheckbox${isDisabled ? ' combined-disabled-checkbox' : ''}"
+                            ${isDisabled ? 'disabled' : ''} />
+
+                        <label for="${combinedProviderId}"
+                            style="${isDisabled ? 'color: gray; cursor: not-allowed;' : ''}">
+                            <e:forHtml value="${combinedProviderName}${isDisabled ? ' (opted out by user preference)' : ''}" />
+                        </label>
+
+                        <input type="hidden"
+                            class="combinedAckProviderName"
+                            data-provider-no="${combinedProviderNo}"
+                            value="${e:forHtml(report.providerName)}" /><br/>
+                    </c:if>
+                </c:forEach>
+
+                <p>Tip: in your user preferences, you can automatically show this prompt or prevent others from filing results on your behalf.  See "Set HL7 Lab Result Preferences"</p>
+            </div>
+        </div>
+        </c:if>
     </form>
 </div>
 
@@ -1485,9 +1764,9 @@ request.setAttribute("missingTests", missingTests);
                                        value="<fmt:setBundle basename="oscarResources"/><fmt:message key="oscarMDS.segmentDisplay.btnAcknowledge"/>"
                                        onclick="openFileDialog(false)" />
                                 <% } else if (isLabNotFiledOrAckFlag) {
-                                    // Flag is true if any provider has NOT filed OR NOT acknowledged the lab 
-                                    // Case: Current provider has acknowledged the lab,
-                                    // but at least one of the linked providers has NOT filed or acknowledged
+                                    // The logged-in provider has acknowledged, at least one other linked
+                                    // provider has not yet filed or acknowledged. Show "File for..." so they can file
+                                    // the result on behalf of those providers via the File Document dialog.
                                 %>
                                 <input type="button"
                                     value="File for..."
@@ -2899,14 +3178,14 @@ request.setAttribute("missingTests", missingTests);
             <tr>
                 <td align="left" width="50%">
                     <% if (!ackFlag) {
-                        // Case: Current provider has not acknowledged the lab
+                        // The logged-in provider has not yet acknowledged this lab. Show "Acknowledge".
                     %>
                     <input type="button" value="<fmt:setBundle basename="oscarResources"/><fmt:message key="oscarMDS.segmentDisplay.btnAcknowledge"/>"
                            onclick="openFileDialog(false)" />
-                    <% } else if (isLabNotFiledOrAckFlag) { 
-                        // Flag is true if any provider has NOT filed OR NOT acknowledged the lab 
-                        // Case: Current provider has acknowledged the lab,
-                        // but at least one of the linked providers has NOT filed or acknowledged
+                    <% } else if (isLabNotFiledOrAckFlag) {
+                        // The logged-in provider has acknowledged, at least one other linked provider
+                        // has not yet filed or acknowledged. Show "File for..." so they can file the result on behalf
+                        // of those providers via the File Document dialog.
                     %>
                     <input type="button"
                         value="File for..."

--- a/src/main/webapp/lab/CA/ALL/labDisplay.jsp
+++ b/src/main/webapp/lab/CA/ALL/labDisplay.jsp
@@ -1555,9 +1555,9 @@ request.setAttribute("missingTests", missingTests);
                             class="ackProviderCheckbox${isDisabled ? ' disabled-checkbox' : ''}"
                             ${isDisabled ? 'disabled' : ''} />
                         
-                        <label for="${providerId}" 
+                        <label for="${providerId}"
                             style="${isDisabled ? 'color: gray; cursor: not-allowed;' : ''}">
-                            <e:forHtml value="${providerName}${isDisabled ? ' (opted out by user preference)' : ''}" />
+                            <c:out value="${providerName}${isDisabled ? ' (opted out by user preference)' : ''}" escapeXml="false" />
                         </label>
                         
                         <input type="hidden"
@@ -1618,7 +1618,7 @@ request.setAttribute("missingTests", missingTests);
 
                         <label for="${combinedProviderId}"
                             style="${isDisabled ? 'color: gray; cursor: not-allowed;' : ''}">
-                            <e:forHtml value="${combinedProviderName}${isDisabled ? ' (opted out by user preference)' : ''}" />
+                            <c:out value="${combinedProviderName}${isDisabled ? ' (opted out by user preference)' : ''}" escapeXml="false" />
                         </label>
 
                         <input type="hidden"

--- a/src/main/webapp/lab/CA/ALL/labDisplay.jsp
+++ b/src/main/webapp/lab/CA/ALL/labDisplay.jsp
@@ -986,14 +986,12 @@ request.setAttribute("missingTests", missingTests);
                             console.log("Adding comment. Formid: " + formid + " labid: " + labid);
                             addComment(formid, labid);
                         } else if (action === 'ackLabAndFileForOther') {
-                            fileOnBehalfOfMultipleProviders().then(() => {
-                                console.log("Acknowledging lab results");
-                                if(confirmAck()){
-                                    console.log("Acknowledge confirmed. Labid: " + labid);
-                                    jQuery("#labStatus_"+labid).val("A")
-                                    updateStatus(formid,labid);
-                                }
-                            });
+                            console.log("Acknowledging lab results");
+                            if(confirmAck()){
+                                console.log("Acknowledge confirmed. Labid: " + labid);
+                                jQuery("#labStatus_"+labid).val("A")
+                                updateStatus(formid,labid);
+                            }
                         }
 
                     } else {
@@ -1148,16 +1146,16 @@ request.setAttribute("missingTests", missingTests);
         //   Otherwise (skipComment=false): opens the combined "Acknowledge/File Document"
         //   modal so the provider can enter a comment. When isHl7OfferFileForOthers=true,
         //   the modal also allows optionally filing for other linked providers.
-        function openFileDialog(isFileOnly) {
+        function openFileDialog(isFileOnly, segmentId, labType) {
             if (isFileOnly) {
-                openFileOnlyDialog();
+                openFileOnlyDialog(segmentId, labType);
                 return;
             }
             if (jQuery("#skipAckComment").val() === "true") {
                 jQuery('#tempAckBtn').click();
                 return;
             }
-            openCombinedAckFileDialog(false);
+            openCombinedAckFileDialog(false, segmentId, labType);
         }
 
         // Opens the "File Document" dialog (#fileDialog) for the "File for..." button flow.
@@ -1168,7 +1166,7 @@ request.setAttribute("missingTests", missingTests);
         // is called for each selected provider in parallel, then the page reloads to reflect
         // the updated filing status. The OK button starts disabled and enables only once
         // at least one provider is checked.
-        function openFileOnlyDialog() {
+        function openFileOnlyDialog(segmentId, labType) {
             jQuery("#fileDialog").dialog({
                 autoOpen: false,
                 modal: true,
@@ -1190,7 +1188,7 @@ request.setAttribute("missingTests", missingTests);
                                 return jQuery(this).val();
                             }).get();
                             jQuery("#fileDialog").dialog("close");
-                            fileOnBehalfOfMultipleProviders(selectedProviders).then(function() {
+                            fileOnBehalfOfMultipleProviders(selectedProviders, segmentId, labType).then(function() {
                                 location.reload();
                             });
                         },
@@ -1212,8 +1210,7 @@ request.setAttribute("missingTests", missingTests);
         //   - Providers selected: files for each via FileLabs.do, then acknowledges.
         //   - No providers selected: acknowledges with the entered comment directly.
         //   - Cancel: closes the modal without acknowledging or filing.
-        function openCombinedAckFileDialog(isFileOnly) {
-            const segmentId = jQuery("#segmentID").val();
+        function openCombinedAckFileDialog(isFileOnly, segmentId, labType) {
 
             // Pre-populate the comment field with any comment the provider has already saved for this lab.
             const textEl = document.getElementById(providerNo + "_" + segmentId + "commentText");
@@ -1243,7 +1240,7 @@ request.setAttribute("missingTests", missingTests);
 
                             if (selectedProviders.length > 0) {
                                 // File on behalf of selected providers, then acknowledge if needed.
-                                fileOnBehalfOfMultipleProviders(selectedProviders).then(function() {
+                                fileOnBehalfOfMultipleProviders(selectedProviders, segmentId, labType).then(function() {
                                     if (!isFileOnly) {
                                         acknowledgeWithComment(comment, segmentId);
                                     } else {
@@ -1293,13 +1290,12 @@ request.setAttribute("missingTests", missingTests);
         // step (acknowledge or page reload) regardless of individual filing outcomes.
         //
         // @param {string[]} selectedProviders - provider numbers to file the lab on behalf of
-        function fileOnBehalfOfMultipleProviders(selectedProviders) {
+        function fileOnBehalfOfMultipleProviders(selectedProviders, segmentId, labType) {
             if (!selectedProviders || selectedProviders.length === 0) {
                 return Promise.reject(new Error("No providers selected"));
             }
 
-            const flaggedLabId = jQuery("#segmentID").val();
-            const labType = jQuery("#labType").val();
+            const flaggedLabId = segmentId;
             const loggedInProviderNo = jQuery("#loggedInProviderNo").val();
             const loggedInProviderName = jQuery("#loggedInProviderName").val();
 
@@ -1541,11 +1537,8 @@ request.setAttribute("missingTests", missingTests);
         <c:forEach var="report" items="${ackList}" varStatus="status">
             <c:choose>
                 <c:when test="${report.oscarProviderNo == sessionScope.user}">
-                    <!-- The logged-in provider's details are also stored as top-level hidden inputs
-                         outside this dialog (see #loggedInProviderNo / #loggedInProviderName above).
-                         These inner values mirror those and are retained for historical reasons. -->
-                    <input type="hidden" id="loggedInProviderNo" value="${e:forHtml(report.oscarProviderNo)}" />
-                    <input type="hidden" id="loggedInProviderName" value="${e:forHtml(report.providerName)}" />
+                    <!-- The logged-in provider's details are stored in the top-level hidden inputs
+                         #loggedInProviderNo / #loggedInProviderName outside this dialog. -->
                 </c:when>
                 <c:otherwise>
                     <!-- Show only providers that have not already filed or ack (status != 'F' && status != 'A') -->
@@ -1762,7 +1755,7 @@ request.setAttribute("missingTests", missingTests);
 
                                 <input type="button"
                                        value="<fmt:setBundle basename="oscarResources"/><fmt:message key="oscarMDS.segmentDisplay.btnAcknowledge"/>"
-                                       onclick="openFileDialog(false)" />
+                                       onclick="openFileDialog(false, '<%=Encode.forJavaScript(segmentID)%>', 'HL7')" />
                                 <% } else if (isLabNotFiledOrAckFlag) {
                                     // The logged-in provider has acknowledged, at least one other linked
                                     // provider has not yet filed or acknowledged. Show "File for..." so they can file
@@ -1770,7 +1763,7 @@ request.setAttribute("missingTests", missingTests);
                                 %>
                                 <input type="button"
                                     value="File for..."
-                                    onclick="openFileDialog(true)" />
+                                    onclick="openFileDialog(true, '<%=Encode.forJavaScript(segmentID)%>', 'HL7')" />
                                 <% } %>
                                 <input type="button" value="<fmt:setBundle basename="oscarResources"/><fmt:message key="oscarMDS.segmentDisplay.btnComment"/>"
                                        onclick="return getComment('addComment',<%=Encode.forJavaScript(segmentID)%>);">
@@ -3181,7 +3174,7 @@ request.setAttribute("missingTests", missingTests);
                         // The logged-in provider has not yet acknowledged this lab. Show "Acknowledge".
                     %>
                     <input type="button" value="<fmt:setBundle basename="oscarResources"/><fmt:message key="oscarMDS.segmentDisplay.btnAcknowledge"/>"
-                           onclick="openFileDialog(false)" />
+                           onclick="openFileDialog(false, '<%=Encode.forJavaScript(segmentID)%>', 'HL7')" />
                     <% } else if (isLabNotFiledOrAckFlag) {
                         // The logged-in provider has acknowledged, at least one other linked provider
                         // has not yet filed or acknowledged. Show "File for..." so they can file the result on behalf
@@ -3189,7 +3182,7 @@ request.setAttribute("missingTests", missingTests);
                     %>
                     <input type="button"
                         value="File for..."
-                        onclick="openFileDialog(true)" />
+                        onclick="openFileDialog(true, '<%=Encode.forJavaScript(segmentID)%>', 'HL7')" />
                     <% } %>
                     <input type="button" value="<fmt:setBundle basename="oscarResources"/><fmt:message key="oscarMDS.segmentDisplay.btnComment"/>"
                            onclick="return getComment('addComment',<%=Encode.forJavaScript(segmentID)%>);">

--- a/src/main/webapp/lab/CA/ALL/labDisplay.jsp
+++ b/src/main/webapp/lab/CA/ALL/labDisplay.jsp
@@ -1510,7 +1510,7 @@ request.setAttribute("missingTests", missingTests);
     comment via getComment() or acknowledges directly via handleLab(), depending on the
     provider's lab_ack_comment preference (skipComment).
 -->
-<button id="tempAckBtn" onclick="${e:forJavaScriptAttribute(ackLabFunc)}" style="display:none;"></button>
+<button id="tempAckBtn" onclick="${e:forHtmlAttribute(ackLabFunc)}" style="display:none;"></button>
 
 <!--
     "File Document" dialog (#fileDialog) — opened by the "File for..." button.

--- a/src/main/webapp/lab/CA/ALL/labDisplay.jsp
+++ b/src/main/webapp/lab/CA/ALL/labDisplay.jsp
@@ -1500,9 +1500,9 @@ request.setAttribute("missingTests", missingTests);
 </script>
 
 <!-- Save logged-in provider details -->
-<input type="hidden" id="loggedInProviderNo" value="${e:forHtml(sessionScope.user)}" />
-<input type="hidden" id="loggedInProviderName" value="${e:forHtml(loggedInProviderName)}" />
-<input type="hidden" id="isHl7OfferFileForOthers" value="${e:forHtml(isHl7OfferFileForOthers)}" />
+<input type="hidden" id="loggedInProviderNo" value="${e:forHtmlAttribute(sessionScope.user)}" />
+<input type="hidden" id="loggedInProviderName" value="${e:forHtmlAttribute(loggedInProviderName)}" />
+<input type="hidden" id="isHl7OfferFileForOthers" value="${e:forHtmlAttribute(isHl7OfferFileForOthers)}" />
 
 <!--
     Hidden button used by the legacy fallback acknowledge flow (isHl7OfferFileForOthers=false).
@@ -1510,7 +1510,7 @@ request.setAttribute("missingTests", missingTests);
     comment via getComment() or acknowledges directly via handleLab(), depending on the
     provider's lab_ack_comment preference (skipComment).
 -->
-<button id="tempAckBtn" onclick="${e:forHtml(ackLabFunc)}" style="display:none;"></button>
+<button id="tempAckBtn" onclick="${e:forJavaScriptAttribute(ackLabFunc)}" style="display:none;"></button>
 
 <!--
     "File Document" dialog (#fileDialog) — opened by the "File for..." button.
@@ -1524,7 +1524,7 @@ request.setAttribute("missingTests", missingTests);
     <!-- skipAckComment: mirrors the server-side skipComment flag. When "true", the legacy
          #tempAckBtn flow acknowledges without prompting for a comment. Unused in the
          combined modal flow. -->
-    <input id="skipAckComment" type="hidden" value="${e:forHtml(skipComment)}" />
+    <input id="skipAckComment" type="hidden" value="${e:forHtmlAttribute(skipComment)}" />
 
     <!-- Form that lists providers to file on behalf of -->
     <form id="fileForm">
@@ -1545,7 +1545,7 @@ request.setAttribute("missingTests", missingTests);
                     <c:if test="${report.status != 'F' && report.status != 'A'}">
                         <c:set var="isDisabled" value="${!report.isHl7AllowOthersFileForYou()}" />
                         <c:set var="providerId" value="ackProvider${status.index}" />
-                        <c:set var="providerNo" value="${e:forHtml(report.oscarProviderNo)}" />
+                        <c:set var="providerNo" value="${e:forHtmlAttribute(report.oscarProviderNo)}" />
                         <c:set var="providerName" value="${e:forHtml(report.providerName)}" />
                         
                         <input type="checkbox"
@@ -1563,7 +1563,7 @@ request.setAttribute("missingTests", missingTests);
                         <input type="hidden"
                             class="ackProviderName"
                             data-provider-no="${providerNo}"
-                            value="${e:forHtml(report.providerName)}" /><br/>
+                            value="${e:forHtmlAttribute(report.providerName)}" /><br/>
                     </c:if>
                 </c:otherwise>
             </c:choose>
@@ -1606,7 +1606,7 @@ request.setAttribute("missingTests", missingTests);
                     <c:if test="${report.oscarProviderNo != sessionScope.user && report.status != 'F' && report.status != 'A'}">
                         <c:set var="isDisabled" value="${!report.isHl7AllowOthersFileForYou()}" />
                         <c:set var="combinedProviderId" value="combinedAckProvider${status.index}" />
-                        <c:set var="combinedProviderNo" value="${e:forHtml(report.oscarProviderNo)}" />
+                        <c:set var="combinedProviderNo" value="${e:forHtmlAttribute(report.oscarProviderNo)}" />
                         <c:set var="combinedProviderName" value="${e:forHtml(report.providerName)}" />
 
                         <input type="checkbox"
@@ -1624,7 +1624,7 @@ request.setAttribute("missingTests", missingTests);
                         <input type="hidden"
                             class="combinedAckProviderName"
                             data-provider-no="${combinedProviderNo}"
-                            value="${e:forHtml(report.providerName)}" /><br/>
+                            value="${e:forHtmlAttribute(report.providerName)}" /><br/>
                     </c:if>
                 </c:forEach>
 

--- a/src/main/webapp/provider/setHl7LabResultPrefs.jsp
+++ b/src/main/webapp/provider/setHl7LabResultPrefs.jsp
@@ -35,7 +35,7 @@
                 <label class="form-check-label" for="offerFileForOthers">
                     Automatically offer to file results on behalf of other providers when acknowledging HL7 lab results
                 </label>
-                <div class="form-text text-muted">(default: yes)</div>
+                <div class="form-text text-muted">(default: no)</div>
             </div>
 
             <div class="form-check form-switch mb-3">


### PR DESCRIPTION
## Status Quo
  Currently, a logged-in provider **cannot** file lab results on behalf of another provider.

  ---

  ## Change
  We have added functionality to allow a provider to **file results on behalf of other providers**.
  (Example shown logged in as `doctor oscardoc`.)

  > [!IMPORTANT]
  > This PR is designed to **minimize support burden on OpenOSP**.
  > - By default, this PR will NOT change any behaviour because the functionality defaults to "off" for all providers.
  > - Only if providers **actively turn on this feature within the user preferences** will this option to "file on their behalf" become enabled.
  > - Note that for Magenta, we decided to turn on this feature for all providers automatically in our production, without any significant complaints.

  ---

## Main Workflow

  ### Case 1:  0 or 1 provider attached to the lab:
  - Clicking `Acknowledge` opens the updated acknowledgement dialog, but **no file options are shown**.
    - <img width="1074" height="500" alt="image" src="https://github.com/user-attachments/assets/cc755a40-360a-4b9d-a6ac-086572fb2e5a" />

  ### Case 2:  More than 1 provider attached to the lab:
  - Clicking `Acknowledge` opens a **combined modal** where the user selects providers to file for and adds an acknowledgement comment.
    - <img width="1013" height="308" alt="image" src="https://github.com/user-attachments/assets/f7ab95b9-a55d-4940-93af-c23d386d7949" />
    - <img width="1076" height="638" alt="image" src="https://github.com/user-attachments/assets/394ff8ee-e548-49fc-a637-f909c3d0ba0d" />

  - User adds comment and **selects providers** to file on their behalf, then clicks `Submit`.
    - <img width="551" height="433" alt="image" src="https://github.com/user-attachments/assets/83183bbe-e5c2-40ec-9db5-a1e1bff7c7e9" />

  - **After confirmation**, the UI updates accordingly:
    - <img width="1009" height="320" alt="image" src="https://github.com/user-attachments/assets/b39ea3ba-16eb-458f-918c-2ee4bcc9ff1c" />

  ---

  ## Preferences

  Providers can configure the behavior under **Preferences**:

  <img width="1171" height="602" alt="image" src="https://github.com/user-attachments/assets/9fc26955-c7c0-4928-a1db-74161a427737" />

  1. **Control the file dialog accordion**
     Toggle the option:
     *"Automatically offer to file results on behalf of other providers when acknowledging HL7 lab results"*

     - If **disabled**, the accordion is **collapsed by default** when the modal opens:
       - <img width="598" height="206" alt="image" src="https://github.com/user-attachments/assets/4e848bd3-be16-45c5-87b8-d7d917854272" />
     - If **enabled**, the accordion is **expanded by default** when the modal opens:
       - <img width="544" height="430" alt="image" src="https://github.com/user-attachments/assets/d6bf0451-4180-4142-abee-9444a3603a2a" />
     

  2. **Prevent others from filing on your behalf**
     Turn off the option:
     *"Allow other providers to file results on your behalf when they acknowledge HL7 lab results"*
     - <img width="566" height="449" alt="image" src="https://github.com/user-attachments/assets/a6bf8c6d-a606-486b-81e9-e80492c0aeb6" />

  ---

## Additional Features

1. Even if a user has **already acknowledged a lab**, they can still file it for other providers using the `File for…` button.
    - <img width="1007" height="299" alt="image" src="https://github.com/user-attachments/assets/7cdb25e6-65d6-4a9c-87c5-cb149f4237bc" />
    - <img width="731" height="284" alt="image" src="https://github.com/user-attachments/assets/5f0db24e-a217-4d2a-858c-43a63db08b77" />
    - <img width="661" height="124" alt="image" src="https://github.com/user-attachments/assets/3b47f0ef-e36c-4b71-837c-23f66711d796" />
 
2. If the provider has acknowledged version 1 and, after some time, version 2 is released.
    <img width="859" height="286" alt="image" src="https://github.com/user-attachments/assets/ce5fef80-fe8d-4296-93c7-e0c3cddb2e9e" />
    - If the provider then acknowledges version 2:
    - Old behaviour: The status of version 1 was changed from A → F.
      - <img width="770" height="137" alt="image" src="https://github.com/user-attachments/assets/272d4656-fc5c-4680-b0d4-cbd409a3dcc1" />
     - New behaviour: The status of version 1 is not changed if it is already A.
       - <img width="752" height="134" alt="image" src="https://github.com/user-attachments/assets/db82169c-98d6-4791-8854-8c4c61d0dc67" />