### PR TITLE
fix: MDS queue doc count not updating after Save & Next

### DIFF
--- a/src/main/webapp/oscarMDS/documentsInQueues.jsp
+++ b/src/main/webapp/oscarMDS/documentsInQueues.jsp
@@ -1825,13 +1825,26 @@
 //console.log('foundQ='+foundQ);
             //descrease the queue's doc number by 1
             if (foundQ.length > 0) {
-                var n = $('docNo_' + foundQ).innerHTML;
-                //console.log('not found11');
+                const el = document.getElementById('docNo_' + foundQ);
+
+                if (!el) {
+                    console.warn("Element not found for:", 'docNo_' + foundQ);
+                    return;
+                }
+
+                const n = el.innerHTML;
+                console.log("Current count:", n);
+
                 n = parseInt(n);
-                //console.log('not found22');
+
+                if (isNaN(n)) {
+                    console.warn("Count is not a number:", el.innerHTML);
+                    return;
+                }
+
                 if (n > 0) {
-                    //console.log('not found33');
-                    $('docNo_' + foundQ).innerHTML = n - 1;
+                    el.innerHTML = n - 1;
+                    console.log("Updated count:", el.innerHTML);
                 }
             }
             //console.log('not found44');

--- a/src/main/webapp/oscarMDS/documentsInQueues.jsp
+++ b/src/main/webapp/oscarMDS/documentsInQueues.jsp
@@ -1826,25 +1826,13 @@
             //descrease the queue's doc number by 1
             if (foundQ.length > 0) {
                 const el = document.getElementById('docNo_' + foundQ);
+                if (!el) { return; }
 
-                if (!el) {
-                    console.warn("Element not found for:", 'docNo_' + foundQ);
-                    return;
-                }
-
-                const n = el.innerHTML;
-                console.log("Current count:", n);
-
-                n = parseInt(n);
-
-                if (isNaN(n)) {
-                    console.warn("Count is not a number:", el.innerHTML);
-                    return;
-                }
+                const n = parseInt(el.textContent, 10);
+                if (isNaN(n)) { return; }
 
                 if (n > 0) {
-                    el.innerHTML = n - 1;
-                    console.log("Updated count:", el.innerHTML);
+                    el.textContent = n - 1;
                 }
             }
             //console.log('not found44');

--- a/src/main/webapp/share/javascript/oscarMDSIndex.js
+++ b/src/main/webapp/share/javascript/oscarMDSIndex.js
@@ -1538,6 +1538,15 @@ function updateGlobalDataAndSideNav(doclabid, patientId) {
             na.splice(index, 1);
             addIdToPatient(doclabid, patientId);//add to patient
         }
+
+        // Update queue side nav count and remove from queue data if in queue context
+        if (typeof updateSideNavInQueue === 'function') {
+            updateSideNavInQueue(doclabid);
+        }
+        if (typeof removeDocFromQueue === 'function') {
+            removeDocFromQueue(doclabid);
+        }
+
         return true;
     }
 }


### PR DESCRIPTION
## Context
When a user clicks a queue link in the left nav bar of the Pending Docs window (documentsInQueues.jsp), a document is loaded into the right-side panel via showDocLab().
<img width="829" height="380" alt="image" src="https://github.com/user-attachments/assets/fcbb933a-139f-4f83-b742-4afcb2ece9af" />

In commit 7faa754, this loading mechanism was changed from Prototype's Ajax.Updater to fetch + jQuery.html().

 ## The Problem
documentsInQueues.jsp and oscarMDSIndex.js both define a saveNext function, but with different behaviour. The inline version in documentsInQueues.jsp knows how to decrement the queue doc count in the left nav; the oscarMDSIndex.js version does not — it was written for a different context.

 These two script-loading strategies handle <script src="..."> tags very differently:

 **Old behaviour - `Ajax.Updater` (Prototype)**
Prototype's evalScripts: true only executed inline <script> blocks. External <script src="..."> files inside the injected HTML - including oscarMDSIndex.js - were silently ignored and never re-fetched. This meant window.saveNext stayed as the version defined inline in documentsInQueues.jsp, which correctly called updateSideNavInQueue and decremented the queue count span. 

  **New behaviour - `fetch` + `jQuery.html()`**
jQuery's .html() processes all <script> tags, including <script src="...">. When showDocument.jsp was injected, jQuery asynchronously re-loaded oscarMDSIndex.js (and jquery-1.12.0.min.js), silently overriding window.saveNext with oscarMDSIndex.js's version. That version calls updateDocumentAndNext → updateGlobalDataAndSideNav, neither of which updated the queue count span (<span id="docNo_X">). After every Save & Next, the document disappeared but the count stayed the same.

  ## The Fix

Two targeted changes to break the dependency on which saveNext wins:

1. oscarMDSIndex.js - updateGlobalDataAndSideNav
Added calls to updateSideNavInQueue and removeDocFromQueue inside updateGlobalDataAndSideNav, guarded with typeof checks. When running inside documentsInQueues.jsp these functions are in scope and execute; when showDocument.jsp is used standalone they are not defined and the guards skip them safely.

2. documentsInQueues.jsp - updateSideNavInQueue
Changed `$('docNo_' + foundQ)` to document.getElementById('docNo_' + foundQ). This makes the function immune to window.$ being overridden by the async jQuery re-load, ensuring the span is always found and the count is correctly decremented.

## Summary by Sourcery

Ensure MDS queue document counts in the Pending Docs sidebar stay in sync when using Save & Next, regardless of which saveNext implementation is active.

Bug Fixes:
- Correct the Pending Docs queue counter so it decrements when a document is saved and advanced via Save & Next, even when oscarMDSIndex.js overrides the inline saveNext.
- Prevent failures to update the queue count when the corresponding DOM element is missing or has a non-numeric value.

Enhancements:
- Make updateGlobalDataAndSideNav optionally update and prune queue state when running in a queue context by invoking queue-specific helpers when available.
- Harden updateSideNavInQueue to use direct DOM access and safer value parsing so it is resilient to global $ overrides and malformed content.