### PR TITLE
Fix: missing tuning fork measurement diabetes flowsheet

### DIFF
--- a/database/mysql/oscardata.sql
+++ b/database/mysql/oscardata.sql
@@ -1221,7 +1221,7 @@ INSERT INTO `measurementType` (`type`, `typeDisplayName`, `typeDescription`, `me
 ( 'NERF', 'Neuropathic Features?', 'Neuropathic Features?', 'null', '15', '2013-05-07 00:00:00'),
 ( 'NOSK', 'Number of Cigarettes per day', 'Smoking', 'Cigarettes per day', '5', '2013-02-01 00:00:00'),
 ( 'NOVS', 'Need for nocturnal ventilated support', 'Need for nocturnal ventilated support', 'Yes/No', '7', '2013-02-01 00:00:00'),
-( 'NRTF', 'Neurological Exam 128Hz Tuning Fork D1', 'Neurological Exam 128Hz Tuning Fork D1', 'Normal', '7', '2026-03-23 00:00:00'),
+( 'NRTF', 'Neurological exam: 128Hz tuning fork D1', 'Neurological exam: 128Hz tuning fork D1', 'Normal', '7', '2026-03-23 00:00:00'),
 ( 'NtrC', 'Diet/Nutrition Counseling Given', 'Diet/Nutrition Counseling Given', 'Yes/No', '7', '2013-02-01 00:00:00'),
 ( 'NYHA', 'NYHA Functional Capacity Classification', 'NYHA Functional Capacity Classification', 'Class 1-4', '9', '2013-02-01 00:00:00'),
 ( 'OPAE', 'Opioid Adverse Effects', 'Opioid Adverse Effects', 'null', '17', '2014-11-27 13:00:00'),

--- a/database/mysql/oscardata.sql
+++ b/database/mysql/oscardata.sql
@@ -1221,6 +1221,7 @@ INSERT INTO `measurementType` (`type`, `typeDisplayName`, `typeDescription`, `me
 ( 'NERF', 'Neuropathic Features?', 'Neuropathic Features?', 'null', '15', '2013-05-07 00:00:00'),
 ( 'NOSK', 'Number of Cigarettes per day', 'Smoking', 'Cigarettes per day', '5', '2013-02-01 00:00:00'),
 ( 'NOVS', 'Need for nocturnal ventilated support', 'Need for nocturnal ventilated support', 'Yes/No', '7', '2013-02-01 00:00:00'),
+( 'NRTF', 'Neurological Exam 128Hz Tuning Fork D1', 'Neurological Exam 128Hz Tuning Fork D1', 'Normal', '7', '2026-03-23 00:00:00'),
 ( 'NtrC', 'Diet/Nutrition Counseling Given', 'Diet/Nutrition Counseling Given', 'Yes/No', '7', '2013-02-01 00:00:00'),
 ( 'NYHA', 'NYHA Functional Capacity Classification', 'NYHA Functional Capacity Classification', 'Class 1-4', '9', '2013-02-01 00:00:00'),
 ( 'OPAE', 'Opioid Adverse Effects', 'Opioid Adverse Effects', 'null', '17', '2014-11-27 13:00:00'),

--- a/database/mysql/updates/update-2026-03-23-nrtf-tuning-fork.sql
+++ b/database/mysql/updates/update-2026-03-23-nrtf-tuning-fork.sql
@@ -1,0 +1,9 @@
+--
+-- Add NRTF (Neurological Exam 128Hz Tuning Fork D1) measurement type
+-- for diabetes flowsheet compliance with OMD DE16.066
+-- Fixes: https://github.com/openo-beta/Open-O/issues/2338
+--
+
+INSERT INTO `measurementType` (`type`, `typeDisplayName`, `typeDescription`, `measuringInstruction`, `validation`, `createDate`)
+VALUES ('NRTF', 'Neurological Exam 128Hz Tuning Fork D1', 'Neurological Exam 128Hz Tuning Fork D1', 'Normal', '7', '2026-03-23 00:00:00')
+ON DUPLICATE KEY UPDATE `typeDisplayName`='Neurological Exam 128Hz Tuning Fork D1';

--- a/database/mysql/updates/update-2026-03-23-nrtf-tuning-fork.sql
+++ b/database/mysql/updates/update-2026-03-23-nrtf-tuning-fork.sql
@@ -5,5 +5,5 @@
 --
 
 INSERT INTO `measurementType` (`type`, `typeDisplayName`, `typeDescription`, `measuringInstruction`, `validation`, `createDate`)
-VALUES ('NRTF', 'Neurological Exam 128Hz Tuning Fork D1', 'Neurological Exam 128Hz Tuning Fork D1', 'Normal', '7', '2026-03-23 00:00:00')
-ON DUPLICATE KEY UPDATE `typeDisplayName`='Neurological Exam 128Hz Tuning Fork D1';
+VALUES ('NRTF', 'Neurological exam: 128Hz tuning fork D1', 'Neurological exam: 128Hz tuning fork D1', 'Normal', '7', '2026-03-23 00:00:00')
+ON DUPLICATE KEY UPDATE `typeDisplayName`='Neurological exam: 128Hz tuning fork D1';

--- a/database/mysql/updates/update-2026-03-23-nrtf-tuning-fork.sql
+++ b/database/mysql/updates/update-2026-03-23-nrtf-tuning-fork.sql
@@ -6,4 +6,8 @@
 
 INSERT INTO `measurementType` (`type`, `typeDisplayName`, `typeDescription`, `measuringInstruction`, `validation`, `createDate`)
 VALUES ('NRTF', 'Neurological exam: 128Hz tuning fork D1', 'Neurological exam: 128Hz tuning fork D1', 'Normal', '7', '2026-03-23 00:00:00')
-ON DUPLICATE KEY UPDATE `typeDisplayName`='Neurological exam: 128Hz tuning fork D1';
+ON DUPLICATE KEY UPDATE
+  `typeDisplayName`='Neurological exam: 128Hz tuning fork D1',
+  `typeDescription`='Neurological exam: 128Hz tuning fork D1',
+  `measuringInstruction`='Normal',
+  `validation`='7';

--- a/src/main/resources/oscar/oscarEncounter/oscarMeasurements/flowsheets/diabetesFlowsheet.xml
+++ b/src/main/resources/oscar/oscarEncounter/oscarMeasurements/flowsheets/diabetesFlowsheet.xml
@@ -157,8 +157,15 @@
         ds_rules="diab-C-no-is-high.drl"/>
     <item
         measurement_type="FTLS"
-        display_name="Test loss of Sensation"
-        guideline="Check for peripheral anesthesia with 10g monofilament or 128 Hz tuning fork"
+        display_name="Neurological exam: 10g monofilament"
+        guideline="Check for peripheral anesthesia with 10g monofilament"
+        graphable="no"
+        value_name="Normal"
+        ds_rules="diab-C-no-is-high.drl"/>
+    <item
+        measurement_type="NRTF"
+        display_name="Neurological exam: 128Hz tuning fork D1"
+        guideline="Check for peripheral anesthesia with 128 Hz tuning fork"
         graphable="no"
         value_name="Normal"
         ds_rules="diab-C-no-is-high.drl"/>
@@ -389,19 +396,28 @@
     </measurement>   
  
            
-    <measurement 
-        type="FTLS"      
-        typeDesc="Foot Exam  Loss of Sensation"      
+    <measurement
+        type="FTLS"
+        typeDesc="Foot Exam  Loss of Sensation"
         typeDisplayName="Foot Exam  Test loss of Sensation"
-        measuringInstrc="Normal">  
+        measuringInstrc="Normal">
         <validationRule
            name="Yes/No"
-           regularExp="YES|yes|Yes|Y|NO|no|No|N"/>   
-    </measurement>   
- 
-          
-    <measurement 
-        type="PANE" 
+           regularExp="YES|yes|Yes|Y|NO|no|No|N"/>
+    </measurement>
+
+    <measurement
+        type="NRTF"
+        typeDesc="Neurological Exam 128Hz Tuning Fork D1"
+        typeDisplayName="Neurological Exam 128Hz Tuning Fork D1"
+        measuringInstrc="Normal">
+        <validationRule
+           name="Yes/No"
+           regularExp="YES|yes|Yes|Y|NO|no|No|N"/>
+    </measurement>
+
+    <measurement
+        type="PANE"
         typeDesc="Painful Neuropathy"      
         typeDisplayName="Painful Neuropathy" 
         measuringInstrc="Present">  

--- a/src/main/resources/oscar/oscarEncounter/oscarMeasurements/flowsheets/diabetesFlowsheet.xml
+++ b/src/main/resources/oscar/oscarEncounter/oscarMeasurements/flowsheets/diabetesFlowsheet.xml
@@ -408,8 +408,8 @@
 
     <measurement
         type="NRTF"
-        typeDesc="Neurological Exam 128Hz Tuning Fork D1"
-        typeDisplayName="Neurological Exam 128Hz Tuning Fork D1"
+        typeDesc="Neurological exam: 128Hz tuning fork D1"
+        typeDisplayName="Neurological exam: 128Hz tuning fork D1"
         measuringInstrc="Normal">
         <validationRule
            name="Yes/No"

--- a/src/main/resources/oscar/oscarEncounter/oscarMeasurements/flowsheets/diabetesQueensFlowsheet.xml
+++ b/src/main/resources/oscar/oscarEncounter/oscarMeasurements/flowsheets/diabetesQueensFlowsheet.xml
@@ -96,7 +96,8 @@
 
 	<header display_name="Feet">
 		<item measurement_type="FTE" display_name="Foot Exam" guideline="Foot Care" graphable="no" value_name="Normal"  />
-		<item measurement_type="FTLS" display_name="Monofilament 10g" guideline="Check for peripheral anesthesia with 10g monofilament or 128 Hz tuning fork" graphable="no" value_name="Normal"  />
+		<item measurement_type="FTLS" display_name="Neurological exam: 10g monofilament" guideline="Check for peripheral anesthesia with 10g monofilament" graphable="no" value_name="Normal"  />
+		<item measurement_type="NRTF" display_name="Neurological exam: 128Hz tuning fork D1" guideline="Check for peripheral anesthesia with 128 Hz tuning fork" graphable="no" value_name="Normal"  />
 	</header>
 	
 	<header display_name="Psychosocial">
@@ -329,8 +330,12 @@
 	<measurement type="FTLS" typeDesc="Foot Exam  Loss of Sensation" typeDisplayName="Foot Exam  Test loss of Sensation" measuringInstrc="Normal">
 	  <validationRule name="Yes/No" maxValue="" minValue="" isDate="" isNumeric="" regularExp="YES|yes|Yes|Y|NO|no|No|N" maxLength="" minLength="" />
 	</measurement>
-	
-	
+
+	<measurement type="NRTF" typeDesc="Neurological Exam 128Hz Tuning Fork D1" typeDisplayName="Neurological Exam 128Hz Tuning Fork D1" measuringInstrc="Normal">
+	  <validationRule name="Yes/No" maxValue="" minValue="" isDate="" isNumeric="" regularExp="YES|yes|Yes|Y|NO|no|No|N" maxLength="" minLength="" />
+	</measurement>
+
+
 	<measurement type="FGLC" typeDesc="Fasting glucose meter, lab comparison" typeDisplayName="Fasting Glucose meter , lab comparison" measuringInstrc="Within 20 percent">
 	  <validationRule name="Yes/No" maxValue="" minValue="" isDate="" isNumeric="" regularExp="YES|yes|Yes|Y|NO|no|No|N" maxLength="" minLength="" />
 	</measurement>

--- a/src/main/resources/oscar/oscarEncounter/oscarMeasurements/flowsheets/diabetesQueensFlowsheet.xml
+++ b/src/main/resources/oscar/oscarEncounter/oscarMeasurements/flowsheets/diabetesQueensFlowsheet.xml
@@ -331,7 +331,7 @@
 	  <validationRule name="Yes/No" maxValue="" minValue="" isDate="" isNumeric="" regularExp="YES|yes|Yes|Y|NO|no|No|N" maxLength="" minLength="" />
 	</measurement>
 
-	<measurement type="NRTF" typeDesc="Neurological Exam 128Hz Tuning Fork D1" typeDisplayName="Neurological Exam 128Hz Tuning Fork D1" measuringInstrc="Normal">
+	<measurement type="NRTF" typeDesc="Neurological exam: 128Hz tuning fork D1" typeDisplayName="Neurological exam: 128Hz tuning fork D1" measuringInstrc="Normal">
 	  <validationRule name="Yes/No" maxValue="" minValue="" isDate="" isNumeric="" regularExp="YES|yes|Yes|Y|NO|no|No|N" maxLength="" minLength="" />
 	</measurement>
 

--- a/src/main/resources/oscar/oscarEncounter/oscarMeasurements/flowsheets/omdDiabetesFlowsheet.xml
+++ b/src/main/resources/oscar/oscarEncounter/oscarMeasurements/flowsheets/omdDiabetesFlowsheet.xml
@@ -707,7 +707,7 @@
 		<validationRule name="Yes/No" maxValue="" minValue="" isDate="" isNumeric="" regularExp="YES|yes|Yes|Y|NO|no|No|N" maxLength="" minLength="" />
 	</measurement>
 
-	<measurement type="NRTF" typeDesc="Neurological Exam 128Hz Tuning Fork D1" typeDisplayName="Neurological Exam 128Hz Tuning Fork D1" measuringInstrc="Normal">
+	<measurement type="NRTF" typeDesc="Neurological exam: 128Hz tuning fork D1" typeDisplayName="Neurological exam: 128Hz tuning fork D1" measuringInstrc="Normal">
 		<validationRule name="Yes/No" maxValue="" minValue="" isDate="" isNumeric="" regularExp="YES|yes|Yes|Y|NO|no|No|N" maxLength="" minLength="" />
 	</measurement>
 

--- a/src/main/resources/oscar/oscarEncounter/oscarMeasurements/flowsheets/omdDiabetesFlowsheet.xml
+++ b/src/main/resources/oscar/oscarEncounter/oscarMeasurements/flowsheets/omdDiabetesFlowsheet.xml
@@ -300,13 +300,23 @@
 				</recommendation>
 			</rules>
 		</item>
-		<item measurement_type="FTLS" display_name="Monofilament 10g" guideline="Check for peripheral anesthesia with 10g monofilament or 128 Hz tuning fork" graphable="no" value_name="Normal"  >
+		<item measurement_type="FTLS" display_name="Neurological exam: 10g monofilament" guideline="Check for peripheral anesthesia with 10g monofilament" graphable="no" value_name="Normal"  >
 			<rules>
 				<recommendation strength="warning" >
 					<condition type="monthrange" param="FTLS" value="&gt;12" />
 				</recommendation>
 				<recommendation strength="warning" >
 					<condition type="monthrange" param="FTLS" value="-1" />
+				</recommendation>
+			</rules>
+		</item>
+		<item measurement_type="NRTF" display_name="Neurological exam: 128Hz tuning fork D1" guideline="Check for peripheral anesthesia with 128 Hz tuning fork" graphable="no" value_name="Normal"  >
+			<rules>
+				<recommendation strength="warning" >
+					<condition type="monthrange" param="NRTF" value="&gt;12" />
+				</recommendation>
+				<recommendation strength="warning" >
+					<condition type="monthrange" param="NRTF" value="-1" />
 				</recommendation>
 			</rules>
 		</item>
@@ -696,7 +706,11 @@
 	<measurement type="FTLS" typeDesc="Foot Exam  Loss of Sensation" typeDisplayName="Foot Exam  Test loss of Sensation" measuringInstrc="Normal">
 		<validationRule name="Yes/No" maxValue="" minValue="" isDate="" isNumeric="" regularExp="YES|yes|Yes|Y|NO|no|No|N" maxLength="" minLength="" />
 	</measurement>
-	
+
+	<measurement type="NRTF" typeDesc="Neurological Exam 128Hz Tuning Fork D1" typeDisplayName="Neurological Exam 128Hz Tuning Fork D1" measuringInstrc="Normal">
+		<validationRule name="Yes/No" maxValue="" minValue="" isDate="" isNumeric="" regularExp="YES|yes|Yes|Y|NO|no|No|N" maxLength="" minLength="" />
+	</measurement>
+
 	<measurement type="FGLC" typeDesc="Fasting glucose meter, lab comparison" typeDisplayName="Fasting Glucose meter , lab comparison" measuringInstrc="Within 20 percent">
 		<validationRule name="Yes/No" maxValue="" minValue="" isDate="" isNumeric="" regularExp="YES|yes|Yes|Y|NO|no|No|N" maxLength="" minLength="" />
 	</measurement>


### PR DESCRIPTION
## Summary
  Adds the missing "128Hz tuning fork D1" neurological exam measurement to the diabetes flowsheet and relabels the existing monofilament field for clarity.

### See the "Manual Steps" section for required manual updates for these fixes on an already setup DB

Original PR: https://github.com/openo-beta/Open-O/pull/2380

  ## Problem
  The diabetes flowsheet only had a single "Monofilament 10g" field for recording neurological exam results. The 128 Hz tuning fork D1 test had no dedicated field, preventing clinics from meeting OMD DE16.066 validation requirements
  which require both test options to be available.

  ## Solution
  - **Relabeled** the existing FTLS flowsheet item from "Monofilament 10g" to "Neurological exam: 10g monofilament" across all three diabetes flowsheets (`diab`, `diab2`, `diab3`)
  - **Added** a new `NRTF` measurement type ("Neurological exam: 128Hz tuning fork D1") with Yes/No/NA validation, placed directly after the monofilament field in each flowsheet
  - **Database**: added migration script (`update-2026-03-23-nrtf-tuning-fork.sql`) for existing installations and updated seed data in `oscardata.sql` and `development.sql` for fresh installs

## Manual Steps 
                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
Run the database migration script before deploying: 

database/mysql/updates/update-2026-03-23-nrtf-tuning-fork.sql