### PR TITLE
Fix: String object comparison and forward-iteration deletion in medication stash, missing GCN_SEQNO for drug search flow, and drug name encoding on input

### DIFF
--- a/src/main/java/ca/openosp/openo/prescript/pageUtil/RxChooseDrug2Action.java
+++ b/src/main/java/ca/openosp/openo/prescript/pageUtil/RxChooseDrug2Action.java
@@ -85,7 +85,7 @@ public final class RxChooseDrug2Action extends ActionSupport {
             try {
 
                 RxDrugData.DrugMonograph f = drugData.getDrug(drugId);
-//                    rx.setGCN_SEQNO(f.gcnCode);
+                rx.setGCN_SEQNO(drugId);
                 String genName = "";
                 genName = f.name;
                 rx.setAtcCode(f.atc);

--- a/src/main/java/ca/openosp/openo/prescript/pageUtil/RxSessionBean.java
+++ b/src/main/java/ca/openosp/openo/prescript/pageUtil/RxSessionBean.java
@@ -27,7 +27,6 @@
 package ca.openosp.openo.prescript.pageUtil;
 
 import ca.openosp.openo.prescript.data.*;
-import java.util.Objects;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.logging.log4j.Logger;
 import ca.openosp.openo.commn.model.Allergy;

--- a/src/main/java/ca/openosp/openo/prescript/pageUtil/RxSessionBean.java
+++ b/src/main/java/ca/openosp/openo/prescript/pageUtil/RxSessionBean.java
@@ -27,6 +27,7 @@
 package ca.openosp.openo.prescript.pageUtil;
 
 import ca.openosp.openo.prescript.data.*;
+import java.util.Objects;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.logging.log4j.Logger;
 import ca.openosp.openo.commn.model.Allergy;
@@ -225,7 +226,7 @@ public class RxSessionBean implements java.io.Serializable {
             } else {
                 if (rx.getBrandName() != null && item.getBrandName() != null) {
                     if (rx.getBrandName().equals(item.getBrandName())
-                            && rx.getGCN_SEQNO() == item.getGCN_SEQNO()) {
+                            && Objects.equals(rx.getGCN_SEQNO(), item.getGCN_SEQNO())) {
                         ret = i;
                         break;
                     }

--- a/src/main/java/ca/openosp/openo/prescript/pageUtil/RxWriteScript2Action.java
+++ b/src/main/java/ca/openosp/openo/prescript/pageUtil/RxWriteScript2Action.java
@@ -589,13 +589,6 @@ public final class RxWriteScript2Action extends ActionSupport {
             String drugId = request.getParameter("drugId");
             String text = request.getParameter("text");
 
-			if(text != null) {
-				text = text.trim();
-			}
-
-			if(drugId != null) {
-				drugId = drugId.trim();
-			}
 
             logger.debug("requesting drug from drugref id=" + drugId);
             RxDrugData.DrugMonograph dmono = drugData.getDrug2(drugId);

--- a/src/main/java/ca/openosp/openo/prescript/pageUtil/RxWriteScript2Action.java
+++ b/src/main/java/ca/openosp/openo/prescript/pageUtil/RxWriteScript2Action.java
@@ -1246,7 +1246,7 @@ public final class RxWriteScript2Action extends ActionSupport {
                 allIndex.remove(n);
             }
         }
-        List<Integer> deletedIndex = allIndex;
+        List<Integer> deletedIndex = new ArrayList<>(allIndex);
         Collections.sort(deletedIndex, Collections.reverseOrder());
         // remove closed Rx from stash
         for (Integer n : deletedIndex) {

--- a/src/main/java/ca/openosp/openo/prescript/pageUtil/RxWriteScript2Action.java
+++ b/src/main/java/ca/openosp/openo/prescript/pageUtil/RxWriteScript2Action.java
@@ -590,11 +590,11 @@ public final class RxWriteScript2Action extends ActionSupport {
             String text = request.getParameter("text");
 
 			if(text != null) {
-				text = Encode.forJava(text);
+				text = text.trim();
 			}
 
 			if(drugId != null) {
-				drugId = Encode.forJava(drugId);
+				drugId = drugId.trim();
 			}
 
             logger.debug("requesting drug from drugref id=" + drugId);

--- a/src/main/java/ca/openosp/openo/prescript/pageUtil/RxWriteScript2Action.java
+++ b/src/main/java/ca/openosp/openo/prescript/pageUtil/RxWriteScript2Action.java
@@ -68,6 +68,7 @@ import javax.servlet.http.HttpSession;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
@@ -1246,6 +1247,7 @@ public final class RxWriteScript2Action extends ActionSupport {
             }
         }
         List<Integer> deletedIndex = allIndex;
+        Collections.sort(deletedIndex, Collections.reverseOrder());
         // remove closed Rx from stash
         for (Integer n : deletedIndex) {
             bean.removeStashItem(n);

--- a/src/main/webapp/oscarRx/prescribe.jsp
+++ b/src/main/webapp/oscarRx/prescribe.jsp
@@ -232,8 +232,6 @@ List<RxPrescriptionData.Prescription> listRxDrugs=(List)request.getAttribute("li
                     String prnStr="";
                     if(prn) { prnStr="prn"; }
 
-                drugName=drugName.replace("'", "\\'");
-                drugName=drugName.replace("\"","\\\"");
                 byte[] drugNameBytes = drugName.getBytes("ISO-8859-1");
                 drugName= new String(drugNameBytes, "UTF-8");
                 String fieldSetId = "set_" + rand;
@@ -241,7 +239,7 @@ List<RxPrescriptionData.Prescription> listRxDrugs=(List)request.getAttribute("li
 
 <fieldset style="margin-top:2px;" id="<%=fieldSetId%>">
     <a tabindex="-1" href="javascript:void(0);"  style="float:right;margin-left:5px;margin-top:0px;padding-top:0px;" onclick="removePrescribingDrug(<%=fieldSetId%>, <%=DrugReferenceId%>);"><img src='<c:out value="${ctx}/images/close.png"/>' border="0"></a>
-    <a tabindex="-1" href="javascript:void(0);"  style="float:right;;margin-left:5px;margin-top:0px;padding-top:0px;" title="Add to Favorites" onclick="addFav('<%=rand%>','<%=drugName%>')">F</a>
+    <a tabindex="-1" href="javascript:void(0);"  style="float:right;;margin-left:5px;margin-top:0px;padding-top:0px;" title="Add to Favorites" onclick="addFav('<%=rand%>','<%=Encode.forJavaScript(drugName)%>')">F</a>
     <a tabindex="-1" href="javascript:void(0);" style="float:right;margin-top:0px;padding-top:0px;" onclick="$('rx_more_<%=rand%>').toggle();">  <span id="moreLessWord_<%=rand%>" onclick="updateMoreLess(id)" >more</span> </a>
 
     <%-- Modern flexbox layout for drug name field - replaces float-based layout for better alignment and responsiveness --%>
@@ -455,7 +453,7 @@ List<RxPrescriptionData.Prescription> listRxDrugs=(List)request.getAttribute("li
 	</div><div>
         <label style="float:left;width:80px;">Written Date:</label>
            <input type="text" id="writtenDate_<%=rand%>"  name="writtenDate_<%=rand%>" value="<%=writtenDate%>" />
-           <a href="javascript:void(0);" style="float:right;margin-top:0px;padding-top:0px;" onclick="addFav('<%=rand%>','<%=drugName%>');return false;">Add to Favorite</a>
+           <a href="javascript:void(0);" style="float:right;margin-top:0px;padding-top:0px;" onclick="addFav('<%=rand%>','<%=Encode.forJavaScript(drugName)%>');return false;">Add to Favorite</a>
        
            </div><div>
            			           
@@ -750,7 +748,7 @@ List<RxPrescriptionData.Prescription> listRxDrugs=(List)request.getAttribute("li
 
 
         <script type="text/javascript">
-            $('drugName_'+'<%=rand%>').value=decodeURIComponent(encodeURIComponent('<%=drugName%>'));
+            $('drugName_'+'<%=rand%>').value='<%=Encode.forJavaScript(drugName)%>';
             calculateRxData('<%=rand%>');
             handleEnter=function handleEnter(inField, ev){
                 var charCode;


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                            
  Fixes two interconnected bugs in the medication prescription stash that cause duplicate entries and IndexOutOfBoundsException crashes when re-staging previously saved medications.  

> **Note:** These bug numbers are based on a google document listing medication issues found, not other issues tracked in GitHub.    

Original PR in openo-beta: https://github.com/openo-beta/Open-O/pull/2344                                       
                  
##  Problem                                                                                                                                                                                                                                   
                  
  **Bug `#2` (Regression):** String == comparison (RxSessionBean.java:228): After GCN_SEQNO was refactored from int to String, the duplicate detection in addStashItem() uses == (reference comparison) instead of value comparison. This silently allows duplicate 
  "ghost" entries into the stash when re-adding the same drug.
  **Bug `#3` (Pre-existing):**  Forward-iteration deletion (RxWriteScript2Action.java:1250-1255): The stash cleanup loop iterates forward through indices while calling ArrayList.remove(), which shifts remaining elements down after each removal. This causes wrong 
  items to be deleted or throws IndexOutOfBoundsException: Index 3 out of bounds for length 3.                                                                                                                                              
   
  **Bug `#8` (Cascading):** Together, Bugs `#2` and `#3` cascade into a 500 crash during Save & Print after re-staging medications via Edit Rx.

  **Missing GCN_SEQNO in drug search flow (#1879):** The GCN_SEQNO assignment in RxChooseDrug2Action was commented out during the Vigilance integration, leaving prescriptions with null GCN_SEQNO and breaking duplicate detection, custom name classification, and favorite lookups.

  **Drug name corruption (Pre-existing + Regression):** Encode.forJava() was misapplied to input data in createNewRx(), encoding values at storage time instead of at output time. Combined with manual replace("'", "\\'") calls in prescribe.jsp, this double-escaped apostrophes and quotes in brand names (e.g., CHILDREN'S → CHILDREN\\'S), corrupting data stored in the database and breaking duplicate detection for affected drugs.
                                                                                                                               
                  
##  Solution                                                                                                                                                                                                                                  
                  
  **Bug `#2`:** Changed == to Objects.equals() for null-safe String value comparison on GCN_SEQNO.                                                                                                                                                     
  **Bug `#3`:** Added Collections.sort(deletedIndex, Collections.reverseOrder()) before the removal loop so indices are removed highest-first, preventing index shifting corruption. Used a defensive copy (new ArrayList<>(allIndex)) to avoid mutating the original list.

**#1879:** Restored rx.setGCN_SEQNO(drugId) in RxChooseDrug2Action, matching the pre-Vigilance behavior where the drug reference ID was used as GCN_SEQNO.


**Drug name corruption:** Removed Encode.forJava() calls on text and drugId in RxWriteScript2Action.createNewRx() — these encoded input data that should be stored raw and encoded only at output time. Removed manual drugName.replace("'", "\\'") and drugName.replace("\"","\\\"") in prescribe.jsp. Fixed three raw <%=drugName%> JavaScript usages with proper Encode.forJavaScript(drugName) for XSS prevention.

 ## Found Issues (Will be separate investigations, and have been added under the additional concerns section in the google document)

  - **Drugref data inconsistency:** The drug reference service search endpoint and detail endpoint (get_drug_2) can return different drug names for the same ID (e.g., search returns ACETAMINOPHEN for ID 70652, but detail returns JUNIPER BERRIES). This seems to be a data issue in Open-Drugref, not in OpenO.
  - **DB data corruption:** Drugs with special characters (apostrophes, quotes) saved since the Vigilance integration (August 2025) may have backslash-escaped brand names in the database. A migration script may be needed to clean up affected records.

## Summary by Sourcery

Fix medication prescribing flow issues related to duplicate stash entries, missing drug identifiers, and improper drug name encoding in UI and backend.

Bug Fixes:
- Prevent duplicate medication stash entries by performing proper String value comparison on GCN_SEQNO.
- Avoid IndexOutOfBounds and incorrect deletions when cleaning the medication stash by deleting indices in descending order.
- Restore setting of GCN_SEQNO during the drug selection flow so prescriptions carry the correct drug reference ID.
- Stop corrupting stored drug names and IDs by removing premature backend Java encoding of input parameters.
- Ensure drug names with special characters are safely passed into JavaScript without manual escaping that alters stored values.

## Summary by Sourcery

Fix medication prescribing flow issues around stash duplicate detection, stash cleanup, drug identifier propagation, and safe handling of drug names in the UI.

Bug Fixes:
- Prevent duplicate medication stash entries by comparing GCN_SEQNO using null-safe String value comparison instead of reference equality.
- Avoid incorrect deletions and IndexOutOfBounds errors in the medication stash by deleting items in descending index order using a copied list of indices.
- Restore setting of GCN_SEQNO when choosing a drug so prescriptions retain the correct drug reference identifier.
- Stop corrupting stored drug names and IDs by removing premature backend Java encoding of input parameters and relying on output-time encoding instead.
- Ensure drug names with special characters are safely passed into JavaScript by encoding them for JavaScript where they are injected into the page.