### PR TITLE
Feature: eForm auto add tickler window popup

### DIFF
--- a/src/main/java/ca/openosp/openo/webserv/rest/TicklerWebService.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/TicklerWebService.java
@@ -399,8 +399,11 @@ public class TicklerWebService extends AbstractServiceImpl {
             tickler.setProgramId(pp.getProgramId().intValue());
         }
 
-        response.setSuccess(ticklerManager.addTickler(getLoggedInInfo(), tickler));
-        response.setMessage(String.valueOf(tickler.getId()));
+        boolean created = ticklerManager.addTickler(getLoggedInInfo(), tickler);
+        response.setSuccess(created);
+        if (created) {
+            response.setMessage(String.valueOf(tickler.getId()));
+        }
 
         return response;
     }

--- a/src/main/java/ca/openosp/openo/webserv/rest/TicklerWebService.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/TicklerWebService.java
@@ -400,6 +400,7 @@ public class TicklerWebService extends AbstractServiceImpl {
         }
 
         response.setSuccess(ticklerManager.addTickler(getLoggedInInfo(), tickler));
+        response.setMessage(String.valueOf(tickler.getId()));
 
         return response;
     }

--- a/src/main/webapp/eform/efmformadd_data.jsp
+++ b/src/main/webapp/eform/efmformadd_data.jsp
@@ -142,6 +142,7 @@
     thisEForm.addHiddenInputElement("fid", fid);
     thisEForm.addHiddenInputElement("fdid", request.getParameter("fdid"));
     thisEForm.addHiddenInputElement("newForm", "true");
+    thisEForm.addHiddenInputElement("providerNo", provider_no);
 
     // Add email consent properties
     LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);

--- a/src/main/webapp/eform/efmformadd_data.jsp
+++ b/src/main/webapp/eform/efmformadd_data.jsp
@@ -137,15 +137,16 @@
     thisEForm.addCSS(request.getContextPath()+"/library/jquery/jquery-ui-1.12.1.min.css", "all");
     thisEForm.addBodyJavascript(request.getContextPath()+"/eform/eformFloatingToolbar/eform_floating_toolbar.js");
     thisEForm.addBodyJavascript(request.getContextPath()+"/js/oscar-alert.js");
+    LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
+
     thisEForm.addHiddenInputElement("context", request.getContextPath());
     thisEForm.addHiddenInputElement("demographicNo", demographic_no);
     thisEForm.addHiddenInputElement("fid", fid);
     thisEForm.addHiddenInputElement("fdid", request.getParameter("fdid"));
     thisEForm.addHiddenInputElement("newForm", "true");
-    thisEForm.addHiddenInputElement("providerNo", provider_no);
+    thisEForm.addHiddenInputElement("providerNo", loggedInInfo.getLoggedInProviderNo());
 
     // Add email consent properties
-    LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
     addHiddenEmailProperties(loggedInInfo, thisEForm, demographic_no);
 
     out.print(thisEForm.getFormHtml());

--- a/src/main/webapp/eform/efmshowform_data.jsp
+++ b/src/main/webapp/eform/efmshowform_data.jsp
@@ -140,6 +140,7 @@
     eForm.addHiddenInputElement("eFormPDF", (String) request.getAttribute("eFormPDF"));
     eForm.addHiddenInputElement("isDownloadEForm", (String) request.getAttribute("isDownload"));
     eForm.addHiddenInputElement("isSuccess_Autoclose", (String) request.getAttribute("isSuccess_Autoclose"));
+    eForm.addHiddenInputElement("providerNo", LoggedInInfo.getLoggedInInfoFromSession(request).getLoggedInProviderNo());
     // Add EForm attachments
     LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
     addHiddenEFormAttachments(loggedInInfo, eForm, fdid);

--- a/src/main/webapp/eform/efmshowform_data.jsp
+++ b/src/main/webapp/eform/efmshowform_data.jsp
@@ -126,10 +126,13 @@
     eForm.addCSS(request.getContextPath() + "/library/jquery/jquery-ui-1.12.1.min.css", "all");
     eForm.addBodyJavascript(request.getContextPath() + "/eform/eformFloatingToolbar/eform_floating_toolbar.js");
     eForm.addFontLibrary(request.getContextPath() + "/share/javascript/eforms/dejavufonts/ttf/DejaVuSans.ttf");
+    LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
+
     eForm.addHiddenInputElement("context", request.getContextPath());
     eForm.addHiddenInputElement("demographicNo", eForm.getDemographicNo());
     eForm.addHiddenInputElement("fdid", fdid);
     eForm.addHiddenInputElement("fid", eForm.getFid());
+    eForm.addHiddenInputElement("providerNo", loggedInInfo.getLoggedInProviderNo());
 
     // Add EForm error message
     eForm.addHiddenInputElement("error", request.getParameter("error"));
@@ -140,9 +143,8 @@
     eForm.addHiddenInputElement("eFormPDF", (String) request.getAttribute("eFormPDF"));
     eForm.addHiddenInputElement("isDownloadEForm", (String) request.getAttribute("isDownload"));
     eForm.addHiddenInputElement("isSuccess_Autoclose", (String) request.getAttribute("isSuccess_Autoclose"));
-    eForm.addHiddenInputElement("providerNo", LoggedInInfo.getLoggedInInfoFromSession(request).getLoggedInProviderNo());
+
     // Add EForm attachments
-    LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
     addHiddenEFormAttachments(loggedInInfo, eForm, fdid);
 
     // Add email consent properties

--- a/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
+++ b/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
@@ -43,18 +43,19 @@ document.addEventListener("DOMContentLoaded", function(){
 
 	// Tickler integration: wrap toolbar actions if eForm has tickler tags
 	if (hasTicklerTags()) {
-		// _ticklerHandled stays true during one action chain (e.g. Print→Save)
-		// so Save doesn't re-trigger the dialog when called internally by Print.
-		// Every successful path ends in a form submission that reloads the page,
-		// so the flag is naturally cleared. _ticklerIntegration.resetHandled() is only needed
-		// for cancellation paths (X button, "No", "Cancel") to allow re-trigger.
-		let _ticklerHandled = false;
+		// Tickler flow state: "idle", "inProgress", or "proceeding".
+		// - "idle": no tickler flow active, next action triggers the dialog
+		// - "inProgress": dialog is open, block any new toolbar actions
+		// - "proceeding": dialog completed, allow the original action through
+		//   (e.g. Print→Save chain where Save is called internally by Print)
+		// Resets to "idle" on cancellation. Page reload naturally resets via new JS context.
+		let _ticklerState = "idle";
 
 		// Minimal API for dialog handlers to interact with tickler state.
 		// Single window property to avoid polluting the global namespace.
 		// Must be defined before initTicklerDialogs() which references it.
 		window._ticklerIntegration = {
-			resetHandled: function() { _ticklerHandled = false; },
+			resetHandled: function() { _ticklerState = "idle"; },
 			markDialogButton: null // set by initTicklerDialogs closure
 		};
 
@@ -69,19 +70,24 @@ document.addEventListener("DOMContentLoaded", function(){
 
 		function wrapWithTicklerCheck(originalFn) {
 			return function() {
-				if (_ticklerHandled) {
+				if (_ticklerState === "proceeding") {
 					return originalFn.apply(this, arguments);
+				}
+				if (_ticklerState === "inProgress") {
+					return; // block — tickler dialog is still open
 				}
 				// Check mode at action time so dynamically toggled tags are respected
 				const currentMode = getTicklerMode();
 				if (!currentMode) {
 					return originalFn.apply(this, arguments);
 				}
-				_ticklerHandled = true;
+				_ticklerState = "inProgress";
 				const args = arguments;
 				const self = this;
 				const proceedCallback = function() {
+					_ticklerState = "proceeding";
 					originalFn.apply(self, args);
+					_ticklerIntegration.resetHandled();
 				};
 				if (currentMode === "autoOpen") {
 					promptTicklerAutoOpen(proceedCallback);
@@ -631,9 +637,9 @@ function initTicklerDialogs() {
     document.body.appendChild(confirmDiv);
 
     // Proceed dialog (after popup closes)
-    const proceedDiv = createDialogDiv("ticklerProceedDialog", "Tickler Created");
+    const proceedDiv = createDialogDiv("ticklerProceedDialog", "Tickler Window Closed");
     const proceedP = document.createElement("p");
-    proceedP.textContent = "The tickler window has closed. Ready to proceed with saving?";
+    proceedP.textContent = "The tickler window has closed. Ready to proceed?";
     proceedDiv.appendChild(proceedP);
     document.body.appendChild(proceedDiv);
 
@@ -726,13 +732,15 @@ function initTicklerDialogs() {
 function styleTicklerDialogCloseButton(dialogSelector) {
     jQuery(dialogSelector).on("dialogopen", function() {
         const closeBtn = jQuery(this).parent().find(".ui-dialog-titlebar-close");
+        const titlebar = jQuery(this).parent().find(".ui-dialog-titlebar");
+        titlebar.css("padding", "10px 14px");
         closeBtn.empty()
             .removeClass("ui-button-icon-only ui-button-icon ui-icon ui-icon-closethick")
             .addClass("btn-close")
             .attr("aria-label", "Close")
             .css({
                 "position": "absolute",
-                "right": "12px",
+                "right": "14px",
                 "top": "50%",
                 "transform": "translateY(-50%)"
             });
@@ -754,7 +762,6 @@ function promptTicklerAutoOpen(proceedCallback) {
             _ticklerIntegration.markDialogButton();
             jQuery(this).dialog("close");
             proceedCallback();
-            _ticklerIntegration.resetHandled();
         }
     });
     document.getElementById("ticklerConfirmMessage").textContent =
@@ -805,7 +812,6 @@ function showProceedDialog(proceedCallback) {
             _ticklerIntegration.markDialogButton();
             jQuery(this).dialog("close");
             proceedCallback();
-            _ticklerIntegration.resetHandled();
         },
         "No, cancel": function() {
             _ticklerIntegration.markDialogButton();
@@ -823,12 +829,20 @@ function promptTicklerAutoSave(proceedCallback) {
     const data = collectTicklerData();
     const contextPath = getTicklerFieldValue("context", "");
 
+    // Append local timezone offset so Jackson interprets the date as local midnight,
+    // not UTC midnight (which would shift to the previous day in negative UTC offsets).
+    const tzOffset = new Date().getTimezoneOffset();
+    const tzSign = tzOffset <= 0 ? "+" : "-";
+    const tzHours = String(Math.floor(Math.abs(tzOffset) / 60)).padStart(2, '0');
+    const tzMinutes = String(Math.abs(tzOffset) % 60).padStart(2, '0');
+    const serviceDateWithTz = data.serviceDate + "T00:00:00" + tzSign + tzHours + ":" + tzMinutes;
+
     const payload = {
         demographicNo: data.demographicNo,
         message: data.message,
         taskAssignedTo: data.taskAssignedTo,
         priority: data.priority,
-        serviceDate: data.serviceDate + "T00:00:00",
+        serviceDate: serviceDateWithTz,
         status: "A"
     };
 
@@ -848,7 +862,6 @@ function promptTicklerAutoSave(proceedCallback) {
                         _ticklerIntegration.markDialogButton();
                         jQuery(this).dialog("close");
                         proceedCallback();
-                        _ticklerIntegration.resetHandled();
                     }
                 });
                 jQuery("#ticklerAutoSaveSuccessDialog").dialog("open");
@@ -881,7 +894,6 @@ function showTicklerError(detail, proceedCallback) {
             _ticklerIntegration.markDialogButton();
             jQuery(this).dialog("close");
             proceedCallback();
-            _ticklerIntegration.resetHandled();
         },
         "Cancel": function() {
             _ticklerIntegration.markDialogButton();

--- a/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
+++ b/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
@@ -42,22 +42,24 @@ document.addEventListener("DOMContentLoaded", function(){
 	}
 
 	// Tickler integration: wrap toolbar actions if eForm has tickler tags
-	var ticklerMode = hasTicklerTags();
+	const ticklerMode = hasTicklerTags();
 	if (ticklerMode) {
 		initTicklerDialogs();
 
 		// _ticklerHandled stays true during one action chain (e.g. Print→Save)
 		// so Save doesn't re-trigger the dialog when called internally by Print.
-		// resetTicklerHandled() clears it after the chain completes or is canceled.
-		var _ticklerHandled = false;
+		// Every successful path ends in a form submission that reloads the page,
+		// so the flag is naturally cleared. resetTicklerHandled() is only needed
+		// for cancellation paths (X button, "No", "Cancel") to allow re-trigger.
+		let _ticklerHandled = false;
 		window.resetTicklerHandled = function() { _ticklerHandled = false; };
 
-		var _origSave = remoteSave;
-		var _origPrint = remotePrint;
-		var _origDownload = remoteDownload;
-		var _origFax = remoteFax;
-		var _origEmail = remoteEmail;
-		var _origEdocument = remoteEdocument;
+		const _origSave = remoteSave;
+		const _origPrint = remotePrint;
+		const _origDownload = remoteDownload;
+		const _origFax = remoteFax;
+		const _origEmail = remoteEmail;
+		const _origEdocument = remoteEdocument;
 
 		function wrapWithTicklerCheck(originalFn) {
 			return function() {
@@ -65,10 +67,14 @@ document.addEventListener("DOMContentLoaded", function(){
 					return originalFn.apply(this, arguments);
 				}
 				_ticklerHandled = true;
-				var args = arguments;
-				var self = this;
-				var proceedCallback = function() {
-					originalFn.apply(self, args);
+				const args = arguments;
+				const self = this;
+				const proceedCallback = function() {
+					try {
+						originalFn.apply(self, args);
+					} finally {
+						resetTicklerHandled();
+					}
 				};
 				if (ticklerMode === "autoOpen") {
 					promptTicklerAutoOpen(proceedCallback);
@@ -544,11 +550,11 @@ function hasTicklerTags() {
     if (typeof setAtickler === 'function') {
         return null;
     }
-    var autoOpen = document.getElementById("ticklerAutoOpen");
+    const autoOpen = document.getElementById("ticklerAutoOpen");
     if (autoOpen && autoOpen.value && autoOpen.value.toLowerCase() === "true") {
         return "autoOpen";
     }
-    var autoSave = document.getElementById("ticklerAutoSave");
+    const autoSave = document.getElementById("ticklerAutoSave");
     if (autoSave && autoSave.value && autoSave.value.toLowerCase() === "true") {
         return "autoSave";
     }
@@ -559,7 +565,7 @@ function hasTicklerTags() {
  * Reads a hidden input value from the eForm, returning a default if not found.
  */
 function getTicklerFieldValue(fieldId, defaultValue) {
-    var el = document.getElementById(fieldId);
+    const el = document.getElementById(fieldId);
     if (el && el.value && el.value.trim() !== "") {
         return el.value.trim();
     }
@@ -570,11 +576,11 @@ function getTicklerFieldValue(fieldId, defaultValue) {
  * Collects tickler data from hidden inputs in the eForm.
  */
 function collectTicklerData() {
-    var today = new Date();
-    var yyyy = today.getFullYear();
-    var mm = String(today.getMonth() + 1).padStart(2, '0');
-    var dd = String(today.getDate()).padStart(2, '0');
-    var todayStr = yyyy + '-' + mm + '-' + dd;
+    const today = new Date();
+    const yyyy = today.getFullYear();
+    const mm = String(today.getMonth() + 1).padStart(2, '0');
+    const dd = String(today.getDate()).padStart(2, '0');
+    const todayStr = yyyy + '-' + mm + '-' + dd;
 
     return {
         demographicNo: getTicklerFieldValue("demographicNo", ""),
@@ -589,7 +595,7 @@ function collectTicklerData() {
  * Creates a DOM element with text content and optional child elements.
  */
 function createDialogDiv(id, title) {
-    var div = document.createElement("div");
+    const div = document.createElement("div");
     div.id = id;
     div.title = title;
     return div;
@@ -599,61 +605,62 @@ function createDialogDiv(id, title) {
  * Creates and initializes the jQuery UI dialogs used by the tickler integration.
  */
 function initTicklerDialogs() {
-    var promptMessage = getTicklerFieldValue("ticklerPromptMessage", "Do you want to create a tickler first?");
+    const promptMessage = getTicklerFieldValue("ticklerPromptMessage", "Do you want to create a tickler first?");
 
     // Confirm dialog (auto-open mode)
-    var confirmDiv = createDialogDiv("ticklerConfirmDialog", "Create Tickler");
-    var confirmP = document.createElement("p");
+    const confirmDiv = createDialogDiv("ticklerConfirmDialog", "Create Tickler");
+    const confirmP = document.createElement("p");
     confirmP.textContent = promptMessage;
     confirmDiv.appendChild(confirmP);
     document.body.appendChild(confirmDiv);
 
     // Proceed dialog (after popup closes)
-    var proceedDiv = createDialogDiv("ticklerProceedDialog", "Tickler Created");
-    var proceedP = document.createElement("p");
+    const proceedDiv = createDialogDiv("ticklerProceedDialog", "Tickler Created");
+    const proceedP = document.createElement("p");
     proceedP.textContent = "The tickler window has closed. Ready to proceed with saving?";
     proceedDiv.appendChild(proceedP);
     document.body.appendChild(proceedDiv);
 
     // Auto-save success dialog
-    var successDiv = createDialogDiv("ticklerAutoSaveSuccessDialog", "Tickler Created");
-    var successP1 = document.createElement("p");
+    const successDiv = createDialogDiv("ticklerAutoSaveSuccessDialog", "Tickler Created");
+    const successP1 = document.createElement("p");
     successP1.textContent = "A tickler has been automatically created. ";
-    var viewLink = document.createElement("a");
+    const viewLink = document.createElement("a");
     viewLink.id = "ticklerViewLink";
     viewLink.href = "#";
     viewLink.target = "_blank";
     viewLink.textContent = "Click here to view it.";
     successP1.appendChild(viewLink);
     successDiv.appendChild(successP1);
-    var successP2 = document.createElement("p");
+    const successP2 = document.createElement("p");
     successP2.textContent = "Click OK to proceed.";
     successDiv.appendChild(successP2);
     document.body.appendChild(successDiv);
 
     // Auto-save error dialog
-    var errorDiv = createDialogDiv("ticklerAutoSaveErrorDialog", "Tickler Error");
-    var errorP1 = document.createElement("p");
+    const errorDiv = createDialogDiv("ticklerAutoSaveErrorDialog", "Tickler Error");
+    const errorP1 = document.createElement("p");
     errorP1.textContent = "Tickler creation failed: ";
-    var errorDetail = document.createElement("span");
+    const errorDetail = document.createElement("span");
     errorDetail.id = "ticklerErrorDetail";
     errorP1.appendChild(errorDetail);
     errorDiv.appendChild(errorP1);
-    var errorP2 = document.createElement("p");
+    const errorP2 = document.createElement("p");
     errorP2.textContent = "Click OK to proceed anyway, or Cancel to stop.";
     errorDiv.appendChild(errorP2);
     document.body.appendChild(errorDiv);
 
-    // _ticklerDialogButtonClicked tracks whether a dialog was closed by a
-    // button callback (true) vs the X button or Escape key (false).
-    // Only the X/Escape path should reset the handled flag.
-    window._ticklerDialogButtonClicked = false;
+    // Tracks whether a dialog was closed by a button callback (true) vs the
+    // X button or Escape key (false). Scoped to this closure to avoid globals.
+    let _dialogButtonClicked = false;
+
+    window.markTicklerDialogButton = function() { _dialogButtonClicked = true; };
 
     function ticklerDialogClose() {
-        if (!window._ticklerDialogButtonClicked) {
+        if (!_dialogButtonClicked) {
             resetTicklerHandled();
         }
-        window._ticklerDialogButtonClicked = false;
+        _dialogButtonClicked = false;
     }
 
     jQuery("#ticklerConfirmDialog").dialog({
@@ -702,13 +709,16 @@ function initTicklerDialogs() {
  */
 function styleTicklerDialogCloseButton(dialogSelector) {
     jQuery(dialogSelector).on("dialogopen", function() {
-        var closeBtn = jQuery(this).parent().find(".ui-dialog-titlebar-close");
-        closeBtn.empty().removeClass().addClass("btn-close").css({
-            "position": "absolute",
-            "right": "12px",
-            "top": "50%",
-            "transform": "translateY(-50%)"
-        });
+        const closeBtn = jQuery(this).parent().find(".ui-dialog-titlebar-close");
+        closeBtn.empty()
+            .removeClass("ui-button-icon-only ui-button-icon ui-icon ui-icon-closethick")
+            .addClass("btn-close")
+            .css({
+                "position": "absolute",
+                "right": "12px",
+                "top": "50%",
+                "transform": "translateY(-50%)"
+            });
     });
 }
 
@@ -719,12 +729,12 @@ function styleTicklerDialogCloseButton(dialogSelector) {
 function promptTicklerAutoOpen(proceedCallback) {
     jQuery("#ticklerConfirmDialog").dialog("option", "buttons", {
         "Yes": function() {
-            window._ticklerDialogButtonClicked = true;
+            markTicklerDialogButton();
             jQuery(this).dialog("close");
             openTicklerPopup(proceedCallback);
         },
         "No": function() {
-            window._ticklerDialogButtonClicked = true;
+            markTicklerDialogButton();
             jQuery(this).dialog("close");
             proceedCallback();
             resetTicklerHandled();
@@ -740,20 +750,26 @@ function promptTicklerAutoOpen(proceedCallback) {
  * Polls for popup close, then shows the proceed dialog.
  */
 function openTicklerPopup(proceedCallback) {
-    var data = collectTicklerData();
-    var contextPath = getTicklerFieldValue("context", "");
-    var params = "demographic_no=" + encodeURIComponent(data.demographicNo)
+    const data = collectTicklerData();
+    const contextPath = getTicklerFieldValue("context", "");
+    const params = "demographic_no=" + encodeURIComponent(data.demographicNo)
         + "&ticklerMessage=" + encodeURIComponent(data.message)
         + "&taskTo=" + encodeURIComponent(data.taskAssignedTo)
         + "&priority=" + encodeURIComponent(data.priority)
         + "&xml_appointment_date=" + encodeURIComponent(data.serviceDate)
         + "&updateParent=false";
 
-    var url = contextPath + "/tickler/ticklerAdd.jsp?" + params;
-    var popup = window.open(url, "ticklerPopup", "height=600,width=800,scrollbars=yes,resizable=yes");
+    const url = contextPath + "/tickler/ticklerAdd.jsp?" + params;
+    const popup = window.open(url, "ticklerPopup", "height=600,width=800,scrollbars=yes,resizable=yes");
 
-    var pollTimer = setInterval(function() {
-        if (!popup || popup.closed) {
+    if (!popup) {
+        alert("The tickler popup was blocked by your browser. Please allow popups for this site and try again.");
+        resetTicklerHandled();
+        return;
+    }
+
+    const pollTimer = setInterval(function() {
+        if (popup.closed) {
             clearInterval(pollTimer);
             showProceedDialog(proceedCallback);
         }
@@ -766,12 +782,12 @@ function openTicklerPopup(proceedCallback) {
 function showProceedDialog(proceedCallback) {
     jQuery("#ticklerProceedDialog").dialog("option", "buttons", {
         "Yes, proceed": function() {
-            window._ticklerDialogButtonClicked = true;
+            markTicklerDialogButton();
             jQuery(this).dialog("close");
             proceedCallback();
         },
         "No, cancel": function() {
-            window._ticklerDialogButtonClicked = true;
+            markTicklerDialogButton();
             jQuery(this).dialog("close");
             resetTicklerHandled();
         }
@@ -783,10 +799,10 @@ function showProceedDialog(proceedCallback) {
  * Auto-save flow: silently creates a tickler via REST, then shows success or error dialog.
  */
 function promptTicklerAutoSave(proceedCallback) {
-    var data = collectTicklerData();
-    var contextPath = getTicklerFieldValue("context", "");
+    const data = collectTicklerData();
+    const contextPath = getTicklerFieldValue("context", "");
 
-    var payload = {
+    const payload = {
         demographicNo: data.demographicNo,
         message: data.message,
         taskAssignedTo: data.taskAssignedTo,
@@ -803,12 +819,12 @@ function promptTicklerAutoSave(proceedCallback) {
         dataType: "json",
         success: function(resp) {
             if (resp && resp.success) {
-                var ticklerId = resp.message;
-                var viewUrl = contextPath + "/tickler/ticklerEdit.jsp?tickler_no=" + encodeURIComponent(ticklerId);
+                const ticklerId = resp.message;
+                const viewUrl = contextPath + "/tickler/ticklerEdit.jsp?tickler_no=" + encodeURIComponent(ticklerId);
                 jQuery("#ticklerViewLink").attr("href", viewUrl);
                 jQuery("#ticklerAutoSaveSuccessDialog").dialog("option", "buttons", {
                     "OK": function() {
-                        window._ticklerDialogButtonClicked = true;
+                        markTicklerDialogButton();
                         jQuery(this).dialog("close");
                         proceedCallback();
                     }
@@ -819,10 +835,10 @@ function promptTicklerAutoSave(proceedCallback) {
             }
         },
         error: function(xhr) {
-            var detail = "HTTP " + xhr.status;
+            let detail = "HTTP " + xhr.status;
             if (xhr.responseText) {
                 try {
-                    var errResp = JSON.parse(xhr.responseText);
+                    const errResp = JSON.parse(xhr.responseText);
                     if (errResp.message) detail = errResp.message;
                 } catch (e) {
                     // use default detail
@@ -840,12 +856,12 @@ function showTicklerError(detail, proceedCallback) {
     jQuery("#ticklerErrorDetail").text(detail);
     jQuery("#ticklerAutoSaveErrorDialog").dialog("option", "buttons", {
         "OK (proceed anyway)": function() {
-            window._ticklerDialogButtonClicked = true;
+            markTicklerDialogButton();
             jQuery(this).dialog("close");
             proceedCallback();
         },
         "Cancel": function() {
-            window._ticklerDialogButtonClicked = true;
+            markTicklerDialogButton();
             jQuery(this).dialog("close");
             resetTicklerHandled();
         }

--- a/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
+++ b/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
@@ -629,6 +629,11 @@ function createDialogDiv(id, title) {
 function initTicklerDialogs() {
     if (document.getElementById("ticklerConfirmDialog")) return;
 
+    // Fix near-invisible modal overlay (theme CSS sets opacity to .003)
+    const overlayStyle = document.createElement("style");
+    overlayStyle.textContent = ".ui-widget-overlay { background: #000 !important; opacity: 0.4 !important; }";
+    document.head.appendChild(overlayStyle);
+
     // Confirm dialog (auto-open mode)
     const confirmDiv = createDialogDiv("ticklerConfirmDialog", "Create Tickler");
     const confirmP = document.createElement("p");

--- a/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
+++ b/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
@@ -580,7 +580,7 @@ function collectTicklerData() {
         demographicNo: getTicklerFieldValue("demographicNo", ""),
         serviceDate: getTicklerFieldValue("ticklerServiceDate", todayStr),
         priority: getTicklerFieldValue("ticklerPriority", "Normal"),
-        taskAssignedTo: getTicklerFieldValue("ticklerTaskAssignedTo", getTicklerFieldValue("providerNo", "")),
+        taskAssignedTo: getTicklerFieldValue("ticklerAssignedTo", getTicklerFieldValue("providerNo", "")),
         message: getTicklerFieldValue("ticklerMessage", "")
     };
 }
@@ -599,7 +599,7 @@ function createDialogDiv(id, title) {
  * Creates and initializes the jQuery UI dialogs used by the tickler integration.
  */
 function initTicklerDialogs() {
-    var promptMessage = getTicklerFieldValue("ticklerPromptMessage", "Do you want to create a tickler for this eForm?");
+    var promptMessage = getTicklerFieldValue("ticklerPromptMessage", "Do you want to create a tickler first?");
 
     // Confirm dialog (auto-open mode)
     var confirmDiv = createDialogDiv("ticklerConfirmDialog", "Create Tickler");
@@ -609,7 +609,7 @@ function initTicklerDialogs() {
     document.body.appendChild(confirmDiv);
 
     // Proceed dialog (after popup closes)
-    var proceedDiv = createDialogDiv("ticklerProceedDialog", "Continue");
+    var proceedDiv = createDialogDiv("ticklerProceedDialog", "Tickler Created");
     var proceedP = document.createElement("p");
     proceedP.textContent = "The tickler window has closed. Ready to proceed with saving?";
     proceedDiv.appendChild(proceedP);
@@ -727,6 +727,7 @@ function promptTicklerAutoOpen(proceedCallback) {
             window._ticklerDialogButtonClicked = true;
             jQuery(this).dialog("close");
             proceedCallback();
+            resetTicklerHandled();
         }
     });
     jQuery("#ticklerConfirmDialog").dialog("open");
@@ -745,6 +746,7 @@ function openTicklerPopup(proceedCallback) {
         + "&ticklerMessage=" + encodeURIComponent(data.message)
         + "&taskTo=" + encodeURIComponent(data.taskAssignedTo)
         + "&priority=" + encodeURIComponent(data.priority)
+        + "&xml_appointment_date=" + encodeURIComponent(data.serviceDate)
         + "&updateParent=false";
 
     var url = contextPath + "/tickler/ticklerAdd.jsp?" + params;
@@ -784,14 +786,12 @@ function promptTicklerAutoSave(proceedCallback) {
     var data = collectTicklerData();
     var contextPath = getTicklerFieldValue("context", "");
 
-    var serviceDate = new Date(data.serviceDate + "T00:00:00");
-
     var payload = {
         demographicNo: data.demographicNo,
         message: data.message,
         taskAssignedTo: data.taskAssignedTo,
         priority: data.priority,
-        serviceDate: serviceDate.toISOString(),
+        serviceDate: data.serviceDate + "T00:00:00",
         status: "A"
     };
 

--- a/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
+++ b/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
@@ -42,17 +42,23 @@ document.addEventListener("DOMContentLoaded", function(){
 	}
 
 	// Tickler integration: wrap toolbar actions if eForm has tickler tags
-	const ticklerMode = hasTicklerTags();
-	if (ticklerMode) {
-		initTicklerDialogs();
-
+	if (hasTicklerTags()) {
 		// _ticklerHandled stays true during one action chain (e.g. Print→Save)
 		// so Save doesn't re-trigger the dialog when called internally by Print.
 		// Every successful path ends in a form submission that reloads the page,
-		// so the flag is naturally cleared. resetTicklerHandled() is only needed
+		// so the flag is naturally cleared. _ticklerIntegration.resetHandled() is only needed
 		// for cancellation paths (X button, "No", "Cancel") to allow re-trigger.
 		let _ticklerHandled = false;
-		window.resetTicklerHandled = function() { _ticklerHandled = false; };
+
+		// Minimal API for dialog handlers to interact with tickler state.
+		// Single window property to avoid polluting the global namespace.
+		// Must be defined before initTicklerDialogs() which references it.
+		window._ticklerIntegration = {
+			resetHandled: function() { _ticklerHandled = false; },
+			markDialogButton: null // set by initTicklerDialogs closure
+		};
+
+		initTicklerDialogs();
 
 		const _origSave = remoteSave;
 		const _origPrint = remotePrint;
@@ -66,19 +72,20 @@ document.addEventListener("DOMContentLoaded", function(){
 				if (_ticklerHandled) {
 					return originalFn.apply(this, arguments);
 				}
+				// Check mode at action time so dynamically toggled tags are respected
+				const currentMode = getTicklerMode();
+				if (!currentMode) {
+					return originalFn.apply(this, arguments);
+				}
 				_ticklerHandled = true;
 				const args = arguments;
 				const self = this;
 				const proceedCallback = function() {
-					try {
-						originalFn.apply(self, args);
-					} finally {
-						resetTicklerHandled();
-					}
+					originalFn.apply(self, args);
 				};
-				if (ticklerMode === "autoOpen") {
+				if (currentMode === "autoOpen") {
 					promptTicklerAutoOpen(proceedCallback);
-				} else if (ticklerMode === "autoSave") {
+				} else if (currentMode === "autoSave") {
 					promptTicklerAutoSave(proceedCallback);
 				}
 			};
@@ -543,13 +550,22 @@ function remoteClose() {
 
 /**
  * Detects whether this eForm has tickler integration tags.
- * Returns "autoOpen", "autoSave", or null.
- * Skips if the eForm Generator's tickler function is present (conflict guard).
+ * Returns true if either ticklerAutoOpen or ticklerAutoSave elements exist,
+ * false otherwise. Skips if the eForm Generator's tickler function is present.
  */
 function hasTicklerTags() {
     if (typeof setAtickler === 'function') {
-        return null;
+        return false;
     }
+    return !!(document.getElementById("ticklerAutoOpen") || document.getElementById("ticklerAutoSave"));
+}
+
+/**
+ * Returns the current tickler mode by checking hidden input values at call time.
+ * This allows eForms to toggle tickler mode dynamically (e.g. via a checkbox)
+ * after page load. Returns "autoOpen", "autoSave", or null.
+ */
+function getTicklerMode() {
     const autoOpen = document.getElementById("ticklerAutoOpen");
     if (autoOpen && autoOpen.value && autoOpen.value.toLowerCase() === "true") {
         return "autoOpen";
@@ -605,6 +621,8 @@ function createDialogDiv(id, title) {
  * Creates and initializes the jQuery UI dialogs used by the tickler integration.
  */
 function initTicklerDialogs() {
+    if (document.getElementById("ticklerConfirmDialog")) return;
+
     const promptMessage = getTicklerFieldValue("ticklerPromptMessage", "Do you want to create a tickler first?");
 
     // Confirm dialog (auto-open mode)
@@ -654,11 +672,11 @@ function initTicklerDialogs() {
     // X button or Escape key (false). Scoped to this closure to avoid globals.
     let _dialogButtonClicked = false;
 
-    window.markTicklerDialogButton = function() { _dialogButtonClicked = true; };
+    _ticklerIntegration.markDialogButton = function() { _dialogButtonClicked = true; };
 
     function ticklerDialogClose() {
         if (!_dialogButtonClicked) {
-            resetTicklerHandled();
+            _ticklerIntegration.resetHandled();
         }
         _dialogButtonClicked = false;
     }
@@ -713,6 +731,7 @@ function styleTicklerDialogCloseButton(dialogSelector) {
         closeBtn.empty()
             .removeClass("ui-button-icon-only ui-button-icon ui-icon ui-icon-closethick")
             .addClass("btn-close")
+            .attr("aria-label", "Close")
             .css({
                 "position": "absolute",
                 "right": "12px",
@@ -729,15 +748,15 @@ function styleTicklerDialogCloseButton(dialogSelector) {
 function promptTicklerAutoOpen(proceedCallback) {
     jQuery("#ticklerConfirmDialog").dialog("option", "buttons", {
         "Yes": function() {
-            markTicklerDialogButton();
+            _ticklerIntegration.markDialogButton();
             jQuery(this).dialog("close");
             openTicklerPopup(proceedCallback);
         },
         "No": function() {
-            markTicklerDialogButton();
+            _ticklerIntegration.markDialogButton();
             jQuery(this).dialog("close");
             proceedCallback();
-            resetTicklerHandled();
+            _ticklerIntegration.resetHandled();
         }
     });
     jQuery("#ticklerConfirmDialog").dialog("open");
@@ -764,7 +783,7 @@ function openTicklerPopup(proceedCallback) {
 
     if (!popup) {
         alert("The tickler popup was blocked by your browser. Please allow popups for this site and try again.");
-        resetTicklerHandled();
+        _ticklerIntegration.resetHandled();
         return;
     }
 
@@ -782,14 +801,14 @@ function openTicklerPopup(proceedCallback) {
 function showProceedDialog(proceedCallback) {
     jQuery("#ticklerProceedDialog").dialog("option", "buttons", {
         "Yes, proceed": function() {
-            markTicklerDialogButton();
+            _ticklerIntegration.markDialogButton();
             jQuery(this).dialog("close");
             proceedCallback();
         },
         "No, cancel": function() {
-            markTicklerDialogButton();
+            _ticklerIntegration.markDialogButton();
             jQuery(this).dialog("close");
-            resetTicklerHandled();
+            _ticklerIntegration.resetHandled();
         }
     });
     jQuery("#ticklerProceedDialog").dialog("open");
@@ -824,7 +843,7 @@ function promptTicklerAutoSave(proceedCallback) {
                 jQuery("#ticklerViewLink").attr("href", viewUrl);
                 jQuery("#ticklerAutoSaveSuccessDialog").dialog("option", "buttons", {
                     "OK": function() {
-                        markTicklerDialogButton();
+                        _ticklerIntegration.markDialogButton();
                         jQuery(this).dialog("close");
                         proceedCallback();
                     }
@@ -856,14 +875,14 @@ function showTicklerError(detail, proceedCallback) {
     jQuery("#ticklerErrorDetail").text(detail);
     jQuery("#ticklerAutoSaveErrorDialog").dialog("option", "buttons", {
         "OK (proceed anyway)": function() {
-            markTicklerDialogButton();
+            _ticklerIntegration.markDialogButton();
             jQuery(this).dialog("close");
             proceedCallback();
         },
         "Cancel": function() {
-            markTicklerDialogButton();
+            _ticklerIntegration.markDialogButton();
             jQuery(this).dialog("close");
-            resetTicklerHandled();
+            _ticklerIntegration.resetHandled();
         }
     });
     jQuery("#ticklerAutoSaveErrorDialog").dialog("open");

--- a/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
+++ b/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
@@ -659,7 +659,7 @@ function initTicklerDialogs() {
     jQuery("#ticklerConfirmDialog").dialog({
         autoOpen: false,
         modal: true,
-        width: 400,
+        width: 420,
         buttons: {},
         close: ticklerDialogClose
     });
@@ -667,7 +667,7 @@ function initTicklerDialogs() {
     jQuery("#ticklerProceedDialog").dialog({
         autoOpen: false,
         modal: true,
-        width: 400,
+        width: 420,
         buttons: {},
         close: ticklerDialogClose
     });

--- a/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
+++ b/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
@@ -40,6 +40,51 @@ document.addEventListener("DOMContentLoaded", function(){
 	if (isSuccessAndAutoclose) {
 		showSuccessAlert(remoteClose);
 	}
+
+	// Tickler integration: wrap toolbar actions if eForm has tickler tags
+	var ticklerMode = hasTicklerTags();
+	if (ticklerMode) {
+		initTicklerDialogs();
+
+		// _ticklerHandled stays true during one action chain (e.g. Print→Save)
+		// so Save doesn't re-trigger the dialog when called internally by Print.
+		// resetTicklerHandled() clears it after the chain completes or is canceled.
+		var _ticklerHandled = false;
+		window.resetTicklerHandled = function() { _ticklerHandled = false; };
+
+		var _origSave = remoteSave;
+		var _origPrint = remotePrint;
+		var _origDownload = remoteDownload;
+		var _origFax = remoteFax;
+		var _origEmail = remoteEmail;
+		var _origEdocument = remoteEdocument;
+
+		function wrapWithTicklerCheck(originalFn) {
+			return function() {
+				if (_ticklerHandled) {
+					return originalFn.apply(this, arguments);
+				}
+				_ticklerHandled = true;
+				var args = arguments;
+				var self = this;
+				var proceedCallback = function() {
+					originalFn.apply(self, args);
+				};
+				if (ticklerMode === "autoOpen") {
+					promptTicklerAutoOpen(proceedCallback);
+				} else if (ticklerMode === "autoSave") {
+					promptTicklerAutoSave(proceedCallback);
+				}
+			};
+		}
+
+		window.remoteSave = wrapWithTicklerCheck(_origSave);
+		window.remotePrint = wrapWithTicklerCheck(_origPrint);
+		window.remoteDownload = wrapWithTicklerCheck(_origDownload);
+		window.remoteFax = wrapWithTicklerCheck(_origFax);
+		window.remoteEmail = wrapWithTicklerCheck(_origEmail);
+		window.remoteEdocument = wrapWithTicklerCheck(_origEdocument);
+	}
 	});
 
 window.onerror = function uncaughtExceptionHandler(message, source, lineNumber, colno, error) {
@@ -481,6 +526,345 @@ function remoteEdocument() {
  */
 function remoteClose() {
     window.close();
+}
+
+// ============================================================
+// Tickler Integration for eForms
+// Supports two modes via hidden input tags in the eForm HTML:
+//   - ticklerAutoOpen: interactive popup (ticklerAdd.jsp)
+//   - ticklerAutoSave: silent REST creation with confirmation
+// ============================================================
+
+/**
+ * Detects whether this eForm has tickler integration tags.
+ * Returns "autoOpen", "autoSave", or null.
+ * Skips if the eForm Generator's tickler function is present (conflict guard).
+ */
+function hasTicklerTags() {
+    if (typeof setAtickler === 'function') {
+        return null;
+    }
+    var autoOpen = document.getElementById("ticklerAutoOpen");
+    if (autoOpen && autoOpen.value && autoOpen.value.toLowerCase() === "true") {
+        return "autoOpen";
+    }
+    var autoSave = document.getElementById("ticklerAutoSave");
+    if (autoSave && autoSave.value && autoSave.value.toLowerCase() === "true") {
+        return "autoSave";
+    }
+    return null;
+}
+
+/**
+ * Reads a hidden input value from the eForm, returning a default if not found.
+ */
+function getTicklerFieldValue(fieldId, defaultValue) {
+    var el = document.getElementById(fieldId);
+    if (el && el.value && el.value.trim() !== "") {
+        return el.value.trim();
+    }
+    return defaultValue;
+}
+
+/**
+ * Collects tickler data from hidden inputs in the eForm.
+ */
+function collectTicklerData() {
+    var today = new Date();
+    var yyyy = today.getFullYear();
+    var mm = String(today.getMonth() + 1).padStart(2, '0');
+    var dd = String(today.getDate()).padStart(2, '0');
+    var todayStr = yyyy + '-' + mm + '-' + dd;
+
+    return {
+        demographicNo: getTicklerFieldValue("demographicNo", ""),
+        serviceDate: getTicklerFieldValue("ticklerServiceDate", todayStr),
+        priority: getTicklerFieldValue("ticklerPriority", "Normal"),
+        taskAssignedTo: getTicklerFieldValue("ticklerTaskAssignedTo", getTicklerFieldValue("providerNo", "")),
+        message: getTicklerFieldValue("ticklerMessage", "")
+    };
+}
+
+/**
+ * Creates a DOM element with text content and optional child elements.
+ */
+function createDialogDiv(id, title) {
+    var div = document.createElement("div");
+    div.id = id;
+    div.title = title;
+    return div;
+}
+
+/**
+ * Creates and initializes the jQuery UI dialogs used by the tickler integration.
+ */
+function initTicklerDialogs() {
+    var promptMessage = getTicklerFieldValue("ticklerPromptMessage", "Do you want to create a tickler for this eForm?");
+
+    // Confirm dialog (auto-open mode)
+    var confirmDiv = createDialogDiv("ticklerConfirmDialog", "Create Tickler");
+    var confirmP = document.createElement("p");
+    confirmP.textContent = promptMessage;
+    confirmDiv.appendChild(confirmP);
+    document.body.appendChild(confirmDiv);
+
+    // Proceed dialog (after popup closes)
+    var proceedDiv = createDialogDiv("ticklerProceedDialog", "Continue");
+    var proceedP = document.createElement("p");
+    proceedP.textContent = "The tickler window has closed. Ready to proceed with saving?";
+    proceedDiv.appendChild(proceedP);
+    document.body.appendChild(proceedDiv);
+
+    // Auto-save success dialog
+    var successDiv = createDialogDiv("ticklerAutoSaveSuccessDialog", "Tickler Created");
+    var successP1 = document.createElement("p");
+    successP1.textContent = "A tickler has been automatically created. ";
+    var viewLink = document.createElement("a");
+    viewLink.id = "ticklerViewLink";
+    viewLink.href = "#";
+    viewLink.target = "_blank";
+    viewLink.textContent = "Click here to view it.";
+    successP1.appendChild(viewLink);
+    successDiv.appendChild(successP1);
+    var successP2 = document.createElement("p");
+    successP2.textContent = "Click OK to proceed.";
+    successDiv.appendChild(successP2);
+    document.body.appendChild(successDiv);
+
+    // Auto-save error dialog
+    var errorDiv = createDialogDiv("ticklerAutoSaveErrorDialog", "Tickler Error");
+    var errorP1 = document.createElement("p");
+    errorP1.textContent = "Tickler creation failed: ";
+    var errorDetail = document.createElement("span");
+    errorDetail.id = "ticklerErrorDetail";
+    errorP1.appendChild(errorDetail);
+    errorDiv.appendChild(errorP1);
+    var errorP2 = document.createElement("p");
+    errorP2.textContent = "Click OK to proceed anyway, or Cancel to stop.";
+    errorDiv.appendChild(errorP2);
+    document.body.appendChild(errorDiv);
+
+    // _ticklerDialogButtonClicked tracks whether a dialog was closed by a
+    // button callback (true) vs the X button or Escape key (false).
+    // Only the X/Escape path should reset the handled flag.
+    window._ticklerDialogButtonClicked = false;
+
+    function ticklerDialogClose() {
+        if (!window._ticklerDialogButtonClicked) {
+            resetTicklerHandled();
+        }
+        window._ticklerDialogButtonClicked = false;
+    }
+
+    jQuery("#ticklerConfirmDialog").dialog({
+        autoOpen: false,
+        modal: true,
+        width: 400,
+        buttons: {},
+        close: ticklerDialogClose
+    });
+
+    jQuery("#ticklerProceedDialog").dialog({
+        autoOpen: false,
+        modal: true,
+        width: 400,
+        buttons: {},
+        close: ticklerDialogClose
+    });
+
+    jQuery("#ticklerAutoSaveSuccessDialog").dialog({
+        autoOpen: false,
+        modal: true,
+        width: 420,
+        buttons: {},
+        close: ticklerDialogClose
+    });
+
+    jQuery("#ticklerAutoSaveErrorDialog").dialog({
+        autoOpen: false,
+        modal: true,
+        width: 420,
+        buttons: {},
+        close: ticklerDialogClose
+    });
+
+    // Style dialog close (X) buttons to fix Bootstrap/jQuery UI CSS conflict
+    styleTicklerDialogCloseButton("#ticklerConfirmDialog");
+    styleTicklerDialogCloseButton("#ticklerProceedDialog");
+    styleTicklerDialogCloseButton("#ticklerAutoSaveSuccessDialog");
+    styleTicklerDialogCloseButton("#ticklerAutoSaveErrorDialog");
+}
+
+/**
+ * Styles a jQuery UI dialog close button with an X character instead of the
+ * default icon sprite. Resolves the Bootstrap/jQuery UI CSS conflict where
+ * the close icon renders as an empty square.
+ */
+function styleTicklerDialogCloseButton(dialogSelector) {
+    jQuery(dialogSelector).on("dialogopen", function() {
+        var closeBtn = jQuery(this).parent().find(".ui-dialog-titlebar-close");
+        closeBtn.empty().css({
+            "background": "none",
+            "border": "none",
+            "font-size": "21px",
+            "font-weight": "bold",
+            "line-height": "1",
+            "color": "#000",
+            "opacity": "0.2",
+            "padding": "0",
+            "width": "auto",
+            "height": "auto",
+            "cursor": "pointer",
+            "position": "absolute",
+            "right": "10px",
+            "top": "50%",
+            "transform": "translateY(-50%)"
+        }).text("\u00D7").hover(
+            function() { jQuery(this).css("opacity", "0.5"); },
+            function() { jQuery(this).css("opacity", "0.2"); }
+        );
+    });
+}
+
+/**
+ * Auto-open flow: shows a confirm dialog, then opens ticklerAdd.jsp in a popup.
+ * After the popup closes, asks the user if they want to proceed with the original action.
+ */
+function promptTicklerAutoOpen(proceedCallback) {
+    jQuery("#ticklerConfirmDialog").dialog("option", "buttons", {
+        "Yes": function() {
+            window._ticklerDialogButtonClicked = true;
+            jQuery(this).dialog("close");
+            openTicklerPopup(proceedCallback);
+        },
+        "No": function() {
+            window._ticklerDialogButtonClicked = true;
+            jQuery(this).dialog("close");
+            proceedCallback();
+        }
+    });
+    jQuery("#ticklerConfirmDialog").dialog("open");
+}
+
+/**
+ * Opens ticklerAdd.jsp in a popup window with pre-populated params.
+ * Passes updateParent=false so that dbTicklerAdd.jsp does not reload the
+ * opener window (which would destroy our poll timer and proceed callback).
+ * Polls for popup close, then shows the proceed dialog.
+ */
+function openTicklerPopup(proceedCallback) {
+    var data = collectTicklerData();
+    var contextPath = getTicklerFieldValue("context", "");
+    var params = "demographic_no=" + encodeURIComponent(data.demographicNo)
+        + "&ticklerMessage=" + encodeURIComponent(data.message)
+        + "&taskTo=" + encodeURIComponent(data.taskAssignedTo)
+        + "&priority=" + encodeURIComponent(data.priority)
+        + "&updateParent=false";
+
+    var url = contextPath + "/tickler/ticklerAdd.jsp?" + params;
+    var popup = window.open(url, "ticklerPopup", "height=600,width=800,scrollbars=yes,resizable=yes");
+
+    var pollTimer = setInterval(function() {
+        if (!popup || popup.closed) {
+            clearInterval(pollTimer);
+            showProceedDialog(proceedCallback);
+        }
+    }, 500);
+}
+
+/**
+ * After the tickler popup closes, asks the user if they want to proceed.
+ */
+function showProceedDialog(proceedCallback) {
+    jQuery("#ticklerProceedDialog").dialog("option", "buttons", {
+        "Yes, proceed": function() {
+            window._ticklerDialogButtonClicked = true;
+            jQuery(this).dialog("close");
+            proceedCallback();
+        },
+        "No, cancel": function() {
+            window._ticklerDialogButtonClicked = true;
+            jQuery(this).dialog("close");
+            resetTicklerHandled();
+        }
+    });
+    jQuery("#ticklerProceedDialog").dialog("open");
+}
+
+/**
+ * Auto-save flow: silently creates a tickler via REST, then shows success or error dialog.
+ */
+function promptTicklerAutoSave(proceedCallback) {
+    var data = collectTicklerData();
+    var contextPath = getTicklerFieldValue("context", "");
+
+    var serviceDate = new Date(data.serviceDate + "T00:00:00");
+
+    var payload = {
+        demographicNo: data.demographicNo,
+        message: data.message,
+        taskAssignedTo: data.taskAssignedTo,
+        priority: data.priority,
+        serviceDate: serviceDate.toISOString(),
+        status: "A"
+    };
+
+    jQuery.ajax({
+        url: contextPath + "/ws/rs/tickler/add",
+        type: "POST",
+        contentType: "application/json",
+        data: JSON.stringify(payload),
+        dataType: "json",
+        success: function(resp) {
+            if (resp && resp.success) {
+                var ticklerId = resp.message;
+                var viewUrl = contextPath + "/tickler/ticklerEdit.jsp?tickler_no=" + encodeURIComponent(ticklerId);
+                jQuery("#ticklerViewLink").attr("href", viewUrl);
+                jQuery("#ticklerAutoSaveSuccessDialog").dialog("option", "buttons", {
+                    "OK": function() {
+                        window._ticklerDialogButtonClicked = true;
+                        jQuery(this).dialog("close");
+                        proceedCallback();
+                    }
+                });
+                jQuery("#ticklerAutoSaveSuccessDialog").dialog("open");
+            } else {
+                showTicklerError("Server returned unsuccessful response.", proceedCallback);
+            }
+        },
+        error: function(xhr) {
+            var detail = "HTTP " + xhr.status;
+            if (xhr.responseText) {
+                try {
+                    var errResp = JSON.parse(xhr.responseText);
+                    if (errResp.message) detail = errResp.message;
+                } catch (e) {
+                    // use default detail
+                }
+            }
+            showTicklerError(detail, proceedCallback);
+        }
+    });
+}
+
+/**
+ * Shows the error dialog for auto-save failures.
+ */
+function showTicklerError(detail, proceedCallback) {
+    jQuery("#ticklerErrorDetail").text(detail);
+    jQuery("#ticklerAutoSaveErrorDialog").dialog("option", "buttons", {
+        "OK (proceed anyway)": function() {
+            window._ticklerDialogButtonClicked = true;
+            jQuery(this).dialog("close");
+            proceedCallback();
+        },
+        "Cancel": function() {
+            window._ticklerDialogButtonClicked = true;
+            jQuery(this).dialog("close");
+            resetTicklerHandled();
+        }
+    });
+    jQuery("#ticklerAutoSaveErrorDialog").dialog("open");
 }
 
 /**

--- a/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
+++ b/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
@@ -86,8 +86,11 @@ document.addEventListener("DOMContentLoaded", function(){
 				const self = this;
 				const proceedCallback = function() {
 					_ticklerState = "proceeding";
-					originalFn.apply(self, args);
-					_ticklerIntegration.resetHandled();
+					try {
+						originalFn.apply(self, args);
+					} finally {
+						window._ticklerIntegration.resetHandled();
+					}
 				};
 				if (currentMode === "autoOpen") {
 					promptTicklerAutoOpen(proceedCallback);
@@ -614,7 +617,8 @@ function collectTicklerData() {
 }
 
 /**
- * Creates a DOM element with text content and optional child elements.
+ * Creates a div element with the given id and title attribute, used as a
+ * container for jQuery UI dialogs (the title becomes the dialog's titlebar).
  */
 function createDialogDiv(id, title) {
     const div = document.createElement("div");
@@ -681,11 +685,11 @@ function initTicklerDialogs() {
     // X button or Escape key (false). Scoped to this closure to avoid globals.
     let _dialogButtonClicked = false;
 
-    _ticklerIntegration.markDialogButton = function() { _dialogButtonClicked = true; };
+    window._ticklerIntegration.markDialogButton = function() { _dialogButtonClicked = true; };
 
     function ticklerDialogClose() {
         if (!_dialogButtonClicked) {
-            _ticklerIntegration.resetHandled();
+            window._ticklerIntegration.resetHandled();
         }
         _dialogButtonClicked = false;
     }
@@ -740,14 +744,25 @@ function styleTicklerDialogCloseButton(dialogSelector) {
         const titlebar = jQuery(this).parent().find(".ui-dialog-titlebar");
         titlebar.css("padding", "10px 14px");
         closeBtn.empty()
-            .removeClass("ui-button-icon-only ui-button-icon ui-icon ui-icon-closethick")
-            .addClass("btn-close")
+            .removeClass("ui-button ui-corner-all ui-widget ui-button-icon-only ui-button-icon ui-icon ui-icon-closethick")
             .attr("aria-label", "Close")
+            .text("×")
             .css({
                 "position": "absolute",
-                "right": "14px",
+                "right": "10px",
                 "top": "50%",
-                "transform": "translateY(-50%)"
+                "transform": "translateY(-50%)",
+                "width": "30px",
+                "height": "30px",
+                "padding": "0",
+                "font-size": "30px",
+                "line-height": "30px",
+                "text-align": "center",
+                "color": "#555",
+                "background": "transparent",
+                "border": "none",
+                "border-radius": "4px",
+                "cursor": "pointer"
             });
     });
 }
@@ -759,12 +774,12 @@ function styleTicklerDialogCloseButton(dialogSelector) {
 function promptTicklerAutoOpen(proceedCallback) {
     jQuery("#ticklerConfirmDialog").dialog("option", "buttons", {
         "Yes": function() {
-            _ticklerIntegration.markDialogButton();
+            window._ticklerIntegration.markDialogButton();
             jQuery(this).dialog("close");
             openTicklerPopup(proceedCallback);
         },
         "No": function() {
-            _ticklerIntegration.markDialogButton();
+            window._ticklerIntegration.markDialogButton();
             jQuery(this).dialog("close");
             proceedCallback();
         }
@@ -784,28 +799,56 @@ function openTicklerPopup(proceedCallback) {
     const data = collectTicklerData();
     const contextPath = getTicklerFieldValue("context", "");
     const params = "demographic_no=" + encodeURIComponent(data.demographicNo)
-        + "&ticklerMessage=" + encodeURIComponent(data.message)
         + "&taskTo=" + encodeURIComponent(data.taskAssignedTo)
         + "&priority=" + encodeURIComponent(data.priority)
         + "&xml_appointment_date=" + encodeURIComponent(data.serviceDate)
         + "&updateParent=false"
         + "&parentAjaxId=";
 
+    // Pass the tickler message via opener (same-origin) instead of the URL,
+    // since it may contain PHI that would otherwise leak into access logs and
+    // browser history. ticklerAdd.jsp reads window.opener._eformTicklerPrefillMessage.
+    window._eformTicklerPrefillMessage = data.message;
+
     const url = contextPath + "/tickler/ticklerAdd.jsp?" + params;
     const popup = window.open(url, "ticklerPopup", "height=600,width=800,scrollbars=yes,resizable=yes");
 
     if (!popup) {
         alert("The tickler popup was blocked by your browser. Please allow popups for this site and try again.");
-        _ticklerIntegration.resetHandled();
+        window._ticklerIntegration.resetHandled();
         return;
     }
+
+    // Keep the modal overlay visible while the tickler popup is open, so the
+    // parent page stays visually "locked" between the confirm dialog and the
+    // proceed dialog (which would otherwise leave a gap with no overlay).
+    showTicklerWaitingOverlay();
 
     const pollTimer = setInterval(function() {
         if (popup.closed) {
             clearInterval(pollTimer);
+            hideTicklerWaitingOverlay();
             showProceedDialog(proceedCallback);
         }
     }, 500);
+}
+
+/**
+ * Adds a manual overlay div mirroring jQuery UI's modal overlay, used to keep
+ * the parent page dimmed while the tickler popup window is open (no jQuery UI
+ * dialog is active during that phase, so its overlay would otherwise vanish).
+ */
+function showTicklerWaitingOverlay() {
+    if (document.getElementById("ticklerWaitingOverlay")) return;
+    const overlay = document.createElement("div");
+    overlay.id = "ticklerWaitingOverlay";
+    overlay.className = "ui-widget-overlay";
+    document.body.appendChild(overlay);
+}
+
+function hideTicklerWaitingOverlay() {
+    const overlay = document.getElementById("ticklerWaitingOverlay");
+    if (overlay) overlay.parentNode.removeChild(overlay);
 }
 
 /**
@@ -814,14 +857,14 @@ function openTicklerPopup(proceedCallback) {
 function showProceedDialog(proceedCallback) {
     jQuery("#ticklerProceedDialog").dialog("option", "buttons", {
         "Yes, proceed": function() {
-            _ticklerIntegration.markDialogButton();
+            window._ticklerIntegration.markDialogButton();
             jQuery(this).dialog("close");
             proceedCallback();
         },
         "No, cancel": function() {
-            _ticklerIntegration.markDialogButton();
+            window._ticklerIntegration.markDialogButton();
             jQuery(this).dialog("close");
-            _ticklerIntegration.resetHandled();
+            window._ticklerIntegration.resetHandled();
         }
     });
     jQuery("#ticklerProceedDialog").dialog("open");
@@ -864,14 +907,17 @@ function promptTicklerAutoSave(proceedCallback) {
                 jQuery("#ticklerViewLink").attr("href", viewUrl);
                 jQuery("#ticklerAutoSaveSuccessDialog").dialog("option", "buttons", {
                     "OK": function() {
-                        _ticklerIntegration.markDialogButton();
+                        window._ticklerIntegration.markDialogButton();
                         jQuery(this).dialog("close");
                         proceedCallback();
                     }
                 });
                 jQuery("#ticklerAutoSaveSuccessDialog").dialog("open");
             } else {
-                showTicklerError("Server returned unsuccessful response.", proceedCallback);
+                const detail = (resp && resp.message)
+                    ? resp.message
+                    : "Server returned unsuccessful response.";
+                showTicklerError(detail, proceedCallback);
             }
         },
         error: function(xhr) {
@@ -896,14 +942,14 @@ function showTicklerError(detail, proceedCallback) {
     jQuery("#ticklerErrorDetail").text(detail);
     jQuery("#ticklerAutoSaveErrorDialog").dialog("option", "buttons", {
         "OK (proceed anyway)": function() {
-            _ticklerIntegration.markDialogButton();
+            window._ticklerIntegration.markDialogButton();
             jQuery(this).dialog("close");
             proceedCallback();
         },
         "Cancel": function() {
-            _ticklerIntegration.markDialogButton();
+            window._ticklerIntegration.markDialogButton();
             jQuery(this).dialog("close");
-            _ticklerIntegration.resetHandled();
+            window._ticklerIntegration.resetHandled();
         }
     });
     jQuery("#ticklerAutoSaveErrorDialog").dialog("open");

--- a/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
+++ b/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
@@ -623,12 +623,10 @@ function createDialogDiv(id, title) {
 function initTicklerDialogs() {
     if (document.getElementById("ticklerConfirmDialog")) return;
 
-    const promptMessage = getTicklerFieldValue("ticklerPromptMessage", "Do you want to create a tickler first?");
-
     // Confirm dialog (auto-open mode)
     const confirmDiv = createDialogDiv("ticklerConfirmDialog", "Create Tickler");
     const confirmP = document.createElement("p");
-    confirmP.textContent = promptMessage;
+    confirmP.id = "ticklerConfirmMessage";
     confirmDiv.appendChild(confirmP);
     document.body.appendChild(confirmDiv);
 
@@ -759,6 +757,8 @@ function promptTicklerAutoOpen(proceedCallback) {
             _ticklerIntegration.resetHandled();
         }
     });
+    document.getElementById("ticklerConfirmMessage").textContent =
+        getTicklerFieldValue("ticklerPromptMessage", "Do you want to create a tickler first?");
     jQuery("#ticklerConfirmDialog").dialog("open");
 }
 
@@ -776,7 +776,8 @@ function openTicklerPopup(proceedCallback) {
         + "&taskTo=" + encodeURIComponent(data.taskAssignedTo)
         + "&priority=" + encodeURIComponent(data.priority)
         + "&xml_appointment_date=" + encodeURIComponent(data.serviceDate)
-        + "&updateParent=false";
+        + "&updateParent=false"
+        + "&parentAjaxId=";
 
     const url = contextPath + "/tickler/ticklerAdd.jsp?" + params;
     const popup = window.open(url, "ticklerPopup", "height=600,width=800,scrollbars=yes,resizable=yes");
@@ -804,6 +805,7 @@ function showProceedDialog(proceedCallback) {
             _ticklerIntegration.markDialogButton();
             jQuery(this).dialog("close");
             proceedCallback();
+            _ticklerIntegration.resetHandled();
         },
         "No, cancel": function() {
             _ticklerIntegration.markDialogButton();
@@ -846,6 +848,7 @@ function promptTicklerAutoSave(proceedCallback) {
                         _ticklerIntegration.markDialogButton();
                         jQuery(this).dialog("close");
                         proceedCallback();
+                        _ticklerIntegration.resetHandled();
                     }
                 });
                 jQuery("#ticklerAutoSaveSuccessDialog").dialog("open");
@@ -878,6 +881,7 @@ function showTicklerError(detail, proceedCallback) {
             _ticklerIntegration.markDialogButton();
             jQuery(this).dialog("close");
             proceedCallback();
+            _ticklerIntegration.resetHandled();
         },
         "Cancel": function() {
             _ticklerIntegration.markDialogButton();

--- a/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
+++ b/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
@@ -633,9 +633,10 @@ function createDialogDiv(id, title) {
 function initTicklerDialogs() {
     if (document.getElementById("ticklerConfirmDialog")) return;
 
-    // Fix near-invisible modal overlay (theme CSS sets opacity to .003)
+    // Scoped overlay style so we don't override every jQuery UI dialog overlay
+    // app-wide. Applied only to overlays we tag with the tickler-overlay class.
     const overlayStyle = document.createElement("style");
-    overlayStyle.textContent = ".ui-widget-overlay { background: #000 !important; opacity: 0.4 !important; }";
+    overlayStyle.textContent = ".tickler-overlay { background: #000 !important; opacity: 0.4 !important; }";
     document.head.appendChild(overlayStyle);
 
     // Confirm dialog (auto-open mode)
@@ -740,29 +741,24 @@ function initTicklerDialogs() {
  */
 function styleTicklerDialogCloseButton(dialogSelector) {
     jQuery(dialogSelector).on("dialogopen", function() {
+        // Tag the overlay so our scoped CSS rule applies (jQuery UI creates
+        // a fresh overlay element each time a modal dialog opens).
+        jQuery(".ui-widget-overlay").last().addClass("tickler-overlay");
+
         const closeBtn = jQuery(this).parent().find(".ui-dialog-titlebar-close");
         const titlebar = jQuery(this).parent().find(".ui-dialog-titlebar");
         titlebar.css("padding", "10px 14px");
         closeBtn.empty()
-            .removeClass("ui-button ui-corner-all ui-widget ui-button-icon-only ui-button-icon ui-icon ui-icon-closethick")
+            .removeClass("ui-button-icon-only ui-button-icon ui-icon ui-icon-closethick")
             .attr("aria-label", "Close")
             .text("×")
             .css({
-                "position": "absolute",
-                "right": "10px",
+                "width": "24px",
+                "height": "24px",
+                "font-size": "18px",
+                "line-height": "1",
                 "top": "50%",
-                "transform": "translateY(-50%)",
-                "width": "30px",
-                "height": "30px",
-                "padding": "0",
-                "font-size": "30px",
-                "line-height": "30px",
-                "text-align": "center",
-                "color": "#555",
-                "background": "transparent",
-                "border": "none",
-                "border-radius": "4px",
-                "cursor": "pointer"
+                "margin-top": "-12px"
             });
     });
 }
@@ -842,7 +838,7 @@ function showTicklerWaitingOverlay() {
     if (document.getElementById("ticklerWaitingOverlay")) return;
     const overlay = document.createElement("div");
     overlay.id = "ticklerWaitingOverlay";
-    overlay.className = "ui-widget-overlay";
+    overlay.className = "ui-widget-overlay tickler-overlay";
     document.body.appendChild(overlay);
 }
 
@@ -902,7 +898,11 @@ function promptTicklerAutoSave(proceedCallback) {
         dataType: "json",
         success: function(resp) {
             if (resp && resp.success) {
-                const ticklerId = resp.message;
+                const ticklerId = (resp.message != null) ? String(resp.message).trim() : "";
+                if (!ticklerId) {
+                    showTicklerError("Server reported success but did not return a tickler id.", proceedCallback);
+                    return;
+                }
                 const viewUrl = contextPath + "/tickler/ticklerEdit.jsp?tickler_no=" + encodeURIComponent(ticklerId);
                 jQuery("#ticklerViewLink").attr("href", viewUrl);
                 jQuery("#ticklerAutoSaveSuccessDialog").dialog("option", "buttons", {

--- a/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
+++ b/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
@@ -703,26 +703,12 @@ function initTicklerDialogs() {
 function styleTicklerDialogCloseButton(dialogSelector) {
     jQuery(dialogSelector).on("dialogopen", function() {
         var closeBtn = jQuery(this).parent().find(".ui-dialog-titlebar-close");
-        closeBtn.empty().css({
-            "background": "none",
-            "border": "none",
-            "font-size": "21px",
-            "font-weight": "bold",
-            "line-height": "1",
-            "color": "#000",
-            "opacity": "0.2",
-            "padding": "0",
-            "width": "auto",
-            "height": "auto",
-            "cursor": "pointer",
+        closeBtn.empty().removeClass().addClass("btn-close").css({
             "position": "absolute",
-            "right": "10px",
+            "right": "12px",
             "top": "50%",
             "transform": "translateY(-50%)"
-        }).text("\u00D7").hover(
-            function() { jQuery(this).css("opacity", "0.5"); },
-            function() { jQuery(this).css("opacity", "0.2"); }
-        );
+        });
     });
 }
 

--- a/src/main/webapp/tickler/ticklerAdd.jsp
+++ b/src/main/webapp/tickler/ticklerAdd.jsp
@@ -145,9 +145,6 @@
     if (request.getParameter("priority") != null) priority = request.getParameter("priority");
     if (request.getParameter("recall") != null) recall = true;
 
-    String ticklerMessage = request.getParameter("ticklerMessage");
-    if (ticklerMessage == null) ticklerMessage = "";
-
     UserProperty prop = propertyDao.getProp(user_no, UserProperty.TICKLER_TASK_ASSIGNEE);
     //don't override taskTo query param
     if (request.getParameter("taskTo") == null) {
@@ -455,11 +452,28 @@
             }
         }
 
+        // Prefill the message from the opener (same-origin, in-memory) instead of
+        // a URL parameter, since it may contain PHI.
+        function applyOpenerTicklerPrefill() {
+          try {
+            if (window.opener && typeof window.opener._eformTicklerPrefillMessage === 'string') {
+              var textarea = document.getElementById('ticklerMessage');
+              if (textarea) {
+                textarea.value = window.opener._eformTicklerPrefillMessage;
+              }
+              delete window.opener._eformTicklerPrefillMessage;
+            }
+          } catch (e) {
+            // Cross-origin or no opener: nothing to prefill.
+          }
+        }
+
         // on load
         document.addEventListener('DOMContentLoaded', function() {
           addQuickPick();
           setfocus();
           initResize();
+          applyOpenerTicklerPrefill();
         });
         </script>
 
@@ -726,7 +740,7 @@
                       <label for="ticklerMessage"><fmt:setBundle basename="oscarResources"/><fmt:message key="tickler.ticklerAdd.formReminder"/>:</label>
                       </td>
                     <td>
-                      <textarea name="ticklerMessage" id="ticklerMessage" class="form-control"><%=Encode.forHtmlContent(ticklerMessage)%></textarea>
+                      <textarea name="ticklerMessage" id="ticklerMessage" class="form-control"></textarea>
                     </td>
                 </tr>
                 <tr>

--- a/src/main/webapp/tickler/ticklerAdd.jsp
+++ b/src/main/webapp/tickler/ticklerAdd.jsp
@@ -145,6 +145,9 @@
     if (request.getParameter("priority") != null) priority = request.getParameter("priority");
     if (request.getParameter("recall") != null) recall = true;
 
+    String ticklerMessage = request.getParameter("ticklerMessage");
+    if (ticklerMessage == null) ticklerMessage = "";
+
     UserProperty prop = propertyDao.getProp(user_no, UserProperty.TICKLER_TASK_ASSIGNEE);
     //don't override taskTo query param
     if (request.getParameter("taskTo") == null) {
@@ -723,7 +726,7 @@
                       <label for="ticklerMessage"><fmt:setBundle basename="oscarResources"/><fmt:message key="tickler.ticklerAdd.formReminder"/>:</label>
                       </td>
                     <td>
-                      <textarea name="ticklerMessage" id="ticklerMessage" class="form-control"></textarea>
+                      <textarea name="ticklerMessage" id="ticklerMessage" class="form-control"><%=Encode.forHtmlContent(ticklerMessage)%></textarea>
                     </td>
                 </tr>
                 <tr>


### PR DESCRIPTION
## Summary

Adds tickler integration tags to eForms so authors can configure a form to prompt for or silently create a tickler when any toolbar action runs (Save, Print, Download, Fax, Email, Add to Documents). Supports an interactive **Auto-Open** mode (opens the existing Add Tickler window pre-filled) and an **Auto-Save** mode (creates the tickler via REST and links to it from a confirmation dialog).

## User-facing changes

- New optional hidden-input tags on eForms control tickler behavior:
  - `ticklerAutoOpen` (`true`/`false`) — opens the Add Tickler window pre-filled
  - `ticklerAutoSave` (`true`/`false`) — silently creates the tickler via REST
  - `ticklerServiceDate`, `ticklerPriority`, `ticklerAssignedTo`, `ticklerMessage`, `ticklerPromptMessage` — optional pre-population
- Default behavior unchanged: eForms with no tickler tags work exactly as before.
- All 6 toolbar actions trigger the configured flow once per click chain (Print → Save only prompts once).
- **Auto-Open:** confirm dialog → tickler popup pre-filled → "Ready to proceed?" dialog → original action runs (or cancels).
- **Auto-Save:** REST POST to `/ws/rs/tickler/add` → success dialog with "Click here to view" deep link → original action runs.
- Cancellation (X / Escape / "No") fully resets the flow so the next toolbar click prompts again.
- eForm Generator forms (those with `setAtickler()`) are auto-detected and skipped to avoid colliding with the Generator's existing tickler mechanism.

### Confirm dialog (Auto-Open)
<img width="466" height="202" alt="image" src="https://github.com/user-attachments/assets/71fe0d37-bbc3-45af-b070-1e5982fb344c" />

### Tickler Window Closed dialog (Auto-Open)
<img width="449" height="190" alt="image" src="https://github.com/user-attachments/assets/e7597541-d68d-4637-951b-8ef20bef3454" />

### Tickler Created dialog (Auto-Save)
<img width="478" height="243" alt="image" src="https://github.com/user-attachments/assets/9be33665-9dce-4687-ab6f-63f43172248f" />

### Tickler Error dialog (Auto-Save)
<img width="458" height="217" alt="image" src="https://github.com/user-attachments/assets/8e0fe41e-3b85-453d-b609-dc8057e5fd34" />

## Implementation approach

### Toolbar JS — wrapping pattern

`eform_floating_toolbar.js` wraps the 6 `remoteX` toolbar functions with `wrapWithTicklerCheck`. The wrapper uses a closure-scoped tri-state machine (`idle` / `inProgress` / `proceeding`) so the Print → Save chain (where Print internally calls Save) only triggers the dialog once. State reset is wrapped in `try/finally` around the original action call so an unhandled exception cannot leave the toolbar stuck.

### REST contract — tickler id in response

`TicklerWebService.addTickler` now returns the new tickler's id in the `message` field of the standard `GenericRESTResponse` on success. The auto-save success dialog reads this id to build the "Click here to view" deep link, with a guard for missing/empty values. On failure the JS reads `resp.message` for the actual server error rather than showing a generic string.

### eForm display JSPs — provider context injection

`efmformadd_data.jsp` and `efmshowform_data.jsp` inject `providerNo` (the logged-in provider) as a hidden input. The toolbar uses it as the default `taskAssignedTo` when the eForm author hasn't set `ticklerAssignedTo` explicitly.

### Tickler add JSP — opener-based message prefill

`ticklerAdd.jsp` reads the prefill message from `window.opener._eformTicklerPrefillMessage` after `DOMContentLoaded` and immediately deletes it (single-use). The toolbar stashes the message on `window` before opening the popup; the URL itself never carries it.

### Dialog UX — scoped overlay and styled close button

The four jQuery UI dialogs (confirm, proceed, success, error) inject a `.tickler-overlay`-scoped style so the dim background only applies to tickler dialogs, not every modal app-wide. A manual overlay div bridges the gap between the confirm dialog closing and the popup window closing so the parent page stays visually locked. The titlebar X is hand-rendered as a `×` text character so it renders consistently after the Bootstrap 3 → 5.3.3 migration that landed mid-development.

## Privacy and PHI considerations

`ticklerMessage` may contain clinical content (the documented use case is "follow up on lab results" and similar). To keep it out of Tomcat access logs and browser history, the toolbar passes the message via `window.opener._eformTicklerPrefillMessage` rather than as a URL query parameter. The popup reads it client-side after load and deletes it. The remaining URL parameters (`demographic_no`, `taskTo`, `priority`, `xml_appointment_date`) are not PHI in the same sense and stay in the URL.

Auto-Save uses POST with the payload in the body, so no PHI ends up in a URL there either.

## Testing

### Automated

This PR is predominantly client-side (~470 lines of JavaScript orchestration). OpenO has no JS test harness, so a unit/integration suite for the toolbar wrapper would require introducing one — out of scope here. The Java change is a 2-line response field addition; its contract is exercised by the manual auto-save tests below. Recommendation: revisit if a JS test framework lands in the project.

### Manual smoke tests performed

- Auto-Open happy path — confirm → popup pre-filled → save tickler → proceed → original action runs ✓
- Auto-Open cancel — proceed dialog "No, cancel" stops the original action ✓
- Auto-Save happy path — silent creation → success dialog → "Click here to view" opens the new tickler → OK proceeds ✓
- Auto-Save failure (DevTools response override) — actual server message surfaces; guard fires for empty `resp.message` ✓
- No-tickler-tags eForm — unchanged behavior, no dialogs ✓
- eForm Generator (setAtickler present) — skipped, no interference ✓
- All 6 toolbar actions trigger the flow ✓
- Print → Save chain — dialog appears once, not twice ✓
- Special characters in `ticklerMessage` (quotes, ampersands, `<`/`>`, newlines) round-trip verbatim ✓
- Re-open after cancel — closing a popup without saving and re-clicking re-shows the prompt ✓
- Overlay continuity — dim background persists across confirm → popup window → proceed dialog ✓
- Close-button × renders correctly on all four dialogs (post Bootstrap 5 migration) ✓
- Overlay scoping — non-tickler jQuery UI dialogs elsewhere in the app retain their original overlay style ✓

## Design decisions worth noting

- **Pre-action, not post-action** — the tickler flow runs *before* the eForm action, so the user can cancel and so popup blockers don't trip (the popup opens inside the user's click handler chain).
- **Tri-state machine over boolean flag** — the explicit "proceeding" state cleanly handles the Print → Save chain without per-action special cases. Could be simplified to a closure-scoped guard flag in a future refactor; kept as-is for clarity.
- **Message prefill via opener, not URL** — purely a PHI consideration (see above). Adds a microsecond client-side delay before the textarea populates; not perceptible.
- **Auto-Open precedence** — if both `ticklerAutoOpen` and `ticklerAutoSave` are `true`, auto-open wins (safer; provider reviews before saving).

## Summary by Sourcery

Integrate tickler creation workflows into eForm toolbar actions, including auto-open and auto-save modes, and wire through supporting data and REST responses.

New Features:
- Add tickler-aware wrapping of eForm toolbar actions (Save/Print/Download/Fax/Email/eDocument) with a single prompt per action chain when tickler integration tags are present.
- Support tickler auto-open and auto-save modes for eForms, driven by hidden input configuration and contextual tickler data collected from the form.
- Prefill the tickler message in ticklerAdd.jsp from an optional ticklerMessage request parameter to streamline tickler creation from eForms.

Bug Fixes:
- Ensure jQuery UI dialog close buttons render correctly as an X despite Bootstrap CSS, and standardize dialog sizing for tickler-related popups.

Enhancements:
- Return the created tickler ID in the addTickler REST response message field to enable deep-linking to the new tickler from client workflows.
- Expose providerNo as a hidden field on eForm creation and display pages for use in tickler assignment defaults.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds tickler integration to eForms with optional auto-open or auto-save and accessible dialogs. Prompts before Save/Print/Download/Fax/Email/eDocument, links to the new tickler, and skips built‑in generator tickler flows.

- New Features
  - Wraps toolbar actions with one prompt; supports auto-open (`ticklerAdd.jsp`) or auto-save (REST) with a “View” link on success; skips integration when `setAtickler` is present.
  - Detects mode and reads data at action time from hidden inputs; includes `providerNo` from session; REST returns the tickler ID only on success; `ticklerAdd.jsp` pre-fills the message via the opener to avoid PHI in URLs.

- Bug Fixes
  - Tri-state flow to handle chained actions, block inputs during dialogs, and reset after proceed/cancel; clear popup‑blocked message; prevent parent reload in auto-open (`updateParent=false`, `parentAjaxId`) and keep a scoped overlay visible while the popup is open.
  - Fixed auto-save service date by sending local midnight with timezone offset; standardized and accessible jQuery UI close “X” buttons.

<sup>Written for commit 3ae2832002958748c8073c2ddc37a55be90827f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Integrate tickler creation workflows into eForm toolbar actions and backend services, enabling optional auto-open or auto-save ticklers when eForm tags are present.

New Features:
- Add tickler-aware wrapping of eForm toolbar actions so Save/Print/Download/Fax/Email/eDocument can trigger a single tickler prompt and flow per action chain when configured.
- Support tickler auto-open via a popup and auto-save via REST for eForms, driven by hidden configuration fields and contextual data collected from the form, including provider defaults.
- Prefill tickler messages in the tickler add window using data passed from the originating eForm without exposing message content in URLs.

Bug Fixes:
- Ensure jQuery UI dialogs used for tickler flows render clear, accessible close buttons and maintain consistent modal overlays despite Bootstrap styling conflicts.
- Correct tickler service date handling in auto-save mode by sending a timezone-aware local midnight value to prevent off-by-one-day errors.

Enhancements:
- Return the newly created tickler ID in the addTickler REST response to support direct linking from auto-save confirmation dialogs.
- Expose the logged-in provider number as a hidden field on eForm create and display pages for use in tickler assignment defaults.

## Summary by Sourcery

Integrate configurable tickler workflows into eForm toolbar actions, enabling pre- or auto-creation of ticklers before Save/Print/Download/Fax/Email/Add-to-Documents operations.

New Features:
- Add tickler-aware wrapping of eForm toolbar actions to optionally prompt for or automatically create a tickler before running the action.
- Support auto-open tickler popups and auto-save REST-based tickler creation driven by hidden tickler configuration fields on eForms.
- Prefill tickler messages in the Add Tickler window using opener-provided in-memory data to avoid exposing PHI in URLs.

Bug Fixes:
- Ensure tickler-related jQuery UI dialogs render with a consistent, accessible close button despite Bootstrap styling conflicts.
- Prevent off-by-one-day tickler service dates in auto-save mode by sending timezone-aware local midnight timestamps.

Enhancements:
- Return the newly created tickler ID in the tickler add REST response to enable deep-linking from auto-save confirmations.
- Inject the logged-in provider number into eForms as a hidden field for use as a default tickler assignee.
- Scope modal overlays and waiting states for tickler dialogs so they visually lock the page without affecting other dialogs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tickler reminders integrated with toolbar actions (save, print, download, fax, email, export) with interactive dialogs and automatic creation modes
  * Provider identifier automatically captured and included in forms
  * Tickler message now pre-populates when creating a new tickler

* **Improvements**
  * More reliable tickler creation response handling and clearer success/error UX
<!-- end of auto-generated comment: release notes by coderabbit.ai -->