### PR TITLE
Ocean eReferral attachment cross-patient validation

### DIFF
--- a/src/main/java/ca/openosp/openo/commn/dao/DocumentDao.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/DocumentDao.java
@@ -90,4 +90,6 @@ public interface DocumentDao extends AbstractDao<Document> {
     public List<Document> findByDemographicAndDoctype(int demographicId, DocumentType documentType);
 
     public Document findByDemographicAndFilename(int demographicId, String fileName);
+
+    public List<Integer> findDocumentNosForDemographic(Integer demographicNo, List<Integer> docNos);
 }

--- a/src/main/java/ca/openosp/openo/commn/dao/DocumentDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/DocumentDaoImpl.java
@@ -245,6 +245,18 @@ public class DocumentDaoImpl extends AbstractDaoImpl<Document> implements Docume
      *
      * @param demoNo
      */
+    @SuppressWarnings("unchecked")
+    @Override
+    public List<Integer> findDocumentNosForDemographic(Integer demographicNo, List<Integer> docNos) {
+        Query query = entityManager.createQuery(
+                "SELECT c.id.documentNo FROM CtlDocument c " +
+                "WHERE c.id.module = 'demographic' AND c.id.moduleId = :demographicNo " +
+                "AND c.status != 'D' AND c.id.documentNo IN :docNos");
+        query.setParameter("demographicNo", demographicNo);
+        query.setParameter("docNos", docNos);
+        return query.getResultList();
+    }
+
     @Override
     public List<Document> findByDemographicId(String demoNo) {
         Integer id = null;

--- a/src/main/java/ca/openosp/openo/commn/dao/DocumentDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/DocumentDaoImpl.java
@@ -248,6 +248,7 @@ public class DocumentDaoImpl extends AbstractDaoImpl<Document> implements Docume
     @SuppressWarnings("unchecked")
     @Override
     public List<Integer> findDocumentNosForDemographic(Integer demographicNo, List<Integer> docNos) {
+        if (docNos == null || docNos.isEmpty()) return Collections.emptyList();
         Query query = entityManager.createQuery(
                 "SELECT c.id.documentNo FROM CtlDocument c " +
                 "WHERE c.id.module = 'demographic' AND c.id.moduleId = :demographicNo " +

--- a/src/main/java/ca/openosp/openo/commn/dao/EFormDataDao.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/EFormDataDao.java
@@ -79,4 +79,6 @@ public interface EFormDataDao extends AbstractDao<EFormData> {
 
     public Date getLatestFormDateAndTimeForEforms(Collection<Integer> fdidList);
 
+    public List<Integer> findFdidsForDemographic(Integer demographicNo, List<Integer> fdids);
+
 }

--- a/src/main/java/ca/openosp/openo/commn/dao/EFormDataDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/EFormDataDaoImpl.java
@@ -574,4 +574,15 @@ public class EFormDataDaoImpl extends AbstractDaoImpl<EFormData> implements EFor
         }
         return null;
     }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public List<Integer> findFdidsForDemographic(Integer demographicNo, List<Integer> fdids) {
+        Query query = entityManager.createQuery(
+                "SELECT x.id FROM EFormData x " +
+                "WHERE x.demographicId = :demographicNo AND x.id IN :fdids");
+        query.setParameter("demographicNo", demographicNo);
+        query.setParameter("fdids", fdids);
+        return query.getResultList();
+    }
 }

--- a/src/main/java/ca/openosp/openo/commn/dao/EFormDataDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/EFormDataDaoImpl.java
@@ -6,6 +6,7 @@ package ca.openosp.openo.commn.dao;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -578,6 +579,7 @@ public class EFormDataDaoImpl extends AbstractDaoImpl<EFormData> implements EFor
     @SuppressWarnings("unchecked")
     @Override
     public List<Integer> findFdidsForDemographic(Integer demographicNo, List<Integer> fdids) {
+        if (fdids == null || fdids.isEmpty()) return Collections.emptyList();
         Query query = entityManager.createQuery(
                 "SELECT x.id FROM EFormData x " +
                 "WHERE x.demographicId = :demographicNo AND x.id IN :fdids");

--- a/src/main/java/ca/openosp/openo/commn/dao/PatientLabRoutingDao.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/PatientLabRoutingDao.java
@@ -51,4 +51,6 @@ public interface PatientLabRoutingDao extends AbstractDao<PatientLabRouting> {
 
     public List<Integer> findDemographicIdsSince(Date date);
 
+    public List<Integer> findLabNosForDemographic(Integer demographicNo, List<Integer> labNos);
+
 }

--- a/src/main/java/ca/openosp/openo/commn/dao/PatientLabRoutingDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/PatientLabRoutingDaoImpl.java
@@ -344,4 +344,15 @@ public class PatientLabRoutingDaoImpl extends AbstractDaoImpl<PatientLabRouting>
         return results;
     }
 
+    @SuppressWarnings("unchecked")
+    @Override
+    public List<Integer> findLabNosForDemographic(Integer demographicNo, List<Integer> labNos) {
+        Query query = entityManager.createQuery(
+                "SELECT r.labNo FROM PatientLabRouting r " +
+                "WHERE r.demographicNo = :demographicNo AND r.labNo IN :labNos");
+        query.setParameter("demographicNo", demographicNo);
+        query.setParameter("labNos", labNos);
+        return query.getResultList();
+    }
+
 }

--- a/src/main/java/ca/openosp/openo/commn/dao/PatientLabRoutingDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/PatientLabRoutingDaoImpl.java
@@ -3,6 +3,7 @@
 
 package ca.openosp.openo.commn.dao;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
@@ -347,6 +348,7 @@ public class PatientLabRoutingDaoImpl extends AbstractDaoImpl<PatientLabRouting>
     @SuppressWarnings("unchecked")
     @Override
     public List<Integer> findLabNosForDemographic(Integer demographicNo, List<Integer> labNos) {
+        if (labNos == null || labNos.isEmpty()) return Collections.emptyList();
         Query query = entityManager.createQuery(
                 "SELECT r.labNo FROM PatientLabRouting r " +
                 "WHERE r.demographicNo = :demographicNo AND r.labNo IN :labNos");

--- a/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManager.java
+++ b/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManager.java
@@ -74,6 +74,18 @@ public interface DocumentAttachmentManager {
     public String convertPDFToBase64(Path renderedDocument) throws PDFGenerationException;
 
     public void flattenPDFFormFields(Path pdfPath) throws PDFGenerationException;
+
+    /**
+     * Validates that all documents in the array belong to the specified patient demographic.
+     * Each entry is prefixed with a type letter (D, L, E, H) followed by the document ID
+     * (e.g. "D42", "L7").
+     *
+     * @param loggedInInfo  The logged-in provider context
+     * @param demographicNo The patient's demographic number
+     * @param documents     Array of typed document ID strings
+     * @return {@code true} if every document belongs to the patient; {@code false} otherwise
+     */
+    public boolean validateDocumentsBelongToPatient(LoggedInInfo loggedInInfo, Integer demographicNo, String[] documents);
 }
 
 	

--- a/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManagerImpl.java
+++ b/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManagerImpl.java
@@ -40,6 +40,12 @@ public class DocumentAttachmentManagerImpl implements DocumentAttachmentManager 
     private ConsultDocsDao consultDocsDao;
     @Autowired
     private EFormDocsDao eFormDocsDao;
+    @Autowired
+    private ca.openosp.openo.commn.dao.DocumentDao documentDao;
+    @Autowired
+    private ca.openosp.openo.commn.dao.PatientLabRoutingDao patientLabRoutingDao;
+    @Autowired
+    private ca.openosp.openo.commn.dao.EFormDataDao eFormDataDao;
 
     @Autowired
     private ConsultationManager consultationManager;
@@ -406,5 +412,48 @@ public class DocumentAttachmentManagerImpl implements DocumentAttachmentManager 
         } catch (IOException e) {
             throw new PDFGenerationException("Error while flattening the " + pdfPath.getFileName() + " file. " + e.getMessage(), e);
         }
+    }
+
+    @Override
+    public boolean validateDocumentsBelongToPatient(LoggedInInfo loggedInInfo, Integer demographicNo, String[] documents) {
+        List<Integer> docIds = new ArrayList<>();
+        List<Integer> labIds = new ArrayList<>();
+        List<Integer> eformIds = new ArrayList<>();
+        List<Integer> hrmIds = new ArrayList<>();
+
+        for (String doc : documents) {
+            if (doc == null || doc.length() < 2) continue;
+            char type = doc.charAt(0);
+            try {
+                int id = Integer.parseInt(doc.substring(1));
+                switch (type) {
+                    case 'D': docIds.add(id); break;
+                    case 'L': labIds.add(id); break;
+                    case 'E': eformIds.add(id); break;
+                    case 'H': hrmIds.add(id); break;
+                }
+            } catch (NumberFormatException e) {
+                return false;
+            }
+        }
+
+        if (!docIds.isEmpty()) {
+            List<Integer> found = documentDao.findDocumentNosForDemographic(demographicNo, docIds);
+            if (found.size() != docIds.size()) return false;
+        }
+        if (!labIds.isEmpty()) {
+            List<Integer> found = patientLabRoutingDao.findLabNosForDemographic(demographicNo, labIds);
+            if (found.size() != labIds.size()) return false;
+        }
+        if (!eformIds.isEmpty()) {
+            List<Integer> found = eFormDataDao.findFdidsForDemographic(demographicNo, eformIds);
+            if (found.size() != eformIds.size()) return false;
+        }
+        if (!hrmIds.isEmpty()) {
+            List<Integer> found = HRMUtil.findHRMDocumentIdsForPatient(demographicNo, hrmIds);
+            if (found.size() != hrmIds.size()) return false;
+        }
+
+        return true;
     }
 }

--- a/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManagerImpl.java
+++ b/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManagerImpl.java
@@ -416,10 +416,11 @@ public class DocumentAttachmentManagerImpl implements DocumentAttachmentManager 
 
     @Override
     public boolean validateDocumentsBelongToPatient(LoggedInInfo loggedInInfo, Integer demographicNo, String[] documents) {
-        List<Integer> docIds = new ArrayList<>();
-        List<Integer> labIds = new ArrayList<>();
-        List<Integer> eformIds = new ArrayList<>();
-        List<Integer> hrmIds = new ArrayList<>();
+        // Use Set to automatically deduplicate IDs — duplicate entries would cause size-based validation to fail incorrectly
+        Set<Integer> docIds = new HashSet<>();
+        Set<Integer> labIds = new HashSet<>();
+        Set<Integer> eformIds = new HashSet<>();
+        Set<Integer> hrmIds = new HashSet<>();
 
         for (String doc : documents) {
             if (doc == null || doc.length() < 2) continue;
@@ -438,20 +439,20 @@ public class DocumentAttachmentManagerImpl implements DocumentAttachmentManager 
         }
 
         if (!docIds.isEmpty()) {
-            List<Integer> found = documentDao.findDocumentNosForDemographic(demographicNo, docIds);
-            if (found.size() != docIds.size()) return false;
+            List<Integer> found = documentDao.findDocumentNosForDemographic(demographicNo, new ArrayList<>(docIds));
+            if (!found.containsAll(docIds)) return false;
         }
         if (!labIds.isEmpty()) {
-            List<Integer> found = patientLabRoutingDao.findLabNosForDemographic(demographicNo, labIds);
-            if (found.size() != labIds.size()) return false;
+            List<Integer> found = patientLabRoutingDao.findLabNosForDemographic(demographicNo, new ArrayList<>(labIds));
+            if (!found.containsAll(labIds)) return false;
         }
         if (!eformIds.isEmpty()) {
-            List<Integer> found = eFormDataDao.findFdidsForDemographic(demographicNo, eformIds);
-            if (found.size() != eformIds.size()) return false;
+            List<Integer> found = eFormDataDao.findFdidsForDemographic(demographicNo, new ArrayList<>(eformIds));
+            if (!found.containsAll(eformIds)) return false;
         }
         if (!hrmIds.isEmpty()) {
-            List<Integer> found = HRMUtil.findHRMDocumentIdsForPatient(demographicNo, hrmIds);
-            if (found.size() != hrmIds.size()) return false;
+            List<Integer> found = HRMUtil.findHRMDocumentIdsForPatient(demographicNo, new ArrayList<>(hrmIds));
+            if (!found.containsAll(hrmIds)) return false;
         }
 
         return true;

--- a/src/main/java/ca/openosp/openo/encounter/oceanEReferal/pageUtil/ERefer2Action.java
+++ b/src/main/java/ca/openosp/openo/encounter/oceanEReferal/pageUtil/ERefer2Action.java
@@ -7,6 +7,7 @@ import ca.openosp.openo.commn.model.EReferAttachment;
 import ca.openosp.openo.commn.model.EReferAttachmentData;
 import ca.openosp.openo.commn.model.enumerator.DocumentType;
 import ca.openosp.openo.documentManager.DocumentAttachmentManager;
+import ca.openosp.openo.managers.SecurityInfoManager;
 import ca.openosp.openo.utility.LoggedInInfo;
 import ca.openosp.openo.utility.MiscUtils;
 import ca.openosp.openo.utility.SpringUtils;
@@ -29,6 +30,7 @@ public class ERefer2Action extends ActionSupport {
 
     private static final Logger logger = MiscUtils.getLogger();
     private final DocumentAttachmentManager documentAttachmentManager = SpringUtils.getBean(DocumentAttachmentManager.class);
+    private final SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
     public String execute() {
         String method = request.getParameter("method");
@@ -38,15 +40,48 @@ public class ERefer2Action extends ActionSupport {
                 attachOceanEReferralConsult();
             else if (method.equalsIgnoreCase("editOceanEReferralConsult"))
                 editOceanEReferralConsult();
+            else if (method.equalsIgnoreCase("validateDocuments"))
+                validateDocuments();
         }
 
         return SUCCESS;
+    }
+
+    private void writeResponse(boolean valid) {
+        try (PrintWriter writer = response.getWriter()) {
+            response.setContentType("application/json");
+            writer.write(valid ? "{\"valid\":true}" : "{\"valid\":false}");
+        } catch (IOException e) {
+            logger.error("Failed to write validation response", e);
+        }
+    }
+
+    public void validateDocuments() {
+        LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_con", SecurityInfoManager.READ, null)) {
+            writeResponse(false);
+            return;
+        }
+        String demographicNo = request.getParameter("demographicNo");
+        String[] documents = request.getParameterValues("documents");
+        if (StringUtils.isNullOrEmpty(demographicNo) || documents == null || documents.length == 0) {
+            // Nothing to validate - return true
+            writeResponse(true);
+            return;
+        }
+        boolean valid = documentAttachmentManager.validateDocumentsBelongToPatient(
+                loggedInInfo, Integer.parseInt(demographicNo), documents);
+        writeResponse(valid);
     }
 
     // Documents (attachments) originate from the consult request window.
     // Users can attach these documents using the attachment GUI on the consult request form.
     // All documents are internal to Oscar.
     public void attachOceanEReferralConsult() {
+        LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_con", SecurityInfoManager.READ, null)) {
+            throw new SecurityException("missing required sec object (_con)");
+        }
         String demographicNo = StringUtils.isNullOrEmpty(request.getParameter("demographicNo")) ? "" : request.getParameter("demographicNo");
         String documents = StringUtils.isNullOrEmpty(request.getParameter("documents")) ? "" : request.getParameter("documents");
         if (documents.isEmpty() || demographicNo.isEmpty()) {

--- a/src/main/java/ca/openosp/openo/hospitalReportManager/HRMUtil.java
+++ b/src/main/java/ca/openosp/openo/hospitalReportManager/HRMUtil.java
@@ -413,4 +413,15 @@ public class HRMUtil {
             hrmDocumentToProviderDao.remove(existingUnmatched.getId());
         }
     }
+
+    /**
+     * Returns the subset of the given HRM document IDs that are linked to the specified patient.
+     *
+     * @param demographicNo the patient's demographic number
+     * @param hrmIds        the list of HRM document IDs to check
+     * @return List of HRM document IDs that belong to the patient
+     */
+    public static List<Integer> findHRMDocumentIdsForPatient(Integer demographicNo, List<Integer> hrmIds) {
+        return hrmDocumentToDemographicDao.findHrmIdsForDemographic(demographicNo, hrmIds);
+    }
 }

--- a/src/main/java/ca/openosp/openo/hospitalReportManager/dao/HRMDocumentToDemographicDao.java
+++ b/src/main/java/ca/openosp/openo/hospitalReportManager/dao/HRMDocumentToDemographicDao.java
@@ -11,6 +11,7 @@
 package ca.openosp.openo.hospitalReportManager.dao;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import javax.persistence.Query;
@@ -149,8 +150,22 @@ public class HRMDocumentToDemographicDao extends AbstractDaoImpl<HRMDocumentToDe
         return attachedHRMDocumentToDemographics;
     }
 
+    /**
+     * Returns the subset of the given HRM document IDs that are linked to the specified patient.
+     *
+     * <p>Used to validate that HRM document attachments belong to the correct patient before
+     * an Ocean eReferral submission. Returns an empty list immediately when {@code hrmIds} is
+     * {@code null} or empty to avoid JPA provider exceptions on empty {@code IN} clauses.
+     *
+     * @param demographicNo Integer the patient's demographic number
+     * @param hrmIds        List&lt;Integer&gt; the HRM document IDs to validate; may be {@code null} or empty
+     * @return List&lt;Integer&gt; the HRM document IDs from {@code hrmIds} that belong to the patient,
+     *         or an empty list if {@code hrmIds} is {@code null} or empty
+     * @since 2026-03-24
+     */
     @SuppressWarnings("unchecked")
     public List<Integer> findHrmIdsForDemographic(Integer demographicNo, List<Integer> hrmIds) {
+        if (hrmIds == null || hrmIds.isEmpty()) return Collections.emptyList();
         Query query = entityManager.createQuery(
                 "SELECT x.hrmDocumentId FROM HRMDocumentToDemographic x " +
                 "WHERE x.demographicNo = :demographicNo AND x.hrmDocumentId IN :hrmIds");

--- a/src/main/java/ca/openosp/openo/hospitalReportManager/dao/HRMDocumentToDemographicDao.java
+++ b/src/main/java/ca/openosp/openo/hospitalReportManager/dao/HRMDocumentToDemographicDao.java
@@ -149,4 +149,14 @@ public class HRMDocumentToDemographicDao extends AbstractDaoImpl<HRMDocumentToDe
         return attachedHRMDocumentToDemographics;
     }
 
+    @SuppressWarnings("unchecked")
+    public List<Integer> findHrmIdsForDemographic(Integer demographicNo, List<Integer> hrmIds) {
+        Query query = entityManager.createQuery(
+                "SELECT x.hrmDocumentId FROM HRMDocumentToDemographic x " +
+                "WHERE x.demographicNo = :demographicNo AND x.hrmDocumentId IN :hrmIds");
+        query.setParameter("demographicNo", demographicNo);
+        query.setParameter("hrmIds", hrmIds);
+        return query.getResultList();
+    }
+
 }

--- a/src/main/webapp/js/custom/ocean/conreq.js
+++ b/src/main/webapp/js/custom/ocean/conreq.js
@@ -54,10 +54,10 @@ function validateAttachments(demographicNo, docs) {
 // It involves saving attachments in the 'EreferAttachment' table by sending the selected attachments (documents)
 // and demographic information to the EreferAction.java class.
 function eRefer(event) {
-    let demographicNo = document.getElementById("demographicNo").serialize();
+    let demographicNo = jQuery("#demographicNo").serialize();
     let documents = getDocuments(event);
     let docs = documents.replace('documents=', '').split('|').filter(Boolean);
-    if (!validateAttachments(document.getElementById("demographicNo").value, docs)) {
+    if (!validateAttachments(jQuery("#demographicNo").val(), docs)) {
         throw new Error("Document validation failed");
     }
 
@@ -95,11 +95,11 @@ function getDocuments(event) {
 // It will update the attachments in the consult request and send those attachments to OceanMD
 // by saving them into the 'EreferAttachment' table.
 function attachOceanAttachments() {
-    let demographicNo = document.getElementById("demographicNo").serialize();
-    let requestId = document.getElementById("requestId").serialize();
+    let demographicNo = jQuery("#demographicNo").serialize();
+    let requestId = jQuery("#requestId").serialize();
     let documents = getDocuments();
     let docs = documents.replace('documents=', '').split('|').filter(Boolean);
-    if (!validateAttachments(document.getElementById("demographicNo").value, docs)) {
+    if (!validateAttachments(jQuery("#demographicNo").val(), docs)) {
         throw new Error("Document validation failed");
     }
 

--- a/src/main/webapp/js/custom/ocean/conreq.js
+++ b/src/main/webapp/js/custom/ocean/conreq.js
@@ -34,20 +34,38 @@ jQuery(document).ready(function () {
     });
 });
 
+function validateAttachments(demographicNo, docs) {
+    let valid = false;
+    jQuery.ajax({
+        type: 'POST',
+        async: false,
+        url: document.getElementById("contextPath").value + '/oscarEncounter/eRefer.do',
+        data: "demographicNo=" + demographicNo + "&method=validateDocuments&" + jQuery.param({documents: docs}, true),
+        dataType: 'json',
+        success: function (response) { valid = response.valid; }
+    });
+    if (!valid) {
+        alert("Something went wrong. Please close this window and restart the process from the beginning.");
+    }
+    return valid;
+}
+
 // This code will be executed when a user sends a new e-refer to OceanMD from the consult request form.
 // It involves saving attachments in the 'EreferAttachment' table by sending the selected attachments (documents)
 // and demographic information to the EreferAction.java class.
 function eRefer(event) {
     let demographicNo = document.getElementById("demographicNo").serialize();
     let documents = getDocuments(event);
-    let data = demographicNo + "&" + documents + "&method=attachOceanEReferralConsult";
+    let docs = documents.replace('documents=', '').split('|').filter(Boolean);
+    if (!validateAttachments(document.getElementById("demographicNo").value, docs)) {
+        throw new Error("Document validation failed");
+    }
+
     jQuery.ajax({
         type: 'POST',
         url: document.getElementById("contextPath").value + '/oscarEncounter/eRefer.do',
-        data: data,
-        success: function (response) {
-            console.log(response);
-        }
+        data: demographicNo + "&" + documents + "&method=attachOceanEReferralConsult",
+        success: function (response) { console.log(response); }
     });
 }
 
@@ -80,13 +98,15 @@ function attachOceanAttachments() {
     let demographicNo = document.getElementById("demographicNo").serialize();
     let requestId = document.getElementById("requestId").serialize();
     let documents = getDocuments();
-    let data = demographicNo + "&" + requestId + "&" + documents + "&method=editOceanEReferralConsult";
+    let docs = documents.replace('documents=', '').split('|').filter(Boolean);
+    if (!validateAttachments(document.getElementById("demographicNo").value, docs)) {
+        throw new Error("Document validation failed");
+    }
+
     jQuery.ajax({
         type: 'POST',
         url: document.getElementById("contextPath").value + '/oscarEncounter/eRefer.do',
-        data: data,
-        success: function (response) {
-            console.log(response);
-        }
+        data: demographicNo + "&" + requestId + "&" + documents + "&method=editOceanEReferralConsult",
+        success: function (response) { console.log(response); }
     });
 }


### PR DESCRIPTION
- Adds a `validateDocuments` endpoint in `ERefer2Action` that confirms all selected attachments belong to the specified patient before the referral is submitted
- Covers all four attachment types: documents (`CtlDocument`), labs (`PatientLabRouting`), eforms (`EFormData`), and HRM documents (`HRMDocumentToDemographic`)
- If validation fails, an error message is shown and execution is halted entirely - no tab is opened, no data is sent
     -  <img width="1336" height="496" alt="image" src="https://github.com/user-attachments/assets/d35cf3e4-c656-41ad-b069-4a4d33189670" />

- Adds missing `SecurityInfoManager.hasPrivilege` check to `attachOceanEReferralConsult`

## Summary by Sourcery

Add server- and client-side validation to ensure Ocean eReferral attachments belong to the selected patient and enforce consult security checks before processing attachments.

New Features:
- Introduce a validateDocuments action and corresponding JavaScript flow to verify eReferral attachments before creating or editing Ocean eReferrals.

Bug Fixes:
- Prevent cross-patient attachment of documents, labs, eForms, and HRM documents when submitting or editing Ocean eReferrals.

Enhancements:
- Add repository methods and utility helpers to look up document, lab, eForm, and HRM document IDs by demographic for validation.
- Guard the attachOceanEReferralConsult flow with a missing privilege check using SecurityInfoManager.