### PR TITLE
fix: restore <br> rendering and fix missing labels in RxPreview

### DIFF
--- a/src/main/java/ca/openosp/openo/rx/RxPrintPreview2Action.java
+++ b/src/main/java/ca/openosp/openo/rx/RxPrintPreview2Action.java
@@ -553,7 +553,11 @@ public class RxPrintPreview2Action extends ActionSupport {
         addressJoiner.add(pharmacy.getName());
         addressJoiner.add(pharmacy.getAddress());
         addressJoiner.add(pharmacy.getCity() + ", " + pharmacy.getProvince() + " " + pharmacy.getPostalCode());
-        addressJoiner.add("Tel: " + pharmacy.getPhone1() + " " + pharmacy.getPhone2());
+        String tel = "Tel: " + pharmacy.getPhone1();
+        if (pharmacy.getPhone2() != null && !pharmacy.getPhone2().isEmpty()) {
+            tel += " " + pharmacy.getPhone2();
+        }
+        addressJoiner.add(tel);
         addressJoiner.add("Fax: " + pharmacy.getFax());
         if (pharmacy.getEmail() != null && !pharmacy.getEmail().isEmpty()) {
             addressJoiner.add("Email: " + pharmacy.getEmail());

--- a/src/main/webapp/css/searchDrug3.css
+++ b/src/main/webapp/css/searchDrug3.css
@@ -53,6 +53,10 @@ br {
 	display: none !important;
 }
 
+#preview br {
+	display: revert !important;
+}
+
 form {
 	margin: 0 !important;
 	padding: 0 !important;

--- a/src/main/webapp/oscarRx/printRx/PreviewContent.jsp
+++ b/src/main/webapp/oscarRx/printRx/PreviewContent.jsp
@@ -154,12 +154,12 @@
                                         <%= ((ca.openosp.openo.prescript.data.RxProviderData.Provider) request.getAttribute("provider")).getClinicCity() %>&nbsp;&nbsp;<%= ((ca.openosp.openo.prescript.data.RxProviderData.Provider) request.getAttribute("provider")).getClinicProvince() %>&nbsp;&nbsp;
                                         <%= ((ca.openosp.openo.prescript.data.RxProviderData.Provider) request.getAttribute("provider")).getClinicPostal() %>
                                         <% if (((ca.openosp.openo.prescript.data.RxProviderData.Provider) request.getAttribute("provider")).getPractitionerNo() != null && !((ca.openosp.openo.prescript.data.RxProviderData.Provider) request.getAttribute("provider")).getPractitionerNo().equals("")) { %>
-                                        <br><fmt:message key="RxPreview.PractNo"/>:<%= ((ca.openosp.openo.prescript.data.RxProviderData.Provider) request.getAttribute("provider")).getPractitionerNo() %>
+                                        <br><fmt:message key="RxPreview.PractNo"/>:<%= Encode.forHtml(((ca.openosp.openo.prescript.data.RxProviderData.Provider) request.getAttribute("provider")).getPractitionerNo()) %>
                                         <% } %>
                                         <br>
                                         <fmt:message key="RxPreview.msgTel"/>: ${requestScope.phone}<br>
                                         <oscar:oscarPropertiesCheck property="RXFAX" value="yes">
-                                            <fmt:message key="RxPreview.msgFax"/>: <%= ((ca.openosp.openo.prescript.data.RxProviderData.Provider) request.getAttribute("provider")).getClinicFax() %>
+                                            <fmt:message key="RxPreview.msgFax"/>: <%= Encode.forHtml(((ca.openosp.openo.prescript.data.RxProviderData.Provider) request.getAttribute("provider")).getClinicFax()) %>
                                             <br>
                                         </oscar:oscarPropertiesCheck>
                                     </c:when>

--- a/src/main/webapp/oscarRx/printRx/PreviewContent.jsp
+++ b/src/main/webapp/oscarRx/printRx/PreviewContent.jsp
@@ -154,14 +154,12 @@
                                         <%= ((ca.openosp.openo.prescript.data.RxProviderData.Provider) request.getAttribute("provider")).getClinicCity() %>&nbsp;&nbsp;<%= ((ca.openosp.openo.prescript.data.RxProviderData.Provider) request.getAttribute("provider")).getClinicProvince() %>&nbsp;&nbsp;
                                         <%= ((ca.openosp.openo.prescript.data.RxProviderData.Provider) request.getAttribute("provider")).getClinicPostal() %>
                                         <% if (((ca.openosp.openo.prescript.data.RxProviderData.Provider) request.getAttribute("provider")).getPractitionerNo() != null && !((ca.openosp.openo.prescript.data.RxProviderData.Provider) request.getAttribute("provider")).getPractitionerNo().equals("")) { %>
-                                        <br><bean:message
-                                            key="RxPreview.PractNo"/>:<%= ((ca.openosp.openo.prescript.data.RxProviderData.Provider) request.getAttribute("provider")).getPractitionerNo() %>
+                                        <br><fmt:message key="RxPreview.PractNo"/>:<%= ((ca.openosp.openo.prescript.data.RxProviderData.Provider) request.getAttribute("provider")).getPractitionerNo() %>
                                         <% } %>
                                         <br>
                                         <fmt:message key="RxPreview.msgTel"/>: ${requestScope.phone}<br>
                                         <oscar:oscarPropertiesCheck property="RXFAX" value="yes">
-                                            <bean:message
-                                                    key="RxPreview.msgFax"/>: <%= ((ca.openosp.openo.prescript.data.RxProviderData.Provider) request.getAttribute("provider")).getClinicFax() %>
+                                            <fmt:message key="RxPreview.msgFax"/>: <%= ((ca.openosp.openo.prescript.data.RxProviderData.Provider) request.getAttribute("provider")).getClinicFax() %>
                                             <br>
                                         </oscar:oscarPropertiesCheck>
                                     </c:when>


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                    
                  
  - `searchDrug3.css`: Added `#preview br { display: revert !important }` to restore line break rendering inside the prescription preview, which was suppressed by the global `br { display: none !important }` rule
  - `PreviewContent.jsp`: Replaced deprecated `<bean:message>` tags with `<fmt:message>` for Practitioner No and Fax labels - these were silently failing and rendering nothing

Before:
<img width="1039" height="1061" alt="image" src="https://github.com/user-attachments/assets/bc65eeb4-4893-41e1-96fe-8ccb404de0e7" />


After:
<img width="1058" height="1274" alt="image" src="https://github.com/user-attachments/assets/ca20a640-f6e3-4dc7-85fa-6856d4a49fbc" />

## Summary by Sourcery

Restore correct rendering and labelling in the Rx print preview, and avoid displaying empty pharmacy phone details.

Bug Fixes:
- Restore line break rendering inside the prescription preview without affecting global <br> suppression.
- Fix missing Practitioner No and Fax labels in the Rx preview by using the correct message tag library.
- Prevent an empty secondary phone number from being shown in the pharmacy Tel line when it is not provided.

Enhancements:
- HTML-encode practitioner number and clinic fax values before rendering in the preview for safer output.