### PR TITLE
fix: restore server-side drug filtering and heading display broken by…

### DIFF
--- a/src/main/webapp/oscarRx/ListDrugs.jsp
+++ b/src/main/webapp/oscarRx/ListDrugs.jsp
@@ -84,99 +84,11 @@
 
 
 
-<style>
-    /* Container for the drug-maintenance-switch */
-    .drug-maintenance-switch {
-        top: -2px;
-        position: relative;
-        width: 34px;
-        height: 16px;
-    }
-
-    /* Hide the default checkbox */
-    .drug-maintenance-switch-input {
-        display: none;
-    }
-
-    /* Style the switch track */
-    .drug-maintenance-switch-label {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background-color: #dfdfdf;
-        cursor: pointer;
-        transition: background-color 0.3s;
-        border-radius: 5%;
-    }
-
-    /* Style the toggle knob, default label to blank if unchecked */
-    .drug-maintenance-switch-label::after {
-        text-align: center;
-        content: '';
-        font-size: xx-small;
-        font-stretch: extra-expanded;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        position: absolute;
-        top: 2px;
-        left: 2px;
-        width: 12px;
-        height: 12px;
-        background-color: #FFFFFFAF;
-        border-radius: 50%;
-        transition: transform 0.3s, content 0.3s, width 0.3s, height 0.3s, border-radius 0.3s;
-        box-shadow: 0 1px 6px rgba(0, 0, 0, 0.4);
-    }
-
-    /* Change Label to LT (long term) when checked */
-    .drug-maintenance-switch-input:checked + .drug-maintenance-switch-label::after {
-        content: 'LT'; /* Change label when checked */
-        transform: translateX(14px);
-        border-radius: 5%;
-        width: 16px;
-        height: 12px;
-        color: white;
-        background-color: #1e7e34AF;
-    }
-
-    /* Disabled State Styling */
-    .drug-maintenance-switch-input:disabled + .drug-maintenance-switch-label {
-        background-color: #e0e0e0;
-        cursor: not-allowed;
-    }
-
-    /* Disabled State: Handle appearance */
-    .drug-maintenance-switch-input:disabled:checked + .drug-maintenance-switch-label::after {
-        background-color: #1e7e349F;
-        transform: translateX(14px);
-        content: 'LT';
-        width: 16px;
-        height: 12px;
-        border-radius: 5%;
-    }
-
-    .list-drugs td:nth-child(5) {
-        word-break: break-word;
-        white-space: normal;
-    }
-
-
-</style>
 
 <%
     LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
     SecurityManager securityManager = new SecurityManager();
     PartialDateDao partialDateDao = SpringUtils.getBean(PartialDateDao.class);
-
-    boolean showall = false;
-    if (request.getParameter("show") != null) {
-        if (request.getParameter("show").equals("all")) {
-            showall = true;
-        }
-    }
 
     CodingSystemManager codingSystemManager = SpringUtils.getBean(CodingSystemManager.class);
 
@@ -233,11 +145,7 @@
             List<Drug> prescriptDrugs = null;
             CaseManagementManager caseManagementManager = SpringUtils.getBean(CaseManagementManager.class);
 
-            if (showall) {
-                prescriptDrugs = caseManagementManager.getPrescriptions(loggedInInfo, patient.getDemographicNo(), showall);
-            } else {
-                prescriptDrugs = caseManagementManager.getCurrentPrescriptions(patient.getDemographicNo());
-            }
+            prescriptDrugs = caseManagementManager.getPrescriptions(loggedInInfo, patient.getDemographicNo(), true);
 
             DrugReasonDao drugReasonDao = SpringUtils.getBean(DrugReasonDao.class);
 
@@ -269,29 +177,6 @@
                     isPrevAnnotation = true;
                 }
 
-                if (request.getParameter("status") != null) { //TODO: Redo this in a better way
-                    String stat = request.getParameter("status");
-                    if (stat.equals("active") && !prescriptDrug.isLongTerm() && !prescriptDrug.isCurrent()) {
-                        continue;
-                    } else if (stat.equals("inactive") && prescriptDrug.isCurrent()) {
-                        continue;
-                    }
-                }
-                if (request.getParameter("longTermOnly") != null && request.getParameter("longTermOnly").equals("true")) {
-                    if (!prescriptDrug.isLongTerm()) {
-                        continue;
-                    }
-                }
-
-                if (request.getParameter("longTermOnly") != null && request.getParameter("longTermOnly").equals("acute")) {
-                    if (prescriptDrug.isLongTerm()) {
-                        continue;
-                    }
-                }
-                if (request.getParameter("drugLocation") != null && request.getParameter("drugLocation").equals("external")) {
-                    if (!prescriptDrug.isExternal())
-                        continue;
-                }
 //add all long term med drugIds to an array.
                 styleColor = getClassColour(prescriptDrug, now, month);
                 String specialText = prescriptDrug.getSpecial();
@@ -301,7 +186,10 @@
 
                 boolean startDateUnknown = prescriptDrug.getStartDateUnknown();
         %>
-        <tr>
+        <tr data-is-archived="<%= prescriptDrug.isArchived() %>"
+            data-is-longterm="<%= prescriptDrug.isLongTerm() %>"
+            data-is-current="<%= prescriptDrug.isCurrent() %>"
+            data-is-external="<%= prescriptDrug.isExternal() %>">
 
         <td><a id="createDate_<%=prescriptIdInt%>" <%=styleColor%> href="<%= request.getContextPath() %>/oscarRx/StaticScript2.jsp?regionalIdentifier=<%=Encode.forUriComponent(prescriptDrug.getRegionalIdentifier())%>&amp;cn=<%=Encode.forUriComponent(prescriptDrug.getCustomName())%>&amp;bn=<%=Encode.forUriComponent(bn)%>&amp;atc=<%=Encode.forUriComponent(prescriptDrug.getAtc())%>"><%=DateToString(prescriptDrug.getCreateDate())%></a></td>
             <td>
@@ -524,7 +412,7 @@
 
 <script type="text/javascript">
 
-    drugListTable = jQuery('#${e:forJavaScript(drugTableId)}').dataTable({
+    window.drugListTableConfig = window.drugListTableConfig || {
       bStateSave: true,
       fnStateSave: function (oSettings, oData) {
         localStorage.setItem('drugListTable', JSON.stringify(oData));
@@ -577,7 +465,8 @@
 
       // order: [[4, 'desc']]
 
-    });
+    };
+    drugListTable = jQuery('#${e:forJavaScript(drugTableId)}').dataTable(window.drugListTableConfig);
 </script>
 <%!
 

--- a/src/main/webapp/oscarRx/ListDrugs.jsp
+++ b/src/main/webapp/oscarRx/ListDrugs.jsp
@@ -30,6 +30,7 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="https://www.owasp.org/index.php/OWASP_Java_Encoder_Project" prefix="e" %>
 <%@ page import="ca.openosp.OscarProperties,ca.openosp.openo.log.*" %>
 <%@page import="ca.openosp.openo.casemgmt.service.CaseManagementManager,
                 ca.openosp.openo.casemgmt.model.CaseManagementNoteLink,
@@ -181,9 +182,25 @@
 
     boolean integratorEnabled = loggedInInfo.getCurrentFacility().isIntegratorEnabled();
     String annotation_display = CaseManagementNoteLink.DISP_PRESCRIP;
+
+    // The legend in SearchDrug3.jsp can load this page multiple times into #drugProfile —
+    // once as a replacement (e.g. "Long Term Meds") and one or more times as appended
+    // sections (e.g. "Acute", "Inactive", "External"). Each request passes a "heading"
+    // param that labels the section and is used to give its table a unique DOM id so that
+    // each section can be independently initialised as its own DataTable instance.
+    String heading = request.getParameter("heading");
+    
+    // Remove spaces so the heading is safe to embed directly in an HTML element id.
+    String headingSuffix = (heading != null) ? heading.replaceAll("\\s+", "") : "";
+    String tableId = "Drug_table" + headingSuffix;
+    request.setAttribute("sectionHeading", heading);
+    request.setAttribute("drugTableId", tableId);
 %>
+<c:if test="${not empty sectionHeading}">
+    <h4 style="margin-bottom:1px;margin-top:3px;"><e:forHtml value="${sectionHeading}"/></h4>
+</c:if>
 <div class="drugProfileText" style="">
-    <table class="table table-condensed list-drugs" id="Drug_table">
+    <table class="table table-condensed list-drugs" id="<e:forHtmlAttribute value="${drugTableId}"/>">
       <thead>
         <tr>
         	<th>Entered Date</th>
@@ -507,8 +524,7 @@
 
 <script type="text/javascript">
 
-    drugListTable = jQuery("#Drug_table").dataTable({
-      // cache the datatable state to persist through page refreshes
+    drugListTable = jQuery('#${e:forJavaScript(drugTableId)}').dataTable({
       bStateSave: true,
       fnStateSave: function (oSettings, oData) {
         localStorage.setItem('drugListTable', JSON.stringify(oData));
@@ -516,7 +532,7 @@
       fnStateLoad: function () {
         return JSON.parse(localStorage.getItem('drugListTable'));
       },
-      "searching": true,
+      searching: true,
       // "aLengthMenu": [[25, 50, 75, -1], [25, 50, 75, "All"]],
       // "iDisplayLength": 50,
       columns: [
@@ -561,7 +577,7 @@
 
       // order: [[4, 'desc']]
 
-    })
+    });
 </script>
 <%!
 

--- a/src/main/webapp/oscarRx/ListDrugs.jsp
+++ b/src/main/webapp/oscarRx/ListDrugs.jsp
@@ -109,7 +109,7 @@
     request.setAttribute("drugTableId", tableId);
 %>
 <c:if test="${not empty sectionHeading}">
-    <h4 style="margin-bottom:1px;margin-top:3px;"><e:forHtml value="${sectionHeading}"/></h4>
+    <h4 style="margin-bottom:1px;margin-top:10px;font-size:16px"><e:forHtml value="${sectionHeading}"/></h4>
 </c:if>
 <div class="drugProfileText" style="">
     <table class="table table-condensed list-drugs" id="<e:forHtmlAttribute value="${drugTableId}"/>">

--- a/src/main/webapp/oscarRx/ListDrugs.jsp
+++ b/src/main/webapp/oscarRx/ListDrugs.jsp
@@ -252,29 +252,29 @@
                     isPrevAnnotation = true;
                 }
 
-//                if (request.getParameter("status") != null) { //TODO: Redo this in a better way
-//                    String stat = request.getParameter("status");
-//                    if (stat.equals("active") && !prescriptDrug.isLongTerm() && !prescriptDrug.isCurrent()) {
-//                        continue;
-//                    } else if (stat.equals("inactive") && prescriptDrug.isCurrent()) {
-//                        continue;
-//                    }
-//                }
-//                if (request.getParameter("longTermOnly") != null && request.getParameter("longTermOnly").equals("true")) {
-//                    if (!prescriptDrug.isLongTerm()) {
-//                        continue;
-//                    }
-//                }
-//
-//                if (request.getParameter("longTermOnly") != null && request.getParameter("longTermOnly").equals("acute")) {
-//                    if (prescriptDrug.isLongTerm()) {
-//                        continue;
-//                    }
-//                }
-//                if (request.getParameter("drugLocation") != null && request.getParameter("drugLocation").equals("external")) {
-//                    if (!prescriptDrug.isExternal())
-//                        continue;
-//                }
+                if (request.getParameter("status") != null) { //TODO: Redo this in a better way
+                    String stat = request.getParameter("status");
+                    if (stat.equals("active") && !prescriptDrug.isLongTerm() && !prescriptDrug.isCurrent()) {
+                        continue;
+                    } else if (stat.equals("inactive") && prescriptDrug.isCurrent()) {
+                        continue;
+                    }
+                }
+                if (request.getParameter("longTermOnly") != null && request.getParameter("longTermOnly").equals("true")) {
+                    if (!prescriptDrug.isLongTerm()) {
+                        continue;
+                    }
+                }
+
+                if (request.getParameter("longTermOnly") != null && request.getParameter("longTermOnly").equals("acute")) {
+                    if (prescriptDrug.isLongTerm()) {
+                        continue;
+                    }
+                }
+                if (request.getParameter("drugLocation") != null && request.getParameter("drugLocation").equals("external")) {
+                    if (!prescriptDrug.isExternal())
+                        continue;
+                }
 //add all long term med drugIds to an array.
                 styleColor = getClassColour(prescriptDrug, now, month);
                 String specialText = prescriptDrug.getSpecial();

--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -239,6 +239,91 @@
   <link rel="stylesheet" type="text/css" href="${ctx}/library/jquery/jquery-ui-1.12.1.min.css"/>
   <link href="${pageContext.request.contextPath}/library/DataTables/DataTables-1.13.4/css/jquery.dataTables.css" rel="stylesheet" type="text/css"/>
 
+  <style>
+    /* Drug maintenance (LT) toggle switch — moved here from ListDrugs.jsp so these
+       styles survive rebuildDrugProfile(), which clears #drugProfile on every
+       legend-button click and would otherwise discard ListDrugs.jsp's inline <style>. */
+
+    /* Container */
+    .drug-maintenance-switch {
+        top: -2px;
+        position: relative;
+        width: 34px;
+        height: 16px;
+    }
+
+    /* Hide the native checkbox */
+    .drug-maintenance-switch-input {
+        display: none;
+    }
+
+    /* Switch track */
+    .drug-maintenance-switch-label {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background-color: #dfdfdf;
+        cursor: pointer;
+        transition: background-color 0.3s;
+        border-radius: 5%;
+    }
+
+    /* Knob (unchecked) */
+    .drug-maintenance-switch-label::after {
+        text-align: center;
+        content: '';
+        font-size: xx-small;
+        font-stretch: extra-expanded;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        position: absolute;
+        top: 2px;
+        left: 2px;
+        width: 12px;
+        height: 12px;
+        background-color: #FFFFFFAF;
+        border-radius: 50%;
+        transition: transform 0.3s, content 0.3s, width 0.3s, height 0.3s, border-radius 0.3s;
+        box-shadow: 0 1px 6px rgba(0, 0, 0, 0.4);
+    }
+
+    /* Knob (checked → shows "LT") */
+    .drug-maintenance-switch-input:checked + .drug-maintenance-switch-label::after {
+        content: 'LT';
+        transform: translateX(14px);
+        border-radius: 5%;
+        width: 16px;
+        height: 12px;
+        color: white;
+        background-color: #1e7e34AF;
+    }
+
+    /* Disabled track */
+    .drug-maintenance-switch-input:disabled + .drug-maintenance-switch-label {
+        background-color: #e0e0e0;
+        cursor: not-allowed;
+    }
+
+    /* Disabled knob (checked) */
+    .drug-maintenance-switch-input:disabled:checked + .drug-maintenance-switch-label::after {
+        background-color: #1e7e349F;
+        transform: translateX(14px);
+        content: 'LT';
+        width: 16px;
+        height: 12px;
+        border-radius: 5%;
+    }
+
+    /* Prescription name column — allow wrapping */
+    .list-drugs td:nth-child(5) {
+        word-break: break-word;
+        white-space: normal;
+    }
+  </style>
+
   <script type="text/javascript" src="${ctx}/js/global.js"></script>
   <script type="text/javascript" src="<c:out value="${ctx}/share/javascript/prototype.js"/>"></script>
   <script type="text/javascript" src="<c:out value="${ctx}/share/javascript/screen.js"/>"></script>
@@ -673,7 +758,7 @@
     let Lst;
 
     function CngClass(obj) {
-      document.getElementById("selected_default").removeAttribute("style");
+      document.getElementById("selected_default").className = '';
       if (Lst) Lst.className = '';
       obj.className = 'selected';
       Lst = obj;
@@ -911,6 +996,13 @@
     .link-default-selected {
       color: #000000;
       text-decoration: none;
+      font-weight: bold;
+    }
+
+    .selected {
+      color: #000000;
+      text-decoration: none;
+      font-weight: bold;
     }
 
     .link-no-decoration {
@@ -1235,7 +1327,7 @@
                     <%if (show_current) {%>
                     <td>
                       <a href="javascript:void(0);"
-                         onclick="callReplacementWebService('ListDrugs.jsp','drugProfile');CngClass(this);"
+                         onclick="filterDrugView('current');CngClass(this);"
                          id="selected_default" class="link-default-selected"
                          TITLE="<fmt:setBundle basename="oscarResources"/><fmt:message key='SearchDrug.msgShowCurrentDesc'/>">
                         <fmt:setBundle basename="oscarResources"/><fmt:message key="SearchDrug.msgShowCurrent"/>
@@ -1247,7 +1339,7 @@
                     %>
                     <td>
                       <a href="javascript:void(0);"
-                         onclick="callReplacementWebService('ListDrugs.jsp?show=all','drugProfile');CngClass(this);"
+                         onclick="filterDrugView('all');CngClass(this);"
                          Title="<fmt:setBundle basename="oscarResources"/><fmt:message key='SearchDrug.msgShowAllDesc'/>">
                         <fmt:setBundle basename="oscarResources"/><fmt:message key="SearchDrug.msgShowAll"/>
                       </a>
@@ -1258,7 +1350,7 @@
                     %>
                     <td>
                       <a href="javascript:void(0);"
-                         onclick="callReplacementWebService('ListDrugs.jsp?status=active','drugProfile');CngClass(this);"
+                         onclick="filterDrugView('active');CngClass(this);"
                          TITLE="<fmt:setBundle basename="oscarResources"/><fmt:message key='SearchDrug.msgActiveDesc'/>">
                         <fmt:setBundle basename="oscarResources"/><fmt:message key="SearchDrug.msgActive"/>
                       </a>
@@ -1269,7 +1361,7 @@
                     %>
                     <td>
                       <a href="javascript:void(0);"
-                         onclick="callReplacementWebService('ListDrugs.jsp?status=inactive','drugProfile');CngClass(this);"
+                         onclick="filterDrugView('inactive');CngClass(this);"
                          TITLE="<fmt:setBundle basename="oscarResources"/><fmt:message key='SearchDrug.msgInactiveDesc'/>">
                         <fmt:setBundle basename="oscarResources"/><fmt:message key="SearchDrug.msgInactive"/>
                       </a>
@@ -1282,7 +1374,7 @@
                     %>
                     <td>
                       <a href="javascript:void(0);"
-                         onclick="callReplacementWebService('ListDrugs.jsp?longTermOnly=true&heading=Long Term Meds','drugProfile'); callAdditionWebService('ListDrugs.jsp?longTermOnly=acute&heading=Acute','drugProfile');CngClass(this);"
+                         onclick="showLongTermAcuteView();CngClass(this);"
                          TITLE="<fmt:setBundle basename='oscarResources'/><fmt:message key='SearchDrug.msgLongTermAcuteDesc'/>">
                         <fmt:setBundle basename="oscarResources"/><fmt:message key="SearchDrug.msgLongTermAcute"/>
                       </a>
@@ -1293,7 +1385,7 @@
                     %>
                     <td>
                       <a href="javascript:void(0);"
-                         onclick="callReplacementWebService('ListDrugs.jsp?longTermOnly=true&heading=Long Term Meds','drugProfile'); callAdditionWebService('ListDrugs.jsp?longTermOnly=acute&heading=Acute&status=active','drugProfile');callAdditionWebService('ListDrugs.jsp?longTermOnly=acute&heading=Inactive&status=inactive','drugProfile');callAdditionWebService('ListDrugs.jsp?heading=External&drugLocation=external','drugProfile');CngClass(this);"
+                         onclick="showFullProfileView();CngClass(this);"
                          TITLE="<fmt:setBundle basename='oscarResources'/><fmt:message key='SearchDrug.msgLongTermAcuteInactiveExternalDesc'/>">
                         <fmt:setBundle basename="oscarResources"/><fmt:message
                         key="SearchDrug.msgLongTermAcuteInactiveExternal"/>
@@ -2288,7 +2380,29 @@
           // .html() replaces the container content and evaluates inline scripts,
           // which triggers the DataTable init for the first section's table.
           jQuery('#' + id).html(responseText);
-          
+
+          // Re-cache whenever the drug list is refreshed (initial load, re-rx, changeLt).
+          // After caching, re-apply the active legend view so the display is consistent:
+          //   - Initial load: activeViewMode='current' → shows only non-archived rows even
+          //     though the server now always returns all drugs including archived.
+          //   - changeLt / save-Rx: re-applies whatever view the user had selected.
+          if (id === 'drugProfile') {
+              // DataTables pagination removes off-page rows from the live DOM.
+              // jQuery('#Drug_table tbody tr') would therefore only return the
+              // current page's rows (default: 10), silently truncating the cache.
+              // fnGetNodes() returns ALL row nodes from DataTables' internal store,
+              // including detached off-page ones, giving us the full dataset.
+              const dtInstance = jQuery('#Drug_table').dataTable();
+              allDrugRows = jQuery(dtInstance.fnGetNodes()).clone(true, true);
+              drugTableHeadHtml = jQuery('#Drug_table thead').html();
+              drugTableClasses = jQuery('#Drug_table').attr('class');
+              if (activeSectionDefs) {
+                  showSections(activeSectionDefs);
+              } else {
+                  filterDrugView(activeViewMode);
+              }
+          }
+
           // Drain the queue — any addition calls that arrived while the replacement
           // was in flight now execute in order.
           let queue = drugProfileAdditionQueue[id] || [];
@@ -2301,7 +2415,117 @@
         });
   }
 
-  callReplacementWebService("ListDrugs.jsp", 'drugProfile');
+  // ---------------------------------------------------------------------------
+  //  Client-side drug profile filtering
+  //
+  //  On every drug-list load (page open, re-rx, changeLt), all rows are fetched
+  //  once and stored in allDrugRows. Legend buttons then filter that cache
+  //  client-side — no extra server round-trips required.
+  //
+  //  activeViewMode / activeSectionDefs track which legend view is currently
+  //  active so that non-legend refreshes (changeLt, save-Rx) can re-apply the
+  //  same view automatically after the new data is cached.
+  // ---------------------------------------------------------------------------
+
+  // Row cache — populated after every drug-list load via callReplacementWebService.
+  let allDrugRows = null;       // cloned jQuery set of all <tr> from the full server response
+  let drugTableHeadHtml = null; // cached <thead> innerHTML, reused when building each section table
+  let drugTableClasses = null;  // class string copied from #Drug_table to each rebuilt table
+
+  // Exactly one of these is non-null at any time, depending on which legend button is active.
+  let activeViewMode = 'current'; // argument for filterDrugView  (single-table views)
+  let activeSectionDefs = null;   // argument for showSections     (multi-section views)
+
+  // Row predicate helpers — centralise the data-* attribute checks so filter
+  // functions below don't repeat the same string comparisons everywhere.
+  const rowIsArchived = r => r.dataset.isArchived === 'true';
+  const rowIsLongTerm = r => r.dataset.isLongterm === 'true';
+  const rowIsCurrent = r => r.dataset.isCurrent === 'true';
+  const rowIsExternal = r => r.dataset.isExternal === 'true';
+
+  // Tear down every DataTable inside #drugProfile, wipe the container, then
+  // render each section: an optional heading, a cloned table, and a new DataTable.
+  function rebuildDrugProfile(sections) {
+      jQuery('#drugProfile table').each(function () {
+          if (jQuery.fn.dataTable && jQuery.fn.dataTable.isDataTable(this)) {
+              jQuery(this).dataTable().fnDestroy();
+          }
+      });
+      jQuery('#drugProfile').empty();
+
+      sections.forEach(section => {
+          const tableId = section.label
+              ? 'Drug_table' + section.label.replace(/\s+/g, '')
+              : 'Drug_table';
+
+          if (section.label) {
+              jQuery('#drugProfile').append(
+                  jQuery('<h4 style="margin-bottom:1px;margin-top:3px;"></h4>').text(section.label)
+              );
+          }
+
+          const $tbody = jQuery('<tbody></tbody>');
+          section.rows.each(function () {
+              $tbody.append(jQuery(this).clone(true, true));
+          });
+
+          jQuery('<table></table>')
+              .attr({ id: tableId, class: drugTableClasses })
+              .append(jQuery('<thead></thead>').html(drugTableHeadHtml), $tbody)
+              .appendTo('#drugProfile')
+              .dataTable(window.drugListTableConfig);
+      });
+  }
+
+  // Show a single table containing only the rows that match the given mode.
+  function filterDrugView(mode) {
+      if (!allDrugRows) { return; }
+      activeViewMode = mode;
+      activeSectionDefs = null;
+      const filtered = allDrugRows.filter(function () {
+          switch (mode) {
+              case 'current':  return !rowIsArchived(this);
+              case 'all':      return true;
+              case 'active':   return !rowIsArchived(this) && (rowIsLongTerm(this) || rowIsCurrent(this));
+              case 'inactive': return !rowIsArchived(this) && !rowIsCurrent(this);
+              default:         return true;
+          }
+      });
+      rebuildDrugProfile([{ label: null, rows: filtered }]);
+  }
+
+  // Show multiple labelled sections, each filtered by its own predicate.
+  // Called by showLongTermAcuteView() and showFullProfileView() below.
+  function showSections(sectionDefs) {
+      if (!allDrugRows) { return; }
+      activeSectionDefs = sectionDefs;
+      activeViewMode = null;
+      const sections = sectionDefs.map(def => ({
+          label: def.label,
+          rows: allDrugRows.filter(function () { return def.filterFn(this); })
+      }));
+      rebuildDrugProfile(sections);
+  }
+
+  // Named entry points for the two multi-section legend buttons — keeps onclick
+  // attributes readable and avoids repeating filter logic inline in the HTML.
+  function showLongTermAcuteView() {
+      showSections([
+          { label: 'Long Term Meds', filterFn: r => !rowIsArchived(r) && rowIsLongTerm(r) },
+          { label: 'Acute', filterFn: r => !rowIsArchived(r) && !rowIsLongTerm(r) }
+      ]);
+  }
+
+  function showFullProfileView() {
+      showSections([
+          { label: 'Long Term Meds', filterFn: r => !rowIsArchived(r) && rowIsLongTerm(r) },
+          { label: 'Acute', filterFn: r => !rowIsArchived(r) && !rowIsLongTerm(r) && rowIsCurrent(r) },
+          { label: 'Inactive', filterFn: r => !rowIsArchived(r) && !rowIsLongTerm(r) && !rowIsCurrent(r) },
+          { label: 'External', filterFn: r => !rowIsArchived(r) && rowIsExternal(r) }
+      ]);
+  }
+
+  callReplacementWebService("ListDrugs.jsp?show=all", 'drugProfile');
 
   function searchResultsHandler(type, args) {
     let url = ctx + "/oscarRx/WriteScript.do";

--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -1217,6 +1217,99 @@
     <table>
       <tr>
         <td>
+          <table class="legend">
+            <tr>
+              <td class="legend-change-view">
+                <a href="#"
+                   title="<fmt:setBundle basename="oscarResources"/><fmt:message key='provider.rxChangeProfileViewMessage'/>"
+                   onclick="popupPage(230,860,'../setProviderStaleDate.do?method=viewRxProfileView');"
+                   class="link-red-no-decoration">
+                  <fmt:message key="provider.rxChangeProfileView"/>
+                </a>
+              </td>
+
+              <td>
+
+                <table class="legend_items" align="left">
+                  <tr>
+                    <%if (show_current) {%>
+                    <td>
+                      <a href="javascript:void(0);"
+                         onclick="callReplacementWebService('ListDrugs.jsp','drugProfile');CngClass(this);"
+                         id="selected_default" class="link-default-selected"
+                         TITLE="<fmt:setBundle basename="oscarResources"/><fmt:message key='SearchDrug.msgShowCurrentDesc'/>">
+                        <fmt:setBundle basename="oscarResources"/><fmt:message key="SearchDrug.msgShowCurrent"/>
+                      </a>
+                    </td>
+                    <%
+                      }
+                      if (show_all) {
+                    %>
+                    <td>
+                      <a href="javascript:void(0);"
+                         onclick="callReplacementWebService('ListDrugs.jsp?show=all','drugProfile');CngClass(this);"
+                         Title="<fmt:setBundle basename="oscarResources"/><fmt:message key='SearchDrug.msgShowAllDesc'/>">
+                        <fmt:setBundle basename="oscarResources"/><fmt:message key="SearchDrug.msgShowAll"/>
+                      </a>
+                    </td>
+                    <%
+                      }
+                      if (active) {
+                    %>
+                    <td>
+                      <a href="javascript:void(0);"
+                         onclick="callReplacementWebService('ListDrugs.jsp?status=active','drugProfile');CngClass(this);"
+                         TITLE="<fmt:setBundle basename="oscarResources"/><fmt:message key='SearchDrug.msgActiveDesc'/>">
+                        <fmt:setBundle basename="oscarResources"/><fmt:message key="SearchDrug.msgActive"/>
+                      </a>
+                    </td>
+                    <%
+                      }
+                      if (inactive) {
+                    %>
+                    <td>
+                      <a href="javascript:void(0);"
+                         onclick="callReplacementWebService('ListDrugs.jsp?status=inactive','drugProfile');CngClass(this);"
+                         TITLE="<fmt:setBundle basename="oscarResources"/><fmt:message key='SearchDrug.msgInactiveDesc'/>">
+                        <fmt:setBundle basename="oscarResources"/><fmt:message key="SearchDrug.msgInactive"/>
+                      </a>
+                    </td>
+                    <%
+                      }
+                      if (!OscarProperties.getInstance().getProperty("rx.profile_legend.hide", "false").equals("true")) {
+
+                        if (longterm_acute) {
+                    %>
+                    <td>
+                      <a href="javascript:void(0);"
+                         onclick="callReplacementWebService('ListDrugs.jsp?longTermOnly=true&heading=Long Term Meds','drugProfile'); callAdditionWebService('ListDrugs.jsp?longTermOnly=acute&heading=Acute','drugProfile');CngClass(this);"
+                         TITLE="<fmt:setBundle basename='oscarResources'/><fmt:message key='SearchDrug.msgLongTermAcuteDesc'/>">
+                        <fmt:setBundle basename="oscarResources"/><fmt:message key="SearchDrug.msgLongTermAcute"/>
+                      </a>
+                    </td>
+                    <%
+                      }
+                      if (longterm_acute_inactive_external) {
+                    %>
+                    <td>
+                      <a href="javascript:void(0);"
+                         onclick="callReplacementWebService('ListDrugs.jsp?longTermOnly=true&heading=Long Term Meds','drugProfile'); callAdditionWebService('ListDrugs.jsp?longTermOnly=acute&heading=Acute&status=active','drugProfile');callAdditionWebService('ListDrugs.jsp?longTermOnly=acute&heading=Inactive&status=inactive','drugProfile');callAdditionWebService('ListDrugs.jsp?heading=External&drugLocation=external','drugProfile');CngClass(this);"
+                         TITLE="<fmt:setBundle basename='oscarResources'/><fmt:message key='SearchDrug.msgLongTermAcuteInactiveExternalDesc'/>">
+                        <fmt:setBundle basename="oscarResources"/><fmt:message
+                        key="SearchDrug.msgLongTermAcuteInactiveExternal"/>
+                      </a>
+                    </td>
+                    <%
+                        }
+                      }
+                    %>
+                  </tr>
+                </table>
+
+              </td>
+
+            </tr>
+          </table>
           <div id="drugProfile"></div>
 
           <div id="themeLegend">

--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -2463,7 +2463,7 @@
 
           if (section.label) {
               jQuery('#drugProfile').append(
-                  jQuery('<h4 style="margin-bottom:1px;margin-top:3px;"></h4>').text(section.label)
+                  jQuery('<h4 style="margin-bottom:1px;margin-top:10px;font-size:16px;"></h4>').text(section.label)
               );
           }
 

--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -2222,35 +2222,83 @@
       $('treatmentsMyD').toggle();
   }
 
+  //  Drug profile legend view-switching
+  //
+  // Clicking a legend button (Current, All, Active, Long Term / Acute, etc.)
+  // loads ListDrugs.jsp into #drugProfile. Some views consist of a single table
+  // (callReplacementWebService), while multi-section views like "Long Term / Acute"
+  // fire one replacement call followed by one or more addition calls that each
+  // append a labelled section below the first.
+  //
+  // Problem: both calls are fired at the same time. The addition call is a GET and
+  // often resolves first, appending its section to #drugProfile. The replacement
+  // call then arrives and calls .html(), which wipes #drugProfile — removing the
+  // already-appended section. To prevent this, addition calls are queued until the
+  // replacement response has been written to the DOM.
+  //
+  // drugProfileAdditionQueue is keyed by target element id (e.g. 'drugProfile').
+  // It holds an array of pending addition functions while a replacement is in
+  // flight, and is set back to null once the replacement is complete.
+  let drugProfileAdditionQueue = {};
+
+  // Public entry point for addition calls (appends a section to an existing view).
+  // If a replacement is still in flight for the same target, the call is queued
+  // and will be executed automatically once the replacement finishes.
   function callAdditionWebService(url, id) {
-      let ran_number = generateSecureRandomId();
-      let params = "demographicNo=<%=demoNo%>&rand=" + ran_number;
-      let updater = new Ajax.Updater(id, url, {
-        method: 'get',
-        parameters: params,
-        insertion: Insertion.Bottom,
-        evalScripts: true,
-        onFailure: function (transport) {
-          console.error('Addition web service call failed with status: ' + (transport.status || 'unknown'));
-        }
-      });
+      let contextPath = ctx;
+      if (url.indexOf(contextPath) !== 0) {
+        url = contextPath + "/oscarRx/" + url;
+      }
+      if (drugProfileAdditionQueue[id]) {
+        let capturedUrl = url;
+        drugProfileAdditionQueue[id].push(function () { doAdditionWebService(capturedUrl, id); });
+        return;
+      }
+      doAdditionWebService(url, id);
   }
 
+  // Fetches a ListDrugs.jsp section and appends it to the target container.
+  // Each response contains an <h4> heading and a <table> with its own DataTable
+  // init script. jQuery.append() evaluates those inline scripts automatically,
+  // so each appended section initialises its own independent DataTable instance.
+  function doAdditionWebService(url, id) {
+      let ran_number = generateSecureRandomId();
+      jQuery.get(url, { demographicNo: '<%=demoNo%>', rand: ran_number })
+        .done(function (responseText) {
+          jQuery('#' + id).append(responseText);
+        })
+        .fail(function (xhr) {
+          console.error('Addition web service call failed with status: ' + (xhr.status || 'unknown'));
+        });
+  }
+
+  // Replaces the entire content of the target container with a fresh ListDrugs.jsp
+  // response. Opens drugProfileAdditionQueue before firing so that any concurrent
+  // addition calls wait for this response to land before appending their sections.
   function callReplacementWebService(url, id) {
       let contextPath = ctx;
       if (url.indexOf(contextPath) !== 0) {
         url = contextPath + "/oscarRx/" + url;
       }
+      drugProfileAdditionQueue[id] = [];
       let ran_number = generateSecureRandomId();
-      let params = "demographicNo=<%=demoNo%>&rand=" + ran_number;
-      let updater = new Ajax.Updater(id, url, {
-        method: 'POST',
-        parameters: params,
-        evalScripts: true,
-        onFailure: function (transport) {
-          console.error('Replacement web service call failed with status: ' + (transport.status || 'unknown'));
-        }
-      });
+      jQuery.post(url, { demographicNo: '<%=demoNo%>', rand: ran_number })
+        .done(function (responseText) {
+          
+          // .html() replaces the container content and evaluates inline scripts,
+          // which triggers the DataTable init for the first section's table.
+          jQuery('#' + id).html(responseText);
+          
+          // Drain the queue — any addition calls that arrived while the replacement
+          // was in flight now execute in order.
+          let queue = drugProfileAdditionQueue[id] || [];
+          drugProfileAdditionQueue[id] = null;
+          queue.forEach(function (fn) { fn(); });
+        })
+        .fail(function (xhr) {
+          drugProfileAdditionQueue[id] = null;
+          console.error('Replacement web service call failed with status: ' + (xhr.status || 'unknown'));
+        });
   }
 
   callReplacementWebService("ListDrugs.jsp", 'drugProfile');

--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -758,7 +758,8 @@
     let Lst;
 
     function CngClass(obj) {
-      document.getElementById("selected_default").className = '';
+      const defaultEl = document.getElementById("selected_default");
+      if (defaultEl) defaultEl.className = '';
       if (Lst) Lst.className = '';
       obj.className = 'selected';
       Lst = obj;

--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -2455,6 +2455,8 @@
       jQuery('#drugProfile').empty();
 
       sections.forEach(section => {
+          if (section.label && section.rows.length === 0) { return; }
+
           const tableId = section.label
               ? 'Drug_table' + section.label.replace(/\s+/g, '')
               : 'Drug_table';


### PR DESCRIPTION
## Summary

- Restores the drug profile view legend in `SearchDrug3.jsp` that was removed in [edac1715d550de8062d066badc82eab62d833908](https://github.com/openo-beta/Open-O/commit/edac1715d550de8062d066badc82eab62d833908) 
- Converts filtering from server-side (one AJAX request per legend click) to client-side: all drugs are fetched once on load and filtered in JS on each tab click - no extra round-trips
- Tracks the active view so non-legend refreshes (changeLt, re-rx) re-apply the correct filter automatically after recaching
- Fixes legend selected-state highlight so the active tab turns black and deselects the previous one

<img width="996" height="581" alt="image" src="https://github.com/user-attachments/assets/8215f2f2-2f02-451a-82a7-98b4b8c0a656" />

