### PR TITLE
Fix: repeated error message new and edit tickler pages, error messages shown without styling

### DIFF
--- a/src/main/resources/oscarResources_en.properties
+++ b/src/main/resources/oscarResources_en.properties
@@ -5241,6 +5241,7 @@ tickler.ticklerAdd.formReminder=Reminder Message
 tickler.ticklerAdd.btnCancel=Exit
 tickler.ticklerAdd.btnSubmit=Save
 tickler.ticklerAdd.assignTaskTo=Assign Task To
+tickler.ticklerAdd.msgNoProviderAssigned=Must assign task to a provider.
 tickler.ticklerAdd.msgNoProgramSelected=Program Selected
 
 tickler.ticklerDemoMain.title=Tickler

--- a/src/main/resources/oscarResources_es.properties
+++ b/src/main/resources/oscarResources_es.properties
@@ -4217,6 +4217,7 @@ tickler.ticklerTextSuggest.cancel=Cancel
 tickler.ticklerAdd.title=Recordatorios
 tickler.ticklerAdd.msgInvalidDemographic=Informacion del paciente invalida, por favor controle los datos!
 tickler.ticklerAdd.msgMissingDate=Fecha de prestacion incompleta, por favor completarla!
+tickler.ticklerAdd.msgNoProviderAssigned=Debe asignar la tarea a un proveedor.
 tickler.ticklerAdd.msgTickler=oscar<font size="3">Recordatorio</font>
 tickler.ticklerAdd.formDemoName=Nombre paciente
 tickler.ticklerAdd.btnSearch=Buscar

--- a/src/main/resources/oscarResources_fr.properties
+++ b/src/main/resources/oscarResources_fr.properties
@@ -3721,6 +3721,7 @@ tickler.ticklerMain.msgSaveView=Sauver Voir
 tickler.ticklerAdd.title=oscarTickler
 tickler.ticklerAdd.msgInvalidDemographic=Information d\u00e9mographique non valide, veuillez v\u00e9rifier\!
 tickler.ticklerAdd.msgMissingDate=Date du service manquante, veuillez v\u00e9rifier\!
+tickler.ticklerAdd.msgNoProviderAssigned=Vous devez assigner la t\u00e2che \u00e0 un prestataire.
 tickler.ticklerAdd.msgTickler=oscar<font size\="3">Tickler</font>
 tickler.ticklerAdd.formDemoName=Nom du patient
 tickler.ticklerAdd.btnSearch=Recherche

--- a/src/main/resources/oscarResources_pl.properties
+++ b/src/main/resources/oscarResources_pl.properties
@@ -3686,6 +3686,7 @@ tickler.ticklerMain.msgSaveView=Zapisz Zobacz
 tickler.ticklerAdd.title=Tickler
 tickler.ticklerAdd.msgInvalidDemographic=Nieprawid&#X142;owe dane demograficzne, sprawd&#X17a;!
 tickler.ticklerAdd.msgMissingDate Brak daty=us&#X142;ug, sprawd&#X17a;!
+tickler.ticklerAdd.msgNoProviderAssigned=Trzeba przypisa\u0107 zadanie do \u015bwiadczeniodawcy.
 tickler.ticklerAdd.msgTickler=<font size="3"> Tickler </ font>
 tickler.ticklerAdd.formDemoName=demograficzne Nazwa
 tickler.ticklerAdd.btnSearch=Szukaj

--- a/src/main/resources/oscarResources_pl.properties
+++ b/src/main/resources/oscarResources_pl.properties
@@ -3685,7 +3685,7 @@ tickler.ticklerMain.msgSaveView=Zapisz Zobacz
 
 tickler.ticklerAdd.title=Tickler
 tickler.ticklerAdd.msgInvalidDemographic=Nieprawid&#X142;owe dane demograficzne, sprawd&#X17a;!
-tickler.ticklerAdd.msgMissingDate Brak daty=us&#X142;ug, sprawd&#X17a;!
+tickler.ticklerAdd.msgMissingDate=Brak daty us&#X142;ug, sprawd&#X17a;!
 tickler.ticklerAdd.msgNoProviderAssigned=Trzeba przypisa\u0107 zadanie do \u015bwiadczeniodawcy.
 tickler.ticklerAdd.msgTickler=<font size="3"> Tickler </ font>
 tickler.ticklerAdd.formDemoName=demograficzne Nazwa

--- a/src/main/resources/oscarResources_pt_BR.properties
+++ b/src/main/resources/oscarResources_pt_BR.properties
@@ -5043,6 +5043,7 @@ tickler.ticklerTextSuggest.cancel=Cancelar
 tickler.ticklerAdd.title=Queixa
 tickler.ticklerAdd.msgInvalidDemographic=Informa\u00E7\u00F5es demogr\u00E1ficas inv\u00E1lidas, verifique!
 tickler.ticklerAdd.msgMissingDate=Data de servi\u00E7o ausente, verifique!
+tickler.ticklerAdd.msgNoProviderAssigned=\u00c9 necess\u00e1rio atribuir a tarefa a um prestador.
 tickler.ticklerAdd.msgTickler=<font size="3">Tickler</font>
 tickler.ticklerAdd.formDemoName=Nome demogr\u00E1fico
 tickler.ticklerAdd.btnSearch=Pesquisa

--- a/src/main/webapp/tickler/ticklerAdd.jsp
+++ b/src/main/webapp/tickler/ticklerAdd.jsp
@@ -418,20 +418,21 @@
         }
 
         function validateDemoNo() {
+            var errorDiv = document.getElementById("error");
             if (document.serviceform.demographic_no.value === "") {
-                document.getElementById("error").insertAdjacentText("beforeend", '<fmt:setBundle basename="oscarResources"/><fmt:message key="tickler.ticklerAdd.msgInvalidDemographic"/>');
-                document.getElementById("error").style.display = 'block';
+                errorDiv.textContent = '<fmt:setBundle basename="oscarResources"/><fmt:message key="tickler.ticklerAdd.msgInvalidDemographic"/>';
+                errorDiv.style.display = 'block';
                 return false;
             } else {
                 if (document.serviceform.xml_appointment_date.value === "" || !IsDate(document.serviceform.xml_appointment_date.value)) {
-                    document.getElementById("error").insertAdjacentText("beforeend", '<fmt:setBundle basename="oscarResources"/><fmt:message key="tickler.ticklerAdd.msgMissingDate"/>');
-                    document.getElementById("error").style.display = 'block';
+                    errorDiv.textContent = '<fmt:setBundle basename="oscarResources"/><fmt:message key="tickler.ticklerAdd.msgMissingDate"/>';
+                    errorDiv.style.display = 'block';
                     return false;
                 }
                 <% if (ca.openosp.openo.commn.IsPropertiesOn.isMultisitesEnable()) { %>
                 else if (document.serviceform.site.value === "none" || document.serviceform.site.value === "0") {
-                    document.getElementById("error").insertAdjacentText("beforeend", "Must assign task to a provider.");
-                    document.getElementById("error").style.display = 'block';
+                    errorDiv.textContent = "Must assign task to a provider.";
+                    errorDiv.style.display = 'block';
                     return false;
                 }
                 <% } %>
@@ -505,7 +506,7 @@
       <fmt:message key="tickler.ticklerAdd.title"/>
     </h2>
 
-  <div id="error" class="alert alert-error" style="display:none;"></div>
+  <div id="error" class="alert alert-danger" style="display:none;"></div>
         <%
             String searchMode = request.getParameter("search_mode");
             if (searchMode == null || searchMode.isEmpty()) {

--- a/src/main/webapp/tickler/ticklerAdd.jsp
+++ b/src/main/webapp/tickler/ticklerAdd.jsp
@@ -418,7 +418,7 @@
         }
 
         function validateDemoNo() {
-            var errorDiv = document.getElementById("error");
+            let errorDiv = document.getElementById("error");
             if (document.serviceform.demographic_no.value === "") {
                 errorDiv.textContent = '<fmt:setBundle basename="oscarResources"/><fmt:message key="tickler.ticklerAdd.msgInvalidDemographic"/>';
                 errorDiv.style.display = 'block';
@@ -431,7 +431,7 @@
                 }
                 <% if (ca.openosp.openo.commn.IsPropertiesOn.isMultisitesEnable()) { %>
                 else if (document.serviceform.site.value === "none" || document.serviceform.site.value === "0") {
-                    errorDiv.textContent = "Must assign task to a provider.";
+                    errorDiv.textContent = '<fmt:message key="tickler.ticklerAdd.msgNoProviderAssigned"/>';
                     errorDiv.style.display = 'block';
                     return false;
                 }

--- a/src/main/webapp/tickler/ticklerEdit.jsp
+++ b/src/main/webapp/tickler/ticklerEdit.jsp
@@ -276,9 +276,10 @@
             }
 
             function validateDate(form) {
+                let errorDiv = document.getElementById("error");
                 if (form.xml_appointment_date.value === "" || !IsDate(form.xml_appointment_date.value)) {
-                    document.getElementById("error").textContent = "<fmt:message key="tickler.ticklerAdd.msgMissingDate"/>";
-                    document.getElementById("error").style.display = 'block';
+                    errorDiv.textContent = "<fmt:message key="tickler.ticklerAdd.msgMissingDate"/>";
+                    errorDiv.style.display = 'block';
                     return false;
                 } else {
                     return true;

--- a/src/main/webapp/tickler/ticklerEdit.jsp
+++ b/src/main/webapp/tickler/ticklerEdit.jsp
@@ -277,7 +277,7 @@
 
             function validateDate(form) {
                 if (form.xml_appointment_date.value === "" || !IsDate(form.xml_appointment_date.value)) {
-                    document.getElementById("error").insertAdjacentText("beforeend", "<fmt:message key="tickler.ticklerAdd.msgMissingDate"/>");
+                    document.getElementById("error").textContent = "<fmt:message key="tickler.ticklerAdd.msgMissingDate"/>";
                     document.getElementById("error").style.display = 'block';
                     return false;
                 } else {
@@ -308,7 +308,7 @@
               </svg>
               <fmt:message key="tickler.ticklerEdit.title"/>
             </h2>
-            <div id="error" class="alert alert-error" style="display:none;"></div>
+            <div id="error" class="alert alert-danger" style="display:none;"></div>
 
             <table class="table table-condensed">
 


### PR DESCRIPTION
## Summary                                                                                                                                             
                                                                                                                                                      
Fix validation error display on the New Tickler and Edit Tickler pages so that error messages appear once with proper error styling.     

<img width="966" height="152" alt="image" src="https://github.com/user-attachments/assets/a685c4d3-d3e0-44fc-81fc-bd328a5c9cba" />

<img width="1131" height="105" alt="image" src="https://github.com/user-attachments/assets/3ba0f968-d4f2-40ef-87ce-2a4dcc332c31" />

Fixes #2395            
                                                                                                                                                      
## Problem
                                                                                                                                                      
On the New Tickler page (ticklerAdd.jsp) and Edit Tickler page (ticklerEdit.jsp), clicking "Save" repeatedly without filling required fields causes the error message to duplicate on every click. Additionally, the error message has no visible error styling (no red text/background) because the CSS class alert-error is a Bootstrap 2 class that has no effect under the Bootstrap 3 stylesheet these pages load.                                     
                  
Both issues have existed since the validation was introduced in June 2022 (3faa376d). The styling issue became visible when Bootstrap 3 was added to ticklerAdd.jsp in March 2023 and ticklerEdit.jsp in September 2023.

> Note: the issue with ticklerEdit.jsp was found while investigating the connected issue ticket, the fix was included here since its the exact same issue, just on another jsp page
                                                                                                                                                      
## Solution        

  - Replace insertAdjacentText("beforeend", ...) with textContent = ... so error messages replace rather than append — the validation logic is sequential (early-return on first failure), so only one error can be shown at a time
  - Replace alert-error with alert-danger to use the correct Bootstrap 3 class for red error styling                                                  
                                                                                                                                                     

## Manual testing steps
1. Login to the EMR
2. Click on the "Tickler" option in the top bar
3. Click on the "New Tickler" option near the bottom of the page
4. Without editing the new tickler entry, click "Save" multiple times
3. **If testing the branches behaviour:** Observe that near the top of the screen, an error message appears with error styling, and is only displaying the error text once
4. **If testing the develop behaviour:** Observe that near the top of the screen, an error message appears without any styling, and is duplicated multiple times
5. Next, go back to the main tickler manager page
6. Click on a created tickler entry for editing (edit pencil icon)
7. Scroll down on the page and remove the auto populated date values
8. Click "Update" multiple times
9. **If testing the branches behaviour:** Observe that near the top of the screen, an error message appears with error styling, and is only displaying the error text once
10. **If testing the develop behaviour:** Observe that near the top of the screen, an error message appears without any styling, and is duplicated multiple times

## Summary by Sourcery

Fix validation error handling and styling on New Tickler and Edit Tickler pages.

Bug Fixes:
- Ensure validation errors on New Tickler and Edit Tickler pages replace previous messages instead of duplicating on repeated submits.
- Apply the correct Bootstrap error alert class so tickler validation messages display with proper error styling.
- Correct the Polish tickler missing-date message key so it loads properly in the UI.

Enhancements:
- Add a localized message for the 'no provider assigned' validation error across supported languages.