### PR TITLE
Fix: "Reprint" button in Rx module no longer works

### DIFF
--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -249,6 +249,7 @@
   <script type="text/javascript" src="<c:out value="${ctx}/share/javascript/Oscar.js"/>"></script>
   <script type="text/javascript" src="<c:out value="${ctx}/share/javascript/dragiframe.js"/>"></script>
   <script type="text/javascript" src="<c:out value="${ctx}/js/checkDate.js"/>"></script>
+  <script src="${pageContext.request.contextPath}/csrfguard"></script>
 
   <link rel="stylesheet" type="text/css" href="<c:out value="${ctx}/share/yui/css/autocomplete.css"/>">
   <script type="text/javascript" src="<c:out value="${ctx}/share/yui/js/yahoo-dom-event.js"/>"></script>
@@ -891,7 +892,6 @@
       height: 150px;
       overflow: auto;
       border: thin solid #DCDCDC;
-      display: none;
     }
 
     .text-indent-5 {
@@ -1141,7 +1141,7 @@
                         basename="oscarResources"/><fmt:message key="SearchDrug.Print"/></a>
 
                       <%if (securityManager.hasWriteAccess("_rx", roleName2$, true)) {%>
-                      <a href="javascript:void(0);"  class="btn btn-link"  onclick="$('reprint').toggle();return false;"><fmt:setBundle
+                      <a href="javascript:void(0);"  class="btn btn-link"  onclick="document.getElementById('reprint').toggleAttribute('hidden');return false;"><fmt:setBundle
                         basename="oscarResources"/><fmt:message key="SearchDrug.Reprint"/></a>
 
                       <a href="javascript:void(0);"  class="btn btn-link"  id="cmdRePrescribe" onclick="RePrescribeLongTerm();"><fmt:setBundle basename="oscarResources"/><fmt:message
@@ -1157,7 +1157,8 @@
                   </td>
                 </tr>
                 <tr>
-                  <td id="reprint">
+                  <%-- hidden attribute is toggled by JS via toggleAttribute('hidden') — do not move to CSS or the reprint section will not open --%>
+                  <td id="reprint" hidden>
 
 
                       <% for (int i = 0; prescribedDrugs.length > i; i++) {

--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -1170,7 +1170,7 @@
                                                     %>
 
 
-                    <div class="btn btn-link text-indent-5">
+                    <div class="text-indent-5">
                       <a href="javascript:void(0);" onclick="reprint2('<%=drug.getScript_no()%>')">
                         <%=drug.getRxDisplay()%>
                       </a>

--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -1190,7 +1190,7 @@
     </div>
     <div>
       <a href="javascript:void(0)" onclick="showPreviousPrints(<%=drug.getScript_no() %>);return false;">
-        <%=drug.getNumPrints()%>Print(s)
+        <%=drug.getNumPrints()%> Print(s)
       </a>
     </div>
   </div>

--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -240,6 +240,7 @@
   <link href="${pageContext.request.contextPath}/library/DataTables/DataTables-1.13.4/css/jquery.dataTables.css" rel="stylesheet" type="text/css"/>
 
   <script type="text/javascript" src="${ctx}/js/global.js"></script>
+  <script src="${ctx}/csrfguard"></script>
   <script type="text/javascript" src="<c:out value="${ctx}/share/javascript/prototype.js"/>"></script>
   <script type="text/javascript" src="<c:out value="${ctx}/share/javascript/screen.js"/>"></script>
   <script type="text/javascript" src="<c:out value="${ctx}/share/javascript/rx.js"/>"></script>
@@ -249,7 +250,6 @@
   <script type="text/javascript" src="<c:out value="${ctx}/share/javascript/Oscar.js"/>"></script>
   <script type="text/javascript" src="<c:out value="${ctx}/share/javascript/dragiframe.js"/>"></script>
   <script type="text/javascript" src="<c:out value="${ctx}/js/checkDate.js"/>"></script>
-  <script src="${pageContext.request.contextPath}/csrfguard"></script>
 
   <link rel="stylesheet" type="text/css" href="<c:out value="${ctx}/share/yui/css/autocomplete.css"/>">
   <script type="text/javascript" src="<c:out value="${ctx}/share/yui/js/yahoo-dom-event.js"/>"></script>


### PR DESCRIPTION
## Summary

  Fixes the "Reprint" button in the Rx module which has been non-functional since the de82590af5 commit.

Fixes https://github.com/openo-beta/Open-O/issues/2397

##  Problem

  In de82590af5, the `display: none` on `<td id="reprint">` was moved from an inline style to a CSS rule in the `<style>` block. Prototype.js's show() works by clearing the inline style.display to '', which falls back to the default display value. With the inline style, that fallback was table-cell (visible). With a CSS rule, the fallback is the rule's display: none (still hidden). So toggling appeared to do nothing.

##  Solution

  - Replaced $('reprint').toggle() (Prototype.js) with document.getElementById('reprint').toggleAttribute('hidden') (vanilla JS). The hidden HTML attribute avoids the inline-vs-CSS display conflict entirely and reduces Prototype.js dependency.
  - Added a comment on the hidden attribute explaining not to move it to CSS.

##  Additional fixes

  - Restored the csrfguard script include that was removed in f5eb92f235, ensuring CSRF tokens are injected into AJAX requests on this page.
  - Restored missing space between print count and "Print(s)" label (e.g. "1Print(s)" → "1 Print(s)").

##  Manual Testing Steps

  1. Login to the EMR
  2. Open the Rx module for a patient with past prescriptions
  3. Click on "Reprint" in the drug profile section
  4. **If testing the branch's behaviour:** Observe the reprint section appears with a list of past Rx's grouped by date
  5. **If testing develop's behaviour:** Observe nothing happens when clicking "Reprint"
  6. Click "Reprint" again to confirm the section hides
  7. Click "Reprint" to reopen, then click a drug entry in the list
  8. Observe a print preview modal opens
  9. Verify the print count next to each Rx shows a space (e.g. "1 Print(s)" not "1Print(s)")
  10. Verify no console errors during the above steps

## Summary by Sourcery

Fix the Rx module reprint section visibility and restore related page behavior.

Bug Fixes:
- Make the Rx module "Reprint" button correctly toggle the past prescriptions section using the HTML hidden attribute instead of CSS display rules.
- Restore CSRF protection on the Rx search page by re-adding the csrfguard script include.
- Correct the print count label formatting to include a space between the number and "Print(s)".