### PR TITLE
Fix: "Assign Task To" in new tickler window no longer defaulting to the current user

### DIFF
--- a/src/main/webapp/tickler/ticklerAdd.jsp
+++ b/src/main/webapp/tickler/ticklerAdd.jsp
@@ -170,6 +170,7 @@
 
 
    pageContext.setAttribute("providers", providerDao.getActiveProviders());
+   pageContext.setAttribute("taskTo", taskTo);
 %>
 
 <!DOCTYPE html>
@@ -616,9 +617,8 @@
 
                         <div id="selectWrapper">
                             <select name="task_assigned_to" id="task_assigned_to" class="form-control">
-                              <option value=""></option>
                               <c:forEach items="${ providers }" var="provider">
-                                <option value="${ provider.providerNo }">
+                                <option value="${ provider.providerNo }" ${provider.providerNo == taskTo ? 'selected' : ''}>
                                   <c:out value="${ provider.formattedName }"/>
                                 </option>
                               </c:forEach>


### PR DESCRIPTION
## Summary                                                                                                                                                  
  Fixes the "Assign Task To" field in the New Tickler form to default to the current logged-in user, restoring behavior lost during a prior code cleanup. 

<img width="766" height="98" alt="image" src="https://github.com/user-attachments/assets/b15bb90b-06b6-4291-8399-5ebc8e3d3e53" />
   
  Fixes #2396                                                                                                                                         
  
## Problem
After commit cb930cc (tickler source code cleanup), the provider `<select>` was converted from Java scriptlets to JSTL but two things were lost:      
  1. An empty `<option value="">` was added as the first item, which shouldn't exist since a provider is always required — submitting with this selected caused a 500 error                                                                                                                                 
  2. The selected attribute matching the logged-in user was dropped, so the dropdown defaulted to the empty option instead of the current user

## Solution                                                                                                                                            
  - Exposed the existing taskTo variable (which already correctly computes the default assignee) to JSTL via pageContext.setAttribute                 
  - Removed the empty <option> and added a selected attribute to the option matching taskTo
                                                                                                                                                      
##  Manual testing steps                                                                                                                                                      
  1. Login to the EMR                                                                                                                                 
  2. Click on the "Tickler" option in the top bar
  4. Click "New Tickler"                                                                                                                              
  5. **If testing the branch's behaviour:** Observe the "Assign Task To" dropdown defaults to the logged-in user (e.g. "openodoc")
  6. **If testing develop's behaviour:** Observe the "Assign Task To" dropdown defaults to an empty value                                                 
  7. Select a patient, then click "Save" without changing the "Assign Task To" field                                                                  
  8. **If testing the branch's behaviour:** The tickler saves successfully                                                                                
  9. **If testing develop's behaviour:** A 500 error occurs because the empty assignment fails validation

## Summary by Sourcery

Bug Fixes:
- Prevent New Tickler submissions from using an empty assignee option that caused server errors by removing the blank provider entry and defaulting to the logged-in user.