### PR TITLE
Fix: Medication list in rx module is sorted in the wrong order

### DIFF
--- a/src/main/webapp/oscarRx/ListDrugs.jsp
+++ b/src/main/webapp/oscarRx/ListDrugs.jsp
@@ -511,10 +511,10 @@
       // cache the datatable state to persist through page refreshes
       bStateSave: true,
       fnStateSave: function (oSettings, oData) {
-        localStorage.setItem('drugListTable', JSON.stringify(oData));
+        localStorage.setItem('drugListTable_v2', JSON.stringify(oData));
       },
       fnStateLoad: function () {
-        return JSON.parse(localStorage.getItem('drugListTable'));
+        return JSON.parse(localStorage.getItem('drugListTable_v2'));
       },
       "searching": true,
       // "aLengthMenu": [[25, 50, 75, -1], [25, 50, 75, "All"]],
@@ -559,7 +559,9 @@
       //     });
       // },
 
-      order: [[0, 'desc']]
+      // default sort: column 1 = Start Date (Rx Date), descending (most recent first)
+      // matches the original server-side Drug.START_DATE_COMPARATOR behaviour
+      order: [[1, 'desc']]
 
     })
 </script>

--- a/src/main/webapp/oscarRx/ListDrugs.jsp
+++ b/src/main/webapp/oscarRx/ListDrugs.jsp
@@ -559,7 +559,7 @@
       //     });
       // },
 
-      // order: [[4, 'desc']]
+      order: [[0, 'desc']]
 
     })
 </script>

--- a/src/main/webapp/oscarRx/ListDrugs.jsp
+++ b/src/main/webapp/oscarRx/ListDrugs.jsp
@@ -287,9 +287,13 @@
         <tr>
 
         <td><a id="createDate_<%=prescriptIdInt%>" <%=styleColor%> href="<%= request.getContextPath() %>/oscarRx/StaticScript2.jsp?regionalIdentifier=<%=Encode.forUriComponent(prescriptDrug.getRegionalIdentifier())%>&amp;cn=<%=Encode.forUriComponent(prescriptDrug.getCustomName())%>&amp;bn=<%=Encode.forUriComponent(bn)%>&amp;atc=<%=Encode.forUriComponent(prescriptDrug.getAtc())%>"><%=DateToString(prescriptDrug.getCreateDate())%></a></td>
-            <td>
+            <%-- data-order: DataTables sorts this column by the attribute value instead of the cell
+                 content. When start date is unknown the cell renders empty, so we fall back to
+                 createDate to maintain parity with the previous server-side sort, which used
+                 the same fallback to keep rows in a meaningful sort position. --%>
+            <td data-order="<%= startDateUnknown ? DateToString(prescriptDrug.getCreateDate()) : DateToString(prescriptDrug.getRxDate()) %>">
             	<% if(startDateUnknown) { %>
-            		
+
                 <% } else {
                     String startDate = UtilDateUtilities.DateToString(prescriptDrug.getRxDate());
                     startDate = partialDateDao.getDatePartial(startDate, PartialDate.DRUGS, prescriptDrug.getId(), PartialDate.DRUGS_STARTDATE);

--- a/src/main/webapp/oscarRx/ListDrugs.jsp
+++ b/src/main/webapp/oscarRx/ListDrugs.jsp
@@ -515,10 +515,10 @@
       // cache the datatable state to persist through page refreshes
       bStateSave: true,
       fnStateSave: function (oSettings, oData) {
-        localStorage.setItem('drugListTable_v2', JSON.stringify(oData));
+        localStorage.setItem('drugListTable', JSON.stringify(oData));
       },
       fnStateLoad: function () {
-        return JSON.parse(localStorage.getItem('drugListTable_v2'));
+        return JSON.parse(localStorage.getItem('drugListTable'));
       },
       "searching": true,
       // "aLengthMenu": [[25, 50, 75, -1], [25, 50, 75, "All"]],


### PR DESCRIPTION
## Summary
                                                                                                                                                      
Restores the default sort order for the medication list in the Rx module to descending by "Start Date" (most recent first), which was lost in edac1715d5.                                                                                                                                      
  
Fixes https://github.com/openo-beta/Open-O/issues/2390                                                                                              
                  
##  Problem
In edac1715d5, the medication list table was upgraded from the old sortables_init() library to DataTables. Previously, the sort order was handled server-side by  Drug.START_DATE_COMPARATOR (descending by start date, falling back to entered date when start date is unknown), and sortables_init() preserved that order on render. The DataTables upgrade introduced its own client-side sorting which defaults to column 0 ascending when no order config is specified. The intended order config was left commented out (// order: [[4, 'desc']]) and also pointed at the wrong column (4 = Prescription name, not a date column). This resulted in medications being displayed oldest-first instead of newest-first.

##  Solution
  - Uncommented and corrected the DataTables order configuration in ListDrugs.jsp to order: [[1, 'desc']], which sorts by column 1 ("Start Date") in descending order — matching the original Drug.START_DATE_COMPARATOR behaviour.
  - Added a data-order attribute to the Start Date <td> so that when start date is unknown (cell renders empty), DataTables falls back to sorting by entered date — maintaining parity with the server-side comparator's null-handling logic.
                                                                                                                                                      
##  Manual Testing Steps
  1. Login to the EMR
  2. Search for a patient and open their Rx module
  3. **If testing the branch's behaviour:** Observe the medication list is sorted by "Start Date" in descending order (most recent medications at the top)                                                                                                                                                
  4. **If testing develop's behaviour:** Observe the medication list is sorted in ascending order (oldest medications at the top)
  5. Click the "Start Date" column header to toggle between ascending and descending sort — verify both directions work                             
  6. Navigate away from the Rx module and return — verify the sort order persists (DataTables state saving)

## Summary by Sourcery

Restore the intended default sorting of the Rx module medication list and ensure table state is persisted under a new versioned key.

Bug Fixes:
- Fix the medication list default sort to show medications by Start Date (Rx Date) descending, matching original server-side behaviour even when the start date is unknown.

Enhancements:
- Use a DataTables data-order attribute on the Start Date column to provide a consistent fallback to Created Date when the start date is unknown.
- Version the DataTables localStorage state key for the medication list to avoid conflicts with previously cached table state.

## Summary by Sourcery

Bug Fixes:
- Fix the medication list default sort to order by Start Date descending, matching the original server-side behaviour including fallback when the start date is unknown.