### PR TITLE
Chore: fix Maven repository resolution order and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ __pycache__/
 .editorconfig
 .claude
 CLAUDE.md
+.classpath
+.factorypath
+.project
 
 # Docusaurus
 /website/node_modules/

--- a/pom.xml
+++ b/pom.xml
@@ -50,15 +50,17 @@
             <url>file://${basedir}/local_repo</url>
         </repository>
 
-        <!-- for the com.github.openosp htmltopdf dependency only. Upgrades
-        from this dependency are welcome -->
-        <repository>
-            <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
-        </repository>
         <repository>
             <id>central</id>
             <url>https://repo.maven.apache.org/maven2</url>
+        </repository>
+
+        <!-- for the com.github.openosp htmltopdf dependency only. Upgrades
+        from this dependency are welcome. Listed last to avoid JitPack intercepting
+        Maven Central artifacts (JitPack is queried for all groupIds, not just com.github.*) -->
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
         </repository>
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,9 +55,10 @@
             <url>https://repo.maven.apache.org/maven2</url>
         </repository>
 
-        <!-- for the com.github.openosp htmltopdf dependency only. Upgrades
-        from this dependency are welcome. Listed last to avoid JitPack intercepting
-        Maven Central artifacts (JitPack is queried for all groupIds, not just com.github.*) -->
+        <!-- Primarily needed for com.github.openosp:ultrabuk-htmltopdf-java.
+        Listed last so Maven Central is queried first — Maven resolves repositories
+        in declaration order and JitPack will be queried for all groupIds, not just
+        com.github.*. Upgrades from this dependency are welcome. -->
         <repository>
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>


### PR DESCRIPTION
## Summary

- Move Maven Central repository above JitPack in pom.xml to fix artifact resolution order                                                          
 - Add Eclipse IDE project files (.classpath, .factorypath, .project) to .gitignore
                                                                                                                                                       
## Problem       
A JAR dependency was returning a 404 during builds. The root cause appears to be JitPack being listed before Maven Central in the repository order, Maven queries repositories in declaration order, so JitPack was intercepting resolution for artifacts it doesn't actually host. This likely resulted in JitPack caching or overwriting the artifact reference with a broken version, causing the 404. Removing the broken JAR and fixing the repository order resolved the issue.

Additionally, Eclipse IDE project files were not in .gitignore, risking accidental commits of developer-specific config. This is apparent even outside of the Eclipse IDE, such as within VSCode, as certain extensions like Microsoft's "Extension Pack for Java" will pull in these files                           
   
## Solution                                                                                                                                                           
Reordered pom.xml repositories so Maven Central is queried first, with JitPack listed last only for the com.github.openosp htmltopdf dependency.   
Added a comment explaining the ordering rationale to prevent future reordering. Added Eclipse project files to .gitignore.

## Summary by Sourcery

Adjust Maven repository ordering and ignore IDE-specific project files to improve build reliability and prevent committing local configuration.

Build:
- Reorder Maven repositories so Maven Central is queried before JitPack and document the rationale for JitPack being listed last.

Chores:
- Add Eclipse/IDE project files to .gitignore to avoid committing developer-specific configuration.