### PR TITLE
Fix: resolve ghost card when unchecking ReRx checkbox after staging

### DIFF
--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -2630,7 +2630,8 @@
      * @param drugId The ID of the drug to remove.
      */
     function removeDrugFromReRxList(uiRefId, drugId) {
-      this.removeElementFromUI(this.getPrescribingDrugCardByUiRefId(uiRefId));
+      const card = document.querySelector('fieldset[data-drug-ref-id="' + drugId + '"]');
+      this.removeElementFromUI(card);
       this.removeReRxDrugId(drugId);
     }
 

--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -2629,7 +2629,7 @@
      * @param drugId The ID of the drug to remove.
      */
     function removeDrugFromReRxList(drugId) {
-      const card = document.querySelector('fieldset[data-drug-ref-id="' + drugId + '"]');
+      const card = document.querySelector('#rxText fieldset[data-drug-ref-id="' + drugId + '"]');
       this.removeElementFromUI(card);
       this.removeReRxDrugId(drugId);
     }

--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -2542,7 +2542,7 @@
         this.addDrugToReRxList(uiRefId, drugId);
         selectedReRxIDs.push(drugId);
       } else {
-        this.removeDrugFromReRxList(uiRefId, drugId);
+        this.removeDrugFromReRxList(drugId);
         selectedReRxIDs = selectedReRxIDs.filter(id => id !== drugId);
       }
       this.updateReRxStageConfirmBoxVisibility();
@@ -2626,10 +2626,9 @@
     /**
      * Removes a drug from the re-prescribe list and updates the UI.
      *
-     * @param uiRefId The unique ID used in the UI to reference this drug.
      * @param drugId The ID of the drug to remove.
      */
-    function removeDrugFromReRxList(uiRefId, drugId) {
+    function removeDrugFromReRxList(drugId) {
       const card = document.querySelector('fieldset[data-drug-ref-id="' + drugId + '"]');
       this.removeElementFromUI(card);
       this.removeReRxDrugId(drugId);

--- a/src/main/webapp/oscarRx/prescribe.jsp
+++ b/src/main/webapp/oscarRx/prescribe.jsp
@@ -239,7 +239,7 @@ List<RxPrescriptionData.Prescription> listRxDrugs=(List)request.getAttribute("li
                 String fieldSetId = "set_" + rand;
 %>
 
-<fieldset style="margin-top:2px;" id="<%=fieldSetId%>">
+<fieldset style="margin-top:2px;" id="<%=fieldSetId%>" data-drug-ref-id="<%=DrugReferenceId%>">
     <a tabindex="-1" href="javascript:void(0);"  style="float:right;margin-left:5px;margin-top:0px;padding-top:0px;" onclick="removePrescribingDrug(<%=fieldSetId%>, <%=DrugReferenceId%>);"><img src='<c:out value="${ctx}/images/close.png"/>' border="0"></a>
     <a tabindex="-1" href="javascript:void(0);"  style="float:right;;margin-left:5px;margin-top:0px;padding-top:0px;" title="Add to Favorites" onclick="addFav('<%=rand%>','<%=drugName%>')">F</a>
     <a tabindex="-1" href="javascript:void(0);" style="float:right;margin-top:0px;padding-top:0px;" onclick="$('rx_more_<%=rand%>').toggle();">  <span id="moreLessWord_<%=rand%>" onclick="updateMoreLess(id)" >more</span> </a>

--- a/src/main/webapp/oscarRx/prescribe.jsp
+++ b/src/main/webapp/oscarRx/prescribe.jsp
@@ -239,7 +239,7 @@ List<RxPrescriptionData.Prescription> listRxDrugs=(List)request.getAttribute("li
                 String fieldSetId = "set_" + rand;
 %>
 
-<fieldset style="margin-top:2px;" id="<%=fieldSetId%>" data-drug-ref-id="<%=DrugReferenceId%>">
+<fieldset style="margin-top:2px;" id="<%=fieldSetId%>" data-drug-ref-id="<%=Encode.forHtmlAttribute(String.valueOf(DrugReferenceId))%>">
     <a tabindex="-1" href="javascript:void(0);"  style="float:right;margin-left:5px;margin-top:0px;padding-top:0px;" onclick="removePrescribingDrug(<%=fieldSetId%>, <%=DrugReferenceId%>);"><img src='<c:out value="${ctx}/images/close.png"/>' border="0"></a>
     <a tabindex="-1" href="javascript:void(0);"  style="float:right;;margin-left:5px;margin-top:0px;padding-top:0px;" title="Add to Favorites" onclick="addFav('<%=rand%>','<%=drugName%>')">F</a>
     <a tabindex="-1" href="javascript:void(0);" style="float:right;margin-top:0px;padding-top:0px;" onclick="$('rx_more_<%=rand%>').toggle();">  <span id="moreLessWord_<%=rand%>" onclick="updateMoreLess(id)" >more</span> </a>


### PR DESCRIPTION
## Summary

  Fixes the UI card lookup in removeDrugFromReRxList so unchecking a ReRx checkbox after staging correctly removes the corresponding card from the prescribing area.

> **Note:** These bug numbers are based on a google document listing medication issues found, not other issues tracked in GitHub.     

Original PR in openo-beta: https://github.com/openo-beta/Open-O/pull/2345    

  ## Problem

 **Bug `#1`:** When a user unchecked a ReRx checkbox after staging medications, removeDrugFromReRxList tried to find the staged card
   using $('set_' + prescriptIdInt) — but the card's DOM ID uses a randomId (set_<randomId>), not the prescription ID.
  The lookup silently returned null, leaving the card visible while the backend removed the drug from the stash. This
  created a "ghost card" — visible in the UI but missing from the backend, causing the drug to be skipped during Save & Print while its original prescription was archived.

  ## Solution

  - Added a data-drug-ref-id attribute to the staged card fieldsets in prescribe.jsp, storing the DrugReferenceId
  - Updated removeDrugFromReRxList in SearchDrug3.jsp to find the card via
  document.querySelector('fieldset[data-drug-ref-id="' + drugId + '"]') instead of the mismatched ID lookup

  The backend stash removal in removeFromReRxDrugIdList is unchanged, it was already working correctly. The bug was purely on the UI side.

## Summary by Sourcery

Fix UI removal of staged ReRx prescribing cards when a medication is unchecked after staging.

Bug Fixes:
- Ensure unchecking a ReRx checkbox removes the corresponding staged prescribing card by selecting it via a drug reference data attribute instead of an incorrect DOM ID lookup.

Enhancements:
- Attach a data-drug-ref-id attribute to prescribing fieldsets so UI logic can reliably map ReRx actions to the correct staged medication cards.

## Summary by Sourcery

Fix removal of staged ReRx prescribing cards when a medication is unchecked after staging by aligning the UI card lookup with the drug reference ID.

Bug Fixes:
- Ensure unchecking a ReRx checkbox removes the corresponding staged prescribing card by selecting it via a drug reference data attribute instead of an incorrect UI reference ID.

Enhancements:
- Add a data-drug-ref-id attribute to prescribing fieldsets so ReRx UI logic can reliably map actions to staged medication cards.