### PR TITLE
Feature: show providers' public and private documents in the attachment manager

### DIFF
--- a/src/main/java/ca/openosp/openo/commn/dao/CtlDocumentDao.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/CtlDocumentDao.java
@@ -12,4 +12,15 @@ public interface CtlDocumentDao extends AbstractDao<CtlDocument> {
 
     public List<CtlDocument> findByDocumentNoAndModule(Integer ctlDocNo, String module);
 
+    /**
+     * Batch lookup of ctl_document rows for a set of document IDs. Returns all
+     * bindings for each doc (including multiple ctl rows per doc when present).
+     * Used by attached-doc enrichment to classify many attachments in one query.
+     *
+     * @param documentNos List&lt;Integer&gt; document IDs to fetch ctl rows for
+     * @return List&lt;CtlDocument&gt; all ctl rows matching any of the supplied doc IDs;
+     *         empty list if {@code documentNos} is null or empty
+     */
+    public List<CtlDocument> findByDocumentNos(List<Integer> documentNos);
+
 }

--- a/src/main/java/ca/openosp/openo/commn/dao/CtlDocumentDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/CtlDocumentDaoImpl.java
@@ -2,6 +2,7 @@
 
 package ca.openosp.openo.commn.dao;
 
+import java.util.Collections;
 import java.util.List;
 
 import javax.persistence.Query;
@@ -30,6 +31,17 @@ public class CtlDocumentDaoImpl extends AbstractDaoImpl<CtlDocument> implements 
                 .createQuery("select x from CtlDocument x where x.id.documentNo=?1 and x.id.module = ?2");
         query.setParameter(1, ctlDocNo);
         query.setParameter(2, module);
+
+        @SuppressWarnings("unchecked")
+        List<CtlDocument> cList = query.getResultList();
+        return cList;
+    }
+
+    @Override
+    public List<CtlDocument> findByDocumentNos(List<Integer> documentNos) {
+        if (documentNos == null || documentNos.isEmpty()) return Collections.emptyList();
+        Query query = entityManager.createQuery("select x from CtlDocument x where x.id.documentNo in (?1)");
+        query.setParameter(1, documentNos);
 
         @SuppressWarnings("unchecked")
         List<CtlDocument> cList = query.getResultList();

--- a/src/main/java/ca/openosp/openo/commn/dao/DocumentDao.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/DocumentDao.java
@@ -91,5 +91,16 @@ public interface DocumentDao extends AbstractDao<Document> {
 
     public Document findByDemographicAndFilename(int demographicId, String fileName);
 
-    public List<Integer> findDocumentNosForDemographic(Integer demographicNo, List<Integer> docNos);
+    /**
+     * Returns the subset of {@code docNos} whose {@code ctl_document} row makes
+     * them attachable to this patient's chart — either demographic-scoped to
+     * {@code demographicNo}, or provider-library scoped (module
+     * IN ('provider','providers')). Soft-deleted ctl rows
+     * ({@code status = 'D'}) are excluded from both branches.
+     *
+     * @param demographicNo Integer patient demographic number for the demographic branch
+     * @param docNos List&lt;Integer&gt; doc IDs to check; null or empty yields an empty list
+     * @return List&lt;Integer&gt; the subset of {@code docNos} attachable to this patient's chart
+     */
+    public List<Integer> findValidAttachmentDocNos(Integer demographicNo, List<Integer> docNos);
 }

--- a/src/main/java/ca/openosp/openo/commn/dao/DocumentDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/DocumentDaoImpl.java
@@ -240,18 +240,13 @@ public class DocumentDaoImpl extends AbstractDaoImpl<Document> implements Docume
         }
     }
 
-    /**
-     * Finds all documents for the specified demographic id
-     *
-     * @param demoNo
-     */
     @SuppressWarnings("unchecked")
     @Override
-    public List<Integer> findDocumentNosForDemographic(Integer demographicNo, List<Integer> docNos) {
+    public List<Integer> findValidAttachmentDocNos(Integer demographicNo, List<Integer> docNos) {
         if (docNos == null || docNos.isEmpty()) return Collections.emptyList();
         Query query = entityManager.createQuery(
                 "SELECT c.id.documentNo FROM CtlDocument c " +
-                "WHERE c.id.module = 'demographic' AND c.id.moduleId = :demographicNo " +
+                "WHERE ((c.id.module = 'demographic' AND c.id.moduleId = :demographicNo) OR c.id.module IN ('provider','providers')) " +
                 "AND c.status != 'D' AND c.id.documentNo IN :docNos");
         query.setParameter("demographicNo", demographicNo);
         query.setParameter("docNos", docNos);

--- a/src/main/java/ca/openosp/openo/commn/dao/DocumentDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/DocumentDaoImpl.java
@@ -85,10 +85,6 @@ public class DocumentDaoImpl extends AbstractDaoImpl<Document> implements Docume
 
     @Override
     public List<Object[]> findDocsAndConsultDocsByConsultId(Integer consultationId) {
-        // Joining CtlDocument lets the attached-listing populate module/moduleId
-        // on each EDoc in a single round trip. Orphan attachments (no ctl row)
-        // have always been invisible in the attachment manager; INNER JOIN
-        // preserves that behavior.
         String sql = "SELECT d, cd, ctl FROM Document d, ConsultDocs cd, CtlDocument ctl WHERE d.documentNo = cd.documentNo AND ctl.id.documentNo = d.documentNo AND cd.requestId = ?1 AND cd.docType = ?2 AND cd.deleted IS NULL";
         Query query = entityManager.createQuery(sql);
         query.setParameter(1, consultationId);

--- a/src/main/java/ca/openosp/openo/commn/dao/DocumentDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/DocumentDaoImpl.java
@@ -85,7 +85,11 @@ public class DocumentDaoImpl extends AbstractDaoImpl<Document> implements Docume
 
     @Override
     public List<Object[]> findDocsAndConsultDocsByConsultId(Integer consultationId) {
-        String sql = "FROM Document d, ConsultDocs cd WHERE d.documentNo = cd.documentNo AND cd.requestId = ?1 AND cd.docType = ?2 AND cd.deleted IS NULL";
+        String sql = "FROM Document d, ConsultDocs cd " +
+                "WHERE d.documentNo = cd.documentNo " +
+                "AND cd.requestId = ?1 " +
+                "AND cd.docType = ?2 " +
+                "AND cd.deleted IS NULL";
         Query query = entityManager.createQuery(sql);
         query.setParameter(1, consultationId);
         query.setParameter(2, ConsultDocs.DOCTYPE_DOC);
@@ -94,7 +98,11 @@ public class DocumentDaoImpl extends AbstractDaoImpl<Document> implements Docume
 
     @Override
     public List<Object[]> findDocsAndEFormDocsByFdid(Integer fdid) {
-        String sql = "FROM Document d, EFormDocs cd WHERE d.documentNo = cd.documentNo AND cd.fdid = ?1 AND cd.docType = ?2 AND cd.deleted IS NULL";
+        String sql = "FROM Document d, EFormDocs cd " +
+                "WHERE d.documentNo = cd.documentNo " +
+                "AND cd.fdid = ?1 " +
+                "AND cd.docType = ?2 " +
+                "AND cd.deleted IS NULL";
         Query query = entityManager.createQuery(sql);
         query.setParameter(1, fdid);
         query.setParameter(2, EFormDocs.DOCTYPE_DOC);
@@ -103,7 +111,11 @@ public class DocumentDaoImpl extends AbstractDaoImpl<Document> implements Docume
 
     @Override
     public List<Object[]> findDocsAndConsultResponseDocsByConsultId(Integer consultationId) {
-        String sql = "FROM Document d, ConsultResponseDoc crd WHERE d.documentNo = crd.documentNo AND crd.responseId = ?1 AND crd.docType = 'D' AND crd.deleted IS NULL";
+        String sql = "FROM Document d, ConsultResponseDoc crd " +
+                "WHERE d.documentNo = crd.documentNo " +
+                "AND crd.responseId = ?1 " +
+                "AND crd.docType = 'D' " +
+                "AND crd.deleted IS NULL";
         Query query = entityManager.createQuery(sql);
         query.setParameter(1, consultationId);
         return query.getResultList();

--- a/src/main/java/ca/openosp/openo/commn/dao/DocumentDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/DocumentDaoImpl.java
@@ -85,7 +85,7 @@ public class DocumentDaoImpl extends AbstractDaoImpl<Document> implements Docume
 
     @Override
     public List<Object[]> findDocsAndConsultDocsByConsultId(Integer consultationId) {
-        String sql = "SELECT d, cd, ctl FROM Document d, ConsultDocs cd, CtlDocument ctl WHERE d.documentNo = cd.documentNo AND ctl.id.documentNo = d.documentNo AND cd.requestId = ?1 AND cd.docType = ?2 AND cd.deleted IS NULL";
+        String sql = "FROM Document d, ConsultDocs cd WHERE d.documentNo = cd.documentNo AND cd.requestId = ?1 AND cd.docType = ?2 AND cd.deleted IS NULL";
         Query query = entityManager.createQuery(sql);
         query.setParameter(1, consultationId);
         query.setParameter(2, ConsultDocs.DOCTYPE_DOC);
@@ -94,7 +94,7 @@ public class DocumentDaoImpl extends AbstractDaoImpl<Document> implements Docume
 
     @Override
     public List<Object[]> findDocsAndEFormDocsByFdid(Integer fdid) {
-        String sql = "SELECT d, cd, ctl FROM Document d, EFormDocs cd, CtlDocument ctl WHERE d.documentNo = cd.documentNo AND ctl.id.documentNo = d.documentNo AND cd.fdid = ?1 AND cd.docType = ?2 AND cd.deleted IS NULL";
+        String sql = "FROM Document d, EFormDocs cd WHERE d.documentNo = cd.documentNo AND cd.fdid = ?1 AND cd.docType = ?2 AND cd.deleted IS NULL";
         Query query = entityManager.createQuery(sql);
         query.setParameter(1, fdid);
         query.setParameter(2, EFormDocs.DOCTYPE_DOC);
@@ -103,7 +103,7 @@ public class DocumentDaoImpl extends AbstractDaoImpl<Document> implements Docume
 
     @Override
     public List<Object[]> findDocsAndConsultResponseDocsByConsultId(Integer consultationId) {
-        String sql = "SELECT d, crd, ctl FROM Document d, ConsultResponseDoc crd, CtlDocument ctl WHERE d.documentNo = crd.documentNo AND ctl.id.documentNo = d.documentNo AND crd.responseId = ?1 AND crd.docType = 'D' AND crd.deleted IS NULL";
+        String sql = "FROM Document d, ConsultResponseDoc crd WHERE d.documentNo = crd.documentNo AND crd.responseId = ?1 AND crd.docType = 'D' AND crd.deleted IS NULL";
         Query query = entityManager.createQuery(sql);
         query.setParameter(1, consultationId);
         return query.getResultList();

--- a/src/main/java/ca/openosp/openo/commn/dao/DocumentDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/DocumentDaoImpl.java
@@ -85,11 +85,11 @@ public class DocumentDaoImpl extends AbstractDaoImpl<Document> implements Docume
 
     @Override
     public List<Object[]> findDocsAndConsultDocsByConsultId(Integer consultationId) {
-        String sql = "FROM Document d, ConsultDocs cd " +
-                "WHERE d.documentNo = cd.documentNo " +
-                "AND cd.requestId = ?1 " +
-                "AND cd.docType = ?2 " +
-                "AND cd.deleted IS NULL";
+        // Joining CtlDocument lets the attached-listing populate module/moduleId
+        // on each EDoc in a single round trip. Orphan attachments (no ctl row)
+        // have always been invisible in the attachment manager; INNER JOIN
+        // preserves that behavior.
+        String sql = "SELECT d, cd, ctl FROM Document d, ConsultDocs cd, CtlDocument ctl WHERE d.documentNo = cd.documentNo AND ctl.id.documentNo = d.documentNo AND cd.requestId = ?1 AND cd.docType = ?2 AND cd.deleted IS NULL";
         Query query = entityManager.createQuery(sql);
         query.setParameter(1, consultationId);
         query.setParameter(2, ConsultDocs.DOCTYPE_DOC);
@@ -98,11 +98,7 @@ public class DocumentDaoImpl extends AbstractDaoImpl<Document> implements Docume
 
     @Override
     public List<Object[]> findDocsAndEFormDocsByFdid(Integer fdid) {
-        String sql = "FROM Document d, EFormDocs cd " +
-                "WHERE d.documentNo = cd.documentNo " +
-                "AND cd.fdid = ?1 " +
-                "AND cd.docType = ?2 " +
-                "AND cd.deleted IS NULL";
+        String sql = "SELECT d, cd, ctl FROM Document d, EFormDocs cd, CtlDocument ctl WHERE d.documentNo = cd.documentNo AND ctl.id.documentNo = d.documentNo AND cd.fdid = ?1 AND cd.docType = ?2 AND cd.deleted IS NULL";
         Query query = entityManager.createQuery(sql);
         query.setParameter(1, fdid);
         query.setParameter(2, EFormDocs.DOCTYPE_DOC);
@@ -111,11 +107,7 @@ public class DocumentDaoImpl extends AbstractDaoImpl<Document> implements Docume
 
     @Override
     public List<Object[]> findDocsAndConsultResponseDocsByConsultId(Integer consultationId) {
-        String sql = "FROM Document d, ConsultResponseDoc crd " +
-                "WHERE d.documentNo = crd.documentNo " +
-                "AND crd.responseId = ?1 " +
-                "AND crd.docType = 'D' " +
-                "AND crd.deleted IS NULL";
+        String sql = "SELECT d, crd, ctl FROM Document d, ConsultResponseDoc crd, CtlDocument ctl WHERE d.documentNo = crd.documentNo AND ctl.id.documentNo = d.documentNo AND crd.responseId = ?1 AND crd.docType = 'D' AND crd.deleted IS NULL";
         Query query = entityManager.createQuery(sql);
         query.setParameter(1, consultationId);
         return query.getResultList();

--- a/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManager.java
+++ b/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManager.java
@@ -86,6 +86,53 @@ public interface DocumentAttachmentManager {
      * @return {@code true} if every document belongs to the patient; {@code false} otherwise
      */
     public boolean validateDocumentsBelongToPatient(LoggedInInfo loggedInInfo, Integer demographicNo, String[] documents);
+
+    /**
+     * Classifies the supplied attached docs into the three section lists
+     * (patient documents, provider public eDocs, provider private eDocs) and
+     * populates the two ID sets the view needs for pre-checking and foreign-owner
+     * labelling. The three section lists are mutated in place — deleted docs and
+     * foreign private docs are appended to the matching list so the view still
+     * renders them. {@code allDocuments}, {@code providerPrivateDocs}, and
+     * {@code providerPublicDocs} may be {@code null}: in that case only
+     * {@code attachedDocumentIds} is populated (for pre-checking) and the
+     * section merge is skipped.
+     *
+     * @param loggedInInfo        LoggedInInfo the current user's session (for current-provider comparison)
+     * @param attachedDocs        List&lt;EDoc&gt; the docs attached to the current consult/eForm; may be null/empty
+     * @param allDocuments        List&lt;EDoc&gt; mutable list of patient documents; may be null
+     * @param providerPrivateDocs List&lt;EDoc&gt; mutable list of the current provider's private eDocs; may be null
+     * @param providerPublicDocs  List&lt;EDoc&gt; mutable list of public provider eDocs; may be null
+     * @param attachedDocumentIds Set&lt;String&gt; populated with the doc IDs of every attached doc
+     * @param foreignPrivateDocIds Set&lt;String&gt; populated with the doc IDs of attached private docs not owned by the current provider
+     */
+    public void mergeAttachedIntoSections(LoggedInInfo loggedInInfo, List<EDoc> attachedDocs, List<EDoc> allDocuments, List<EDoc> providerPrivateDocs, List<EDoc> providerPublicDocs, Set<String> attachedDocumentIds, Set<String> foreignPrivateDocIds);
+
+    /**
+     * Returns the EDocs currently attached to a consultation request, or an empty
+     * list when {@code requestId} is absent. Used by the attachment-dialog flow
+     * to render pre-checked and cross-provider markers alongside the patient's
+     * document library.
+     *
+     * @param loggedInInfo  LoggedInInfo the current user's session
+     * @param demographicNo String the patient's demographic number
+     * @param requestId     String the consultation request id; {@code null} short-circuits to an empty list
+     * @return List&lt;EDoc&gt; attached EDocs, or empty list when {@code requestId} is {@code null}
+     */
+    public List<EDoc> getAttachedDocsForConsult(LoggedInInfo loggedInInfo, String demographicNo, String requestId);
+
+    /**
+     * Returns the EDocs currently attached to an eForm instance, or an empty
+     * list when {@code fdid} is absent. Used by the attachment-dialog flow to
+     * render pre-checked and cross-provider markers alongside the patient's
+     * document library.
+     *
+     * @param loggedInInfo  LoggedInInfo the current user's session
+     * @param demographicNo String the patient's demographic number
+     * @param fdid          String the form-data id; {@code null} short-circuits to an empty list
+     * @return List&lt;EDoc&gt; attached EDocs, or empty list when {@code fdid} is {@code null}
+     */
+    public List<EDoc> getAttachedDocsForEForm(LoggedInInfo loggedInInfo, String demographicNo, String fdid);
 }
 
 	

--- a/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManagerImpl.java
+++ b/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManagerImpl.java
@@ -457,4 +457,53 @@ public class DocumentAttachmentManagerImpl implements DocumentAttachmentManager 
 
         return true;
     }
+
+    @Override
+    public void mergeAttachedIntoSections(LoggedInInfo loggedInInfo, List<EDoc> attachedDocs, List<EDoc> allDocuments, List<EDoc> providerPrivateDocs, List<EDoc> providerPublicDocs, Set<String> attachedDocumentIds, Set<String> foreignPrivateDocIds) {
+        if (attachedDocs == null || attachedDocs.isEmpty()) {
+            return;
+        }
+
+        // attachedDocumentIds drives view pre-checking and is useful even when the
+        // per-section lists aren't loaded — populate it unconditionally.
+        for (EDoc attachedDoc : attachedDocs) {
+            attachedDocumentIds.add(attachedDoc.getDocId());
+        }
+
+        if (allDocuments == null || providerPrivateDocs == null || providerPublicDocs == null) {
+            return;
+        }
+
+        String currentProviderNo = loggedInInfo.getLoggedInProviderNo();
+
+        for (EDoc attachedDoc : attachedDocs) {
+            boolean isDeleted = attachedDoc.getStatus() == 'D';
+            boolean isPublic = "1".equals(attachedDoc.getDocPublic());
+            boolean ownedByCurrent = attachedDoc.isOwnedBy(currentProviderNo);
+
+            if (!attachedDoc.isProviderScoped()) {
+                // Patient doc: only deleted ones need re-injecting.
+                if (isDeleted) allDocuments.add(attachedDoc);
+            } else if (isPublic) {
+                // Public provider doc: only deleted ones need re-injecting.
+                if (isDeleted) providerPublicDocs.add(attachedDoc);
+            } else if (isDeleted || !ownedByCurrent) {
+                // Private provider doc: skip active-own (already listed); merge everything else.
+                providerPrivateDocs.add(attachedDoc);
+                if (!ownedByCurrent) foreignPrivateDocIds.add(attachedDoc.getDocId());
+            }
+        }
+    }
+
+    @Override
+    public List<EDoc> getAttachedDocsForConsult(LoggedInInfo loggedInInfo, String demographicNo, String requestId) {
+        if (requestId == null) return Collections.emptyList();
+        return EDocUtil.listDocs(loggedInInfo, demographicNo, requestId, EDocUtil.ATTACHED);
+    }
+
+    @Override
+    public List<EDoc> getAttachedDocsForEForm(LoggedInInfo loggedInInfo, String demographicNo, String fdid) {
+        if (fdid == null) return Collections.emptyList();
+        return EDocUtil.listDocsAttachedToEForm(loggedInInfo, demographicNo, fdid, EDocUtil.ATTACHED);
+    }
 }

--- a/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManagerImpl.java
+++ b/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManagerImpl.java
@@ -481,17 +481,20 @@ public class DocumentAttachmentManagerImpl implements DocumentAttachmentManager 
             boolean isPublic = "1".equals(attachedDoc.getDocPublic());
             boolean ownedByCurrent = attachedDoc.isOwnedBy(currentProviderNo);
 
+            // Patient doc: only deleted ones need re-injecting.
             if (!attachedDoc.isProviderScoped()) {
-                // Patient doc: only deleted ones need re-injecting.
                 if (isDeleted) allDocuments.add(attachedDoc);
-            } else if (isPublic) {
-                // Public provider doc: only deleted ones need re-injecting.
-                if (isDeleted) providerPublicDocs.add(attachedDoc);
-            } else if (isDeleted || !ownedByCurrent) {
-                // Private provider doc: skip active-own (already listed); merge everything else.
-                providerPrivateDocs.add(attachedDoc);
-                if (!ownedByCurrent) foreignPrivateDocIds.add(attachedDoc.getDocId());
+                continue;
             }
+            // Public provider doc: only deleted ones need re-injecting.
+            if (isPublic) {
+                if (isDeleted) providerPublicDocs.add(attachedDoc);
+                continue;
+            }
+            // Private provider doc: skip active-own (already listed); merge everything else.
+            if (!isDeleted && ownedByCurrent) continue;
+            providerPrivateDocs.add(attachedDoc);
+            if (!ownedByCurrent) foreignPrivateDocIds.add(attachedDoc.getDocId());
         }
     }
 

--- a/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManagerImpl.java
+++ b/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManagerImpl.java
@@ -439,7 +439,7 @@ public class DocumentAttachmentManagerImpl implements DocumentAttachmentManager 
         }
 
         if (!docIds.isEmpty()) {
-            List<Integer> found = documentDao.findDocumentNosForDemographic(demographicNo, new ArrayList<>(docIds));
+            List<Integer> found = documentDao.findValidAttachmentDocNos(demographicNo, new ArrayList<>(docIds));
             if (!found.containsAll(docIds)) return false;
         }
         if (!labIds.isEmpty()) {

--- a/src/main/java/ca/openosp/openo/documentManager/EDoc.java
+++ b/src/main/java/ca/openosp/openo/documentManager/EDoc.java
@@ -314,6 +314,34 @@ public class EDoc extends TagObject implements Comparable<EDoc> {
         this.moduleId = moduleId;
     }
 
+    /**
+     * Whether this doc is scoped to a provider's library (as opposed to a
+     * patient's demographic). Recognizes the legacy {@code "provider"} spelling
+     * and the current {@code "providers"} spelling, case-insensitive.
+     *
+     * <p>The rule is intentionally duplicated from {@link EDocUtil#isProviderModule(String)}:
+     * asking EDoc would force EDocUtil's class load, which triggers a chain of
+     * {@code SpringUtils.getBean(...)} static initializers — fine in production
+     * but breaks unit tests that don't stand up a Spring context.
+     *
+     * @return {@code true} when {@link #getModule()} is {@code "provider"} or {@code "providers"}
+     */
+    public boolean isProviderScoped() {
+        return "provider".equalsIgnoreCase(module) || "providers".equalsIgnoreCase(module);
+    }
+
+    /**
+     * Whether this doc's library ownership (its {@code moduleId}) matches the
+     * given provider. Only meaningful for provider-scoped docs; callers should
+     * gate on {@link #isProviderScoped()} if they need that precondition.
+     *
+     * @param providerNo the provider id to compare against; {@code null} short-circuits to {@code false}
+     * @return {@code true} when {@code providerNo} is non-null and equals {@link #getModuleId()}
+     */
+    public boolean isOwnedBy(String providerNo) {
+        return providerNo != null && providerNo.equals(moduleId);
+    }
+
     public String getType() {
         return type;
     }

--- a/src/main/java/ca/openosp/openo/documentManager/EDocUtil.java
+++ b/src/main/java/ca/openosp/openo/documentManager/EDocUtil.java
@@ -437,7 +437,6 @@ public final class EDocUtil {
 
         for (Object[] o : docs) {
             Document d = (Document) o[0];
-            // o[1] is the attachment-link entity (ConsultDocs/EFormDocs/ConsultResponseDoc); o[2] is CtlDocument
             CtlDocument ctl = (CtlDocument) o[2];
 
             EDoc currentdoc = new EDoc();
@@ -457,9 +456,7 @@ public final class EDocUtil {
             }
             currentdoc.setType(d.getDoctype());
             currentdoc.setStatus(d.getStatus());
-            // Format as String (yyyy-MM-dd) rather than passing Date, which
-            // would use DMS_DATE_FORMAT (yyyy/MM/dd) and diverge from the
-            // rest of the system.
+            // yyyy-MM-dd to match rest of system; Date overload uses yyyy/MM/dd.
             currentdoc.setObservationDate(ConversionUtils.toDateString(d.getObservationdate()));
             currentdoc.setReviewerId(d.getReviewer());
             currentdoc.setReviewDateTime(ConversionUtils.toTimestampString(d.getReviewdatetime()));

--- a/src/main/java/ca/openosp/openo/documentManager/EDocUtil.java
+++ b/src/main/java/ca/openosp/openo/documentManager/EDocUtil.java
@@ -583,10 +583,10 @@ public final class EDocUtil {
             currentdoc.setDateTimeStampAsDate(d.getUpdatedatetime());
             currentdoc.setDateTimeStamp(ConversionUtils.toTimestampString(d.getUpdatedatetime()));
             currentdoc.setFileName(d.getDocfilename());
-            currentdoc.setDocPublic("" + d.getPublic1());
+            currentdoc.setDocPublic(String.valueOf(d.getPublic1()));
             currentdoc.setStatus(d.getStatus());
             currentdoc.setContentType(d.getContenttype());
-            currentdoc.setObservationDate(d.getObservationdate());
+            currentdoc.setObservationDate(ConversionUtils.toDateString(d.getObservationdate()));
             currentdoc.setReviewerId(d.getReviewer());
             currentdoc.setReviewDateTime(ConversionUtils.toTimestampString(d.getReviewdatetime()));
             currentdoc.setReviewDateTimeDate(d.getReviewdatetime());

--- a/src/main/java/ca/openosp/openo/documentManager/EDocUtil.java
+++ b/src/main/java/ca/openosp/openo/documentManager/EDocUtil.java
@@ -517,6 +517,22 @@ public final class EDocUtil {
         return listDocs(loggedInInfo, module, moduleid, docType, publicDoc, sort, "active");
     }
 
+    /**
+     * Retrieves private documents belonging to the currently logged-in provider.
+     *
+     * @param loggedInInfo LoggedInInfo the logged-in user's session information
+     * @return List&lt;EDoc&gt; list of the provider's private documents sorted by observation date,
+     *         or an empty list if the provider number is null
+     * @since 2026-02-18
+     */
+    public static List<EDoc> getProviderPrivateDocs(LoggedInInfo loggedInInfo) {
+        String providerNo = loggedInInfo.getLoggedInProviderNo();
+        if (providerNo == null) {
+            return java.util.Collections.emptyList();
+        }
+        return listDocs(loggedInInfo, "providers", providerNo, null, PRIVATE, EDocSort.OBSERVATIONDATE);
+    }
+
     public static EDoc getEDocFromDocId(String docId) {
         DocumentDao dao = SpringUtils.getBean(DocumentDao.class);
         EDoc currentdoc = new EDoc();

--- a/src/main/java/ca/openosp/openo/documentManager/EDocUtil.java
+++ b/src/main/java/ca/openosp/openo/documentManager/EDocUtil.java
@@ -43,11 +43,11 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.ResourceBundle;
-import java.util.Set;
 
 import ca.openosp.openo.commn.dao.*;
 import org.apache.commons.io.FileUtils;
@@ -436,14 +436,9 @@ public final class EDocUtil {
     private static ArrayList<EDoc> listDocs(LoggedInInfo loggedInInfo, boolean attached, List<Object[]> docs, List<Object[]> ctlDocs) {
         ArrayList<EDoc> resultDocs = new ArrayList<EDoc>();
         ArrayList<EDoc> attachedDocs = new ArrayList<EDoc>();
-        // Dedupe: CtlDocument join can yield one tuple per ctl row per document_no.
-        Set<String> seenAttachedIds = new HashSet<>();
 
         for (Object[] o : docs) {
             Document d = (Document) o[0];
-            CtlDocument ctl = (CtlDocument) o[2];
-            String docIdStr = String.valueOf(d.getDocumentNo());
-            if (!seenAttachedIds.add(docIdStr)) continue;
 
             EDoc currentdoc = new EDoc();
             currentdoc.setDocId("" + d.getDocumentNo());
@@ -468,9 +463,8 @@ public final class EDocUtil {
             currentdoc.setReviewDateTime(ConversionUtils.toTimestampString(d.getReviewdatetime()));
             currentdoc.setReviewDateTimeDate(d.getReviewdatetime());
             currentdoc.setContentDateTime(d.getContentdatetime());
-            currentdoc.setModule(ctl.getId().getModule());
-            currentdoc.setModuleId(String.valueOf(ctl.getId().getModuleId()));
             currentdoc.setDocPublic(String.valueOf(d.getPublic1()));
+            // ctl module/moduleId enriched below for the attached branch.
 
             if (d.isRestrictToProgram() != null) {
                 currentdoc.setRestrictToProgram(d.isRestrictToProgram());
@@ -480,6 +474,7 @@ public final class EDocUtil {
         }
 
         if (attached) { //listing attached documents only
+            enrichAttachedWithCtl(attachedDocs);
             resultDocs = attachedDocs;
         } else { //remove attached documents from full document list
             for (Object[] o : ctlDocs) {
@@ -518,6 +513,46 @@ public final class EDocUtil {
         }
 
         return resultDocs;
+    }
+
+    /**
+     * Enriches each attached EDoc with a CtlDocument module/moduleId. Provider
+     * bindings are preferred over demographic so a doc uploaded to a provider's
+     * library classifies as a provider doc even when it also has a demographic
+     * binding. Docs with no ctl row at all are left unclassified and fall through
+     * to the patient section (via {@link #isProviderModule}(null) == false).
+     *
+     * <p>Runs one batch ctl lookup for the whole attachment list to keep this
+     * O(1) queries regardless of attachment count.</p>
+     */
+    private static void enrichAttachedWithCtl(List<EDoc> attachedDocs) {
+        if (attachedDocs.isEmpty()) return;
+
+        List<Integer> docNos = new ArrayList<>(attachedDocs.size());
+        for (EDoc eDoc : attachedDocs) docNos.add(Integer.parseInt(eDoc.getDocId()));
+
+        Map<Integer, CtlDocument> preferredCtl = new HashMap<>();
+        for (CtlDocument c : ctlDocumentDao.findByDocumentNos(docNos)) {
+            Integer docNo = c.getId().getDocumentNo();
+            CtlDocument current = preferredCtl.get(docNo);
+            if (current == null || preferProvider(c, current)) {
+                preferredCtl.put(docNo, c);
+            }
+        }
+
+        for (EDoc eDoc : attachedDocs) {
+            CtlDocument ctl = preferredCtl.get(Integer.parseInt(eDoc.getDocId()));
+            if (ctl != null) {
+                eDoc.setModule(ctl.getId().getModule());
+                eDoc.setModuleId(String.valueOf(ctl.getId().getModuleId()));
+            }
+        }
+    }
+
+    /** Tiebreaker for multi-ctl docs: a provider binding replaces a non-provider one. */
+    private static boolean preferProvider(CtlDocument candidate, CtlDocument current) {
+        return isProviderModule(candidate.getId().getModule())
+                && !isProviderModule(current.getId().getModule());
     }
 
     /**

--- a/src/main/java/ca/openosp/openo/documentManager/EDocUtil.java
+++ b/src/main/java/ca/openosp/openo/documentManager/EDocUtil.java
@@ -533,6 +533,28 @@ public final class EDocUtil {
         return listDocs(loggedInInfo, "providers", providerNo, null, PRIVATE, EDocSort.OBSERVATIONDATE);
     }
 
+    /**
+     * Retrieves public (shared) documents uploaded by any provider.
+     *
+     * <p>When {@code PUBLIC} is passed to {@link #listDocs}, the underlying
+     * {@code DocumentDaoImpl.findDocuments()} queries {@code d.public1 = 1}
+     * without filtering by {@code moduleId}, so all public provider documents
+     * across every provider are returned. The {@code providerNo} parameter is
+     * still required for the method signature but does not restrict results.</p>
+     *
+     * @param loggedInInfo LoggedInInfo the logged-in user's session information
+     * @return List&lt;EDoc&gt; list of all public provider documents sorted by observation date,
+     *         or an empty list if the provider number is null
+     * @since 2026-02-20
+     */
+    public static List<EDoc> getProviderPublicDocs(LoggedInInfo loggedInInfo) {
+        String providerNo = loggedInInfo.getLoggedInProviderNo();
+        if (providerNo == null) {
+            return java.util.Collections.emptyList();
+        }
+        return listDocs(loggedInInfo, "providers", providerNo, null, PUBLIC, EDocSort.OBSERVATIONDATE);
+    }
+
     public static EDoc getEDocFromDocId(String docId) {
         DocumentDao dao = SpringUtils.getBean(DocumentDao.class);
         EDoc currentdoc = new EDoc();

--- a/src/main/java/ca/openosp/openo/documentManager/EDocUtil.java
+++ b/src/main/java/ca/openosp/openo/documentManager/EDocUtil.java
@@ -41,6 +41,7 @@ import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -436,6 +437,8 @@ public final class EDocUtil {
 
         for (Object[] o : docs) {
             Document d = (Document) o[0];
+            // o[1] is the attachment-link entity (ConsultDocs/EFormDocs/ConsultResponseDoc); o[2] is CtlDocument
+            CtlDocument ctl = (CtlDocument) o[2];
 
             EDoc currentdoc = new EDoc();
             currentdoc.setDocId("" + d.getDocumentNo());
@@ -454,11 +457,17 @@ public final class EDocUtil {
             }
             currentdoc.setType(d.getDoctype());
             currentdoc.setStatus(d.getStatus());
-            currentdoc.setObservationDate(d.getObservationdate());
+            // Format as String (yyyy-MM-dd) rather than passing Date, which
+            // would use DMS_DATE_FORMAT (yyyy/MM/dd) and diverge from the
+            // rest of the system.
+            currentdoc.setObservationDate(ConversionUtils.toDateString(d.getObservationdate()));
             currentdoc.setReviewerId(d.getReviewer());
             currentdoc.setReviewDateTime(ConversionUtils.toTimestampString(d.getReviewdatetime()));
             currentdoc.setReviewDateTimeDate(d.getReviewdatetime());
             currentdoc.setContentDateTime(d.getContentdatetime());
+            currentdoc.setModule(ctl.getId().getModule());
+            currentdoc.setModuleId(String.valueOf(ctl.getId().getModuleId()));
+            currentdoc.setDocPublic(String.valueOf(d.getPublic1()));
 
             if (d.isRestrictToProgram() != null) {
                 currentdoc.setRestrictToProgram(d.isRestrictToProgram());
@@ -528,7 +537,7 @@ public final class EDocUtil {
     public static List<EDoc> getProviderPrivateDocs(LoggedInInfo loggedInInfo) {
         String providerNo = loggedInInfo.getLoggedInProviderNo();
         if (providerNo == null) {
-            return java.util.Collections.emptyList();
+            return Collections.emptyList();
         }
         return listDocs(loggedInInfo, "providers", providerNo, null, PRIVATE, EDocSort.OBSERVATIONDATE);
     }
@@ -536,21 +545,23 @@ public final class EDocUtil {
     /**
      * Retrieves public (shared) documents uploaded by any provider.
      *
-     * <p>When {@code PUBLIC} is passed to {@link #listDocs}, the underlying
+     * <p>Results are global, not scoped to the logged-in provider: when
+     * {@code PUBLIC} is passed to {@link #listDocs}, the underlying
      * {@code DocumentDaoImpl.findDocuments()} queries {@code d.public1 = 1}
-     * without filtering by {@code moduleId}, so all public provider documents
-     * across every provider are returned. The {@code providerNo} parameter is
-     * still required for the method signature but does not restrict results.</p>
+     * without filtering by {@code moduleId}. The {@code providerNo} argument
+     * is still required by the shared {@code listDocs} signature but does
+     * not restrict results.</p>
      *
      * @param loggedInInfo LoggedInInfo the logged-in user's session information
-     * @return List&lt;EDoc&gt; list of all public provider documents sorted by observation date,
-     *         or an empty list if the provider number is null
+     * @return List&lt;EDoc&gt; all public provider documents sorted by observation date;
+     *         empty list when no provider is in context (defensive — the query
+     *         itself does not depend on provider identity)
      * @since 2026-02-20
      */
     public static List<EDoc> getProviderPublicDocs(LoggedInInfo loggedInInfo) {
         String providerNo = loggedInInfo.getLoggedInProviderNo();
         if (providerNo == null) {
-            return java.util.Collections.emptyList();
+            return Collections.emptyList();
         }
         return listDocs(loggedInInfo, "providers", providerNo, null, PUBLIC, EDocSort.OBSERVATIONDATE);
     }

--- a/src/main/java/ca/openosp/openo/documentManager/EDocUtil.java
+++ b/src/main/java/ca/openosp/openo/documentManager/EDocUtil.java
@@ -583,6 +583,7 @@ public final class EDocUtil {
             currentdoc.setDateTimeStampAsDate(d.getUpdatedatetime());
             currentdoc.setDateTimeStamp(ConversionUtils.toTimestampString(d.getUpdatedatetime()));
             currentdoc.setFileName(d.getDocfilename());
+            currentdoc.setDocPublic("" + d.getPublic1());
             currentdoc.setStatus(d.getStatus());
             currentdoc.setContentType(d.getContenttype());
             currentdoc.setObservationDate(d.getObservationdate());

--- a/src/main/java/ca/openosp/openo/documentManager/EDocUtil.java
+++ b/src/main/java/ca/openosp/openo/documentManager/EDocUtil.java
@@ -43,9 +43,11 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
+import java.util.Set;
 
 import ca.openosp.openo.commn.dao.*;
 import org.apache.commons.io.FileUtils;
@@ -434,10 +436,14 @@ public final class EDocUtil {
     private static ArrayList<EDoc> listDocs(LoggedInInfo loggedInInfo, boolean attached, List<Object[]> docs, List<Object[]> ctlDocs) {
         ArrayList<EDoc> resultDocs = new ArrayList<EDoc>();
         ArrayList<EDoc> attachedDocs = new ArrayList<EDoc>();
+        // Dedupe: CtlDocument join can yield one tuple per ctl row per document_no.
+        Set<String> seenAttachedIds = new HashSet<>();
 
         for (Object[] o : docs) {
             Document d = (Document) o[0];
             CtlDocument ctl = (CtlDocument) o[2];
+            String docIdStr = String.valueOf(d.getDocumentNo());
+            if (!seenAttachedIds.add(docIdStr)) continue;
 
             EDoc currentdoc = new EDoc();
             currentdoc.setDocId("" + d.getDocumentNo());

--- a/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
+++ b/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
@@ -417,7 +417,7 @@ public class DocumentPreview2Action extends ActionSupport {
      *
      * @since 2026-04-21
      */
-    private void mergeSingleAttachedDoc(
+    static void mergeSingleAttachedDoc(
             EDoc attachedDoc,
             String currentProviderNo,
             List<EDoc> allDocuments,
@@ -426,7 +426,7 @@ public class DocumentPreview2Action extends ActionSupport {
             Set<String> foreignPrivateDocIds) {
 
         boolean isDeleted = attachedDoc.getStatus() == 'D';
-        boolean isProvider = EDocUtil.isProviderModule(attachedDoc.getModule());
+        boolean isProvider = isProviderModule(attachedDoc.getModule());
         boolean isPublic = "1".equals(attachedDoc.getDocPublic());
         boolean ownedByCurrent = isOwnedByCurrentProvider(attachedDoc, currentProviderNo);
 
@@ -446,8 +446,17 @@ public class DocumentPreview2Action extends ActionSupport {
         if (!ownedByCurrent) foreignPrivateDocIds.add(attachedDoc.getDocId());
     }
 
-    private boolean isOwnedByCurrentProvider(EDoc doc, String currentProviderNo) {
+    static boolean isOwnedByCurrentProvider(EDoc doc, String currentProviderNo) {
         return currentProviderNo != null && currentProviderNo.equals(doc.getModuleId());
+    }
+
+    /**
+     * Local copy of {@link EDocUtil#isProviderModule} to avoid triggering EDocUtil's
+     * class-load (and its many SpringUtils-bean static initializers) from this
+     * classifier. Keeps {@link #mergeSingleAttachedDoc} unit-testable without Spring.
+     */
+    static boolean isProviderModule(String module) {
+        return "provider".equalsIgnoreCase(module) || "providers".equalsIgnoreCase(module);
     }
 
     /**

--- a/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
+++ b/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
@@ -401,9 +401,7 @@ public class DocumentPreview2Action extends ActionSupport {
         String currentProviderNo = loggedInInfo.getLoggedInProviderNo();
 
         for (EDoc attachedDoc : attachedDocs) {
-            // Defensive dedupe: EDocUtil.listDocs already dedupes upstream, but keep this
-            // guard so future callers that pass a duped list don't double-merge sections.
-            if (!attachedDocumentIds.add(attachedDoc.getDocId())) continue;
+            attachedDocumentIds.add(attachedDoc.getDocId());
             mergeSingleAttachedDoc(
                     attachedDoc,
                     currentProviderNo,

--- a/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
+++ b/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
@@ -274,12 +274,14 @@ public class DocumentPreview2Action extends ActionSupport {
     private void populateCommonDocs(LoggedInInfo loggedInInfo, String demographicNo) {
         List<EDoc> allDocuments = EDocUtil.listDocs(loggedInInfo, "demographic", demographicNo, null, EDocUtil.PRIVATE, EDocUtil.EDocSort.OBSERVATIONDATE);
         List<EDoc> providerPrivateDocs = EDocUtil.getProviderPrivateDocs(loggedInInfo);
+        List<EDoc> providerPublicDocs = EDocUtil.getProviderPublicDocs(loggedInInfo);
         ArrayList<HashMap<String,? extends Object>> allHRMDocuments = HRMUtil.listHRMDocuments(loggedInInfo, "report_date", false, demographicNo,false);
         List<AttachmentLabResultData> allLabsSortedByVersions = documentAttachmentManager.getAllLabsSortedByVersions(loggedInInfo, demographicNo);
         List<EctFormData.PatientForm> allForms = formsManager.getEncounterFormsbyDemographicNumber(loggedInInfo, Integer.parseInt(demographicNo), false, true);
 
         request.setAttribute("allDocuments", allDocuments);
         request.setAttribute("providerPrivateDocs", providerPrivateDocs);
+        request.setAttribute("providerPublicDocs", providerPublicDocs);
         request.setAttribute("allHRMDocuments", allHRMDocuments);
 		request.setAttribute("allLabsSortedByVersions", allLabsSortedByVersions);
 		request.setAttribute("allForms", allForms);

--- a/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
+++ b/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
@@ -273,11 +273,14 @@ public class DocumentPreview2Action extends ActionSupport {
      */
     private void populateCommonDocs(LoggedInInfo loggedInInfo, String demographicNo) {
         List<EDoc> allDocuments = EDocUtil.listDocs(loggedInInfo, "demographic", demographicNo, null, EDocUtil.PRIVATE, EDocUtil.EDocSort.OBSERVATIONDATE);
+        String providerNo = loggedInInfo.getLoggedInProviderNo();
+        List<EDoc> providerPrivateDocs = EDocUtil.listDocs(loggedInInfo, "providers", providerNo, null, EDocUtil.PRIVATE, EDocUtil.EDocSort.OBSERVATIONDATE);
         ArrayList<HashMap<String,? extends Object>> allHRMDocuments = HRMUtil.listHRMDocuments(loggedInInfo, "report_date", false, demographicNo,false);
         List<AttachmentLabResultData> allLabsSortedByVersions = documentAttachmentManager.getAllLabsSortedByVersions(loggedInInfo, demographicNo);
         List<EctFormData.PatientForm> allForms = formsManager.getEncounterFormsbyDemographicNumber(loggedInInfo, Integer.parseInt(demographicNo), false, true);
 
         request.setAttribute("allDocuments", allDocuments);
+        request.setAttribute("providerPrivateDocs", providerPrivateDocs);
         request.setAttribute("allHRMDocuments", allHRMDocuments);
 		request.setAttribute("allLabsSortedByVersions", allLabsSortedByVersions);
 		request.setAttribute("allForms", allForms);

--- a/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
+++ b/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
@@ -17,6 +17,7 @@ import ca.openosp.openo.documentManager.EDocUtil;
 import ca.openosp.openo.documentManager.data.AttachmentLabResultData;
 import ca.openosp.openo.hospitalReportManager.HRMUtil;
 import ca.openosp.openo.managers.FormsManager;
+import ca.openosp.openo.managers.SecurityInfoManager;
 import ca.openosp.openo.utility.LoggedInInfo;
 import ca.openosp.openo.utility.MiscUtils;
 import ca.openosp.openo.utility.PathValidationUtils;
@@ -51,6 +52,7 @@ public class DocumentPreview2Action extends ActionSupport {
     private static final Logger logger = MiscUtils.getLogger();
     private final DocumentAttachmentManager documentAttachmentManager = SpringUtils.getBean(DocumentAttachmentManager.class);
     private final FormsManager formsManager = SpringUtils.getBean(FormsManager.class);
+    private final SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     public String execute() {
@@ -248,6 +250,9 @@ public class DocumentPreview2Action extends ActionSupport {
      */
     public String fetchConsultDocuments() {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_edoc", "r", null)) {
+            throw new SecurityException("missing required security object (_edoc)");
+        }
 
         String demographicNo = StringUtils.isNullOrEmpty(request.getParameter("demographicNo")) ? "0" : request.getParameter("demographicNo");
         String requestId = StringUtils.isNullOrEmpty(request.getParameter("requestId")) ? null : request.getParameter("requestId");
@@ -289,6 +294,9 @@ public class DocumentPreview2Action extends ActionSupport {
      */
     public String fetchEFormDocuments() {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_edoc", "r", null)) {
+            throw new SecurityException("missing required security object (_edoc)");
+        }
 
         String demographicNo = StringUtils.isNullOrEmpty(request.getParameter("demographicNo")) ? "0" : request.getParameter("demographicNo");
         String fdid = StringUtils.isNullOrEmpty(request.getParameter("fdid")) ? "0" : request.getParameter("fdid");
@@ -335,8 +343,13 @@ public class DocumentPreview2Action extends ActionSupport {
      * @see #mergeAttachedContext for the full list of request attributes set and merge semantics
      */
     private void populateAttachedContextForConsult(LoggedInInfo loggedInInfo, String demographicNo, String requestId) {
-        mergeAttachedContext(loggedInInfo,
-                EDocUtil.listDocs(loggedInInfo, demographicNo, requestId, EDocUtil.ATTACHED));
+        // Guard against missing requestId: fromIntString(null)==0 would otherwise
+        // issue a wasted query for requestId=0. Passing null to mergeAttachedContext
+        // still initializes the empty request attributes the JSP depends on.
+        List<EDoc> attachedDocs = (requestId != null)
+                ? EDocUtil.listDocs(loggedInInfo, demographicNo, requestId, EDocUtil.ATTACHED)
+                : null;
+        mergeAttachedContext(loggedInInfo, attachedDocs);
     }
 
     /**
@@ -349,8 +362,13 @@ public class DocumentPreview2Action extends ActionSupport {
      * @see #mergeAttachedContext for the full list of request attributes set and merge semantics
      */
     private void populateAttachedContextForEForm(LoggedInInfo loggedInInfo, String demographicNo, String fdid) {
-        mergeAttachedContext(loggedInInfo,
-                EDocUtil.listDocsAttachedToEForm(loggedInInfo, demographicNo, fdid, EDocUtil.ATTACHED));
+        // Skip the query when fdid is missing or the "0" sentinel (default for
+        // callers that don't bind to a specific eForm); mergeAttachedContext
+        // still initializes the empty request attributes the JSP depends on.
+        List<EDoc> attachedDocs = (fdid != null && !"0".equals(fdid))
+                ? EDocUtil.listDocsAttachedToEForm(loggedInInfo, demographicNo, fdid, EDocUtil.ATTACHED)
+                : null;
+        mergeAttachedContext(loggedInInfo, attachedDocs);
     }
 
     /**

--- a/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
+++ b/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
@@ -23,6 +23,7 @@ import ca.openosp.openo.utility.MiscUtils;
 import ca.openosp.openo.utility.PathValidationUtils;
 import ca.openosp.openo.utility.PDFGenerationException;
 import ca.openosp.openo.utility.SpringUtils;
+import ca.openosp.openo.utility.WebUtils;
 
 import ca.openosp.openo.util.StringUtils;
 
@@ -254,14 +255,14 @@ public class DocumentPreview2Action extends ActionSupport {
             throw new SecurityException("missing required security object (_edoc)");
         }
 
-        String demographicNo = positiveIntParamOrDefault(request.getParameter("demographicNo"), "0");
-        String requestId = positiveIntParamOrNull(request.getParameter("requestId"));
+        String demographicNo = WebUtils.positiveIntParamOrDefault(request.getParameter("demographicNo"), "0");
+        String requestId = WebUtils.positiveIntParamOrNull(request.getParameter("requestId"));
 
         populateCommonDocs(loggedInInfo, demographicNo);
 		List<EFormData> allEForms = EFormUtil.listPatientEformsCurrent(Integer.valueOf(demographicNo), true);
         request.setAttribute("allEForms", allEForms);
 
-        populateAttachedContextForConsult(loggedInInfo, demographicNo, requestId);
+        populateAttachedContext(loggedInInfo, documentAttachmentManager.getAttachedDocsForConsult(loggedInInfo, demographicNo, requestId));
 
         return "fetchDocuments";
     }
@@ -298,16 +299,16 @@ public class DocumentPreview2Action extends ActionSupport {
             throw new SecurityException("missing required security object (_edoc)");
         }
 
-        String demographicNo = positiveIntParamOrDefault(request.getParameter("demographicNo"), "0");
+        String demographicNo = WebUtils.positiveIntParamOrDefault(request.getParameter("demographicNo"), "0");
         String rawFdid = request.getParameter("fdid");
-        String fdidForEformList = positiveIntParamOrDefault(rawFdid, "0");
-        String fdidForAttached = positiveIntParamOrNull(rawFdid);
+        String fdidForEformList = WebUtils.positiveIntParamOrDefault(rawFdid, "0");
+        String fdidForAttached = WebUtils.positiveIntParamOrNull(rawFdid);
 
         populateCommonDocs(loggedInInfo, demographicNo);
 		List<EFormData> allEForms = documentAttachmentManager.getAllEFormsExpectFdid(loggedInInfo, Integer.parseInt(demographicNo), Integer.parseInt(fdidForEformList));
 		request.setAttribute("allEForms", allEForms);
 
-        populateAttachedContextForEForm(loggedInInfo, demographicNo, fdidForAttached);
+        populateAttachedContext(loggedInInfo, documentAttachmentManager.getAttachedDocsForEForm(loggedInInfo, demographicNo, fdidForAttached));
 
         return "fetchDocuments";
     }
@@ -335,133 +336,28 @@ public class DocumentPreview2Action extends ActionSupport {
         }
     }
 
-    /** @see #mergeAttachedContext */
-    private void populateAttachedContextForConsult(LoggedInInfo loggedInInfo, String demographicNo, String requestId) {
-        List<EDoc> attachedDocs = (requestId != null)
-                ? EDocUtil.listDocs(loggedInInfo, demographicNo, requestId, EDocUtil.ATTACHED)
-                : null;
-        mergeAttachedContext(loggedInInfo, attachedDocs);
-    }
-
-    /** @see #mergeAttachedContext */
-    private void populateAttachedContextForEForm(LoggedInInfo loggedInInfo, String demographicNo, String fdid) {
-        List<EDoc> attachedDocs = (fdid != null)
-                ? EDocUtil.listDocsAttachedToEForm(loggedInInfo, demographicNo, fdid, EDocUtil.ATTACHED)
-                : null;
-        mergeAttachedContext(loggedInInfo, attachedDocs);
-    }
-
-    /** Returns {@code value} if it parses as a positive integer, else null. Treats "null"/empty/non-numeric as absent. */
-    private static String positiveIntParamOrNull(String value) {
-        if (StringUtils.isNullOrEmpty(value)) return null;
-        String trimmed = value.trim();
-        if (trimmed.isEmpty() || "null".equalsIgnoreCase(trimmed)) return null;
-        try {
-            return Integer.parseInt(trimmed) > 0 ? trimmed : null;
-        } catch (NumberFormatException e) {
-            return null;
-        }
-    }
-
-    /** Like {@link #positiveIntParamOrNull} but returns {@code defaultValue} instead of null. */
-    private static String positiveIntParamOrDefault(String value, String defaultValue) {
-        String parsed = positiveIntParamOrNull(value);
-        return parsed != null ? parsed : defaultValue;
-    }
-
     /**
-     * Sets {@code attachedDocumentIds} and {@code foreignPrivateDocIds} request
-     * attributes, and merges deleted/cross-provider docs into the existing
-     * {@code allDocuments} / {@code providerPrivateDocs} / {@code providerPublicDocs}
-     * lists so the JSP can render them in the right section with the right markers.
+     * Pulls the three section lists out of the request, hands them to
+     * {@link DocumentAttachmentManager#mergeAttachedIntoSections} for the
+     * deleted / cross-provider merge, and writes the two resulting id Sets back
+     * to the request so the JSP can pre-check attached docs and label foreign
+     * private docs. Pure request-attribute plumbing — the classification lives
+     * on the manager.
      *
      * @since 2026-04-20
      */
     @SuppressWarnings("unchecked")
-    private void mergeAttachedContext(LoggedInInfo loggedInInfo, List<EDoc> attachedDocs) {
+    private void populateAttachedContext(LoggedInInfo loggedInInfo, List<EDoc> attachedDocs) {
         Set<String> attachedDocumentIds = new HashSet<>();
         Set<String> foreignPrivateDocIds = new HashSet<>();
         request.setAttribute("attachedDocumentIds", attachedDocumentIds);
         request.setAttribute("foreignPrivateDocIds", foreignPrivateDocIds);
 
-        if (attachedDocs == null || attachedDocs.isEmpty()) {
-            logger.debug("mergeAttachedContext: no attached docs; nothing to merge");
-            return;
-        }
-
-        // attachedDocumentIds drives JSP pre-checking and is useful even when the
-        // per-section lists aren't loaded — populate it unconditionally.
-        for (EDoc attachedDoc : attachedDocs) {
-            attachedDocumentIds.add(attachedDoc.getDocId());
-        }
-
         List<EDoc> allDocuments = (List<EDoc>) request.getAttribute("allDocuments");
         List<EDoc> providerPrivateDocs = (List<EDoc>) request.getAttribute("providerPrivateDocs");
         List<EDoc> providerPublicDocs = (List<EDoc>) request.getAttribute("providerPublicDocs");
 
-        if (allDocuments == null || providerPrivateDocs == null || providerPublicDocs == null) {
-            logger.warn("mergeAttachedContext: expected document list attributes missing; skipping section merge");
-            return;
-        }
-
-        String currentProviderNo = loggedInInfo.getLoggedInProviderNo();
-
-        for (EDoc attachedDoc : attachedDocs) {
-            mergeSingleAttachedDoc(
-                    attachedDoc,
-                    currentProviderNo,
-                    allDocuments,
-                    providerPrivateDocs,
-                    providerPublicDocs,
-                    foreignPrivateDocIds);
-        }
-    }
-
-    /**
-     * Classifies one attached doc and appends it to the appropriate section list.
-     *
-     * @since 2026-04-21
-     */
-    static void mergeSingleAttachedDoc(
-            EDoc attachedDoc,
-            String currentProviderNo,
-            List<EDoc> allDocuments,
-            List<EDoc> providerPrivateDocs,
-            List<EDoc> providerPublicDocs,
-            Set<String> foreignPrivateDocIds) {
-
-        boolean isDeleted = attachedDoc.getStatus() == 'D';
-        boolean isProvider = isProviderModule(attachedDoc.getModule());
-        boolean isPublic = "1".equals(attachedDoc.getDocPublic());
-        boolean ownedByCurrent = isOwnedByCurrentProvider(attachedDoc, currentProviderNo);
-
-        // Patient doc: only deleted ones need re-injecting.
-        if (!isProvider) {
-            if (isDeleted) allDocuments.add(attachedDoc);
-            return;
-        }
-        // Public provider doc: only deleted ones need re-injecting.
-        if (isPublic) {
-            if (isDeleted) providerPublicDocs.add(attachedDoc);
-            return;
-        }
-        // Private provider doc: skip active-own (already listed); merge everything else.
-        if (!isDeleted && ownedByCurrent) return;
-        providerPrivateDocs.add(attachedDoc);
-        if (!ownedByCurrent) foreignPrivateDocIds.add(attachedDoc.getDocId());
-    }
-
-    static boolean isOwnedByCurrentProvider(EDoc doc, String currentProviderNo) {
-        return currentProviderNo != null && currentProviderNo.equals(doc.getModuleId());
-    }
-
-    /**
-     * Local copy of {@link EDocUtil#isProviderModule} to avoid triggering EDocUtil's
-     * class-load (and its many SpringUtils-bean static initializers) from this
-     * classifier. Keeps {@link #mergeSingleAttachedDoc} unit-testable without Spring.
-     */
-    static boolean isProviderModule(String module) {
-        return "provider".equalsIgnoreCase(module) || "providers".equalsIgnoreCase(module);
+        documentAttachmentManager.mergeAttachedIntoSections(loggedInInfo, attachedDocs, allDocuments, providerPrivateDocs, providerPublicDocs, attachedDocumentIds, foreignPrivateDocIds);
     }
 
     /**

--- a/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
+++ b/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
@@ -254,7 +254,7 @@ public class DocumentPreview2Action extends ActionSupport {
             throw new SecurityException("missing required security object (_edoc)");
         }
 
-        String demographicNo = StringUtils.isNullOrEmpty(request.getParameter("demographicNo")) ? "0" : request.getParameter("demographicNo");
+        String demographicNo = positiveIntParamOrDefault(request.getParameter("demographicNo"), "0");
         String requestId = positiveIntParamOrNull(request.getParameter("requestId"));
 
         populateCommonDocs(loggedInInfo, demographicNo);
@@ -298,9 +298,9 @@ public class DocumentPreview2Action extends ActionSupport {
             throw new SecurityException("missing required security object (_edoc)");
         }
 
-        String demographicNo = StringUtils.isNullOrEmpty(request.getParameter("demographicNo")) ? "0" : request.getParameter("demographicNo");
+        String demographicNo = positiveIntParamOrDefault(request.getParameter("demographicNo"), "0");
         String rawFdid = request.getParameter("fdid");
-        String fdidForEformList = StringUtils.isNullOrEmpty(rawFdid) ? "0" : rawFdid;
+        String fdidForEformList = positiveIntParamOrDefault(rawFdid, "0");
         String fdidForAttached = positiveIntParamOrNull(rawFdid);
 
         populateCommonDocs(loggedInInfo, demographicNo);
@@ -363,6 +363,12 @@ public class DocumentPreview2Action extends ActionSupport {
         }
     }
 
+    /** Like {@link #positiveIntParamOrNull} but returns {@code defaultValue} instead of null. */
+    private static String positiveIntParamOrDefault(String value, String defaultValue) {
+        String parsed = positiveIntParamOrNull(value);
+        return parsed != null ? parsed : defaultValue;
+    }
+
     /**
      * Sets {@code attachedDocumentIds} and {@code foreignPrivateDocIds} request
      * attributes, and merges deleted/cross-provider docs into the existing
@@ -395,32 +401,55 @@ public class DocumentPreview2Action extends ActionSupport {
         String currentProviderNo = loggedInInfo.getLoggedInProviderNo();
 
         for (EDoc attachedDoc : attachedDocs) {
-            String docId = attachedDoc.getDocId();
-            // Dedupe by docId: the CtlDocument join can yield one tuple per ctl row for a doc.
-            if (!attachedDocumentIds.add(docId)) {
-                continue;
-            }
-
-            boolean isDeleted = attachedDoc.getStatus() == 'D';
-            boolean isProvider = EDocUtil.isProviderModule(attachedDoc.getModule());
-            boolean ownedByCurrent = currentProviderNo != null
-                    && currentProviderNo.equals(attachedDoc.getModuleId());
-
-            // Patient doc: only deleted ones need re-injecting.
-            if (!isProvider) {
-                if (isDeleted) allDocuments.add(attachedDoc);
-                continue;
-            }
-            // Public provider doc: only deleted ones need re-injecting.
-            if ("1".equals(attachedDoc.getDocPublic())) {
-                if (isDeleted) providerPublicDocs.add(attachedDoc);
-                continue;
-            }
-            // Private provider doc: skip active-own (already listed); merge everything else.
-            if (!isDeleted && ownedByCurrent) continue;
-            providerPrivateDocs.add(attachedDoc);
-            if (!ownedByCurrent) foreignPrivateDocIds.add(docId);
+            // Defensive dedupe: EDocUtil.listDocs already dedupes upstream, but keep this
+            // guard so future callers that pass a duped list don't double-merge sections.
+            if (!attachedDocumentIds.add(attachedDoc.getDocId())) continue;
+            mergeSingleAttachedDoc(
+                    attachedDoc,
+                    currentProviderNo,
+                    allDocuments,
+                    providerPrivateDocs,
+                    providerPublicDocs,
+                    foreignPrivateDocIds);
         }
+    }
+
+    /**
+     * Classifies one attached doc and appends it to the appropriate section list.
+     *
+     * @since 2026-04-21
+     */
+    private void mergeSingleAttachedDoc(
+            EDoc attachedDoc,
+            String currentProviderNo,
+            List<EDoc> allDocuments,
+            List<EDoc> providerPrivateDocs,
+            List<EDoc> providerPublicDocs,
+            Set<String> foreignPrivateDocIds) {
+
+        boolean isDeleted = attachedDoc.getStatus() == 'D';
+        boolean isProvider = EDocUtil.isProviderModule(attachedDoc.getModule());
+        boolean isPublic = "1".equals(attachedDoc.getDocPublic());
+        boolean ownedByCurrent = isOwnedByCurrentProvider(attachedDoc, currentProviderNo);
+
+        // Patient doc: only deleted ones need re-injecting.
+        if (!isProvider) {
+            if (isDeleted) allDocuments.add(attachedDoc);
+            return;
+        }
+        // Public provider doc: only deleted ones need re-injecting.
+        if (isPublic) {
+            if (isDeleted) providerPublicDocs.add(attachedDoc);
+            return;
+        }
+        // Private provider doc: skip active-own (already listed); merge everything else.
+        if (!isDeleted && ownedByCurrent) return;
+        providerPrivateDocs.add(attachedDoc);
+        if (!ownedByCurrent) foreignPrivateDocIds.add(attachedDoc.getDocId());
+    }
+
+    private boolean isOwnedByCurrentProvider(EDoc doc, String currentProviderNo) {
+        return currentProviderNo != null && currentProviderNo.equals(doc.getModuleId());
     }
 
     /**

--- a/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
+++ b/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
@@ -258,11 +258,9 @@ public class DocumentPreview2Action extends ActionSupport {
         String demographicNo = WebUtils.positiveIntParamOrDefault(request.getParameter("demographicNo"), "0");
         String requestId = WebUtils.positiveIntParamOrNull(request.getParameter("requestId"));
 
-        populateCommonDocs(loggedInInfo, demographicNo);
+        populateCommonDocs(loggedInInfo, demographicNo, documentAttachmentManager.getAttachedDocsForConsult(loggedInInfo, demographicNo, requestId));
 		List<EFormData> allEForms = EFormUtil.listPatientEformsCurrent(Integer.valueOf(demographicNo), true);
         request.setAttribute("allEForms", allEForms);
-
-        populateAttachedContext(loggedInInfo, documentAttachmentManager.getAttachedDocsForConsult(loggedInInfo, demographicNo, requestId));
 
         return "fetchDocuments";
     }
@@ -304,11 +302,9 @@ public class DocumentPreview2Action extends ActionSupport {
         String fdidForEformList = WebUtils.positiveIntParamOrDefault(rawFdid, "0");
         String fdidForAttached = WebUtils.positiveIntParamOrNull(rawFdid);
 
-        populateCommonDocs(loggedInInfo, demographicNo);
+        populateCommonDocs(loggedInInfo, demographicNo, documentAttachmentManager.getAttachedDocsForEForm(loggedInInfo, demographicNo, fdidForAttached));
 		List<EFormData> allEForms = documentAttachmentManager.getAllEFormsExpectFdid(loggedInInfo, Integer.parseInt(demographicNo), Integer.parseInt(fdidForEformList));
 		request.setAttribute("allEForms", allEForms);
-
-        populateAttachedContext(loggedInInfo, documentAttachmentManager.getAttachedDocsForEForm(loggedInInfo, demographicNo, fdidForAttached));
 
         return "fetchDocuments";
     }
@@ -337,35 +333,18 @@ public class DocumentPreview2Action extends ActionSupport {
     }
 
     /**
-     * Pulls the three section lists out of the request, hands them to
-     * {@link DocumentAttachmentManager#mergeAttachedIntoSections} for the
-     * deleted / cross-provider merge, and writes the two resulting id Sets back
-     * to the request so the JSP can pre-check attached docs and label foreign
-     * private docs. Pure request-attribute plumbing — the classification lives
-     * on the manager.
+     * Fetches the shared view state the attachment-dialog JSP expects — patient
+     * docs, provider private/public eDocs, HRM docs, labs, encounter forms —
+     * runs {@link DocumentAttachmentManager#mergeAttachedIntoSections} to merge
+     * deleted / cross-provider attached docs into the matching section lists,
+     * and writes all eight collections as request attributes for the JSP to
+     * render.
      *
-     * @since 2026-04-20
+     * @param loggedInInfo  LoggedInInfo the current user's session
+     * @param demographicNo String the patient's demographic number
+     * @param attachedDocs  List&lt;EDoc&gt; docs already attached to this consult/eForm; drives the merge and the id Sets (empty when not applicable)
      */
-    @SuppressWarnings("unchecked")
-    private void populateAttachedContext(LoggedInInfo loggedInInfo, List<EDoc> attachedDocs) {
-        Set<String> attachedDocumentIds = new HashSet<>();
-        Set<String> foreignPrivateDocIds = new HashSet<>();
-        request.setAttribute("attachedDocumentIds", attachedDocumentIds);
-        request.setAttribute("foreignPrivateDocIds", foreignPrivateDocIds);
-
-        List<EDoc> allDocuments = (List<EDoc>) request.getAttribute("allDocuments");
-        List<EDoc> providerPrivateDocs = (List<EDoc>) request.getAttribute("providerPrivateDocs");
-        List<EDoc> providerPublicDocs = (List<EDoc>) request.getAttribute("providerPublicDocs");
-
-        documentAttachmentManager.mergeAttachedIntoSections(loggedInInfo, attachedDocs, allDocuments, providerPrivateDocs, providerPublicDocs, attachedDocumentIds, foreignPrivateDocIds);
-    }
-
-    /**
-     * Populate common documents like EDocs, Labs, Forms, HRM documents
-     * @param loggedInInfo Information about the logged-in user
-     * @param demographicNo Demographic number of the patient
-     */
-    private void populateCommonDocs(LoggedInInfo loggedInInfo, String demographicNo) {
+    private void populateCommonDocs(LoggedInInfo loggedInInfo, String demographicNo, List<EDoc> attachedDocs) {
         List<EDoc> allDocuments = new ArrayList<>(EDocUtil.listDocs(loggedInInfo, "demographic", demographicNo, null, EDocUtil.PRIVATE, EDocUtil.EDocSort.OBSERVATIONDATE));
         List<EDoc> providerPrivateDocs = new ArrayList<>(EDocUtil.getProviderPrivateDocs(loggedInInfo));
         List<EDoc> providerPublicDocs = new ArrayList<>(EDocUtil.getProviderPublicDocs(loggedInInfo));
@@ -373,11 +352,17 @@ public class DocumentPreview2Action extends ActionSupport {
         List<AttachmentLabResultData> allLabsSortedByVersions = documentAttachmentManager.getAllLabsSortedByVersions(loggedInInfo, demographicNo);
         List<EctFormData.PatientForm> allForms = formsManager.getEncounterFormsbyDemographicNumber(loggedInInfo, Integer.parseInt(demographicNo), false, true);
 
+        Set<String> attachedDocumentIds = new HashSet<>();
+        Set<String> foreignPrivateDocIds = new HashSet<>();
+        documentAttachmentManager.mergeAttachedIntoSections(loggedInInfo, attachedDocs, allDocuments, providerPrivateDocs, providerPublicDocs, attachedDocumentIds, foreignPrivateDocIds);
+
         request.setAttribute("allDocuments", allDocuments);
         request.setAttribute("providerPrivateDocs", providerPrivateDocs);
         request.setAttribute("providerPublicDocs", providerPublicDocs);
         request.setAttribute("allHRMDocuments", allHRMDocuments);
 		request.setAttribute("allLabsSortedByVersions", allLabsSortedByVersions);
 		request.setAttribute("allForms", allForms);
+        request.setAttribute("attachedDocumentIds", attachedDocumentIds);
+        request.setAttribute("foreignPrivateDocIds", foreignPrivateDocIds);
     }
 }

--- a/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
+++ b/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
@@ -37,7 +37,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import com.opensymphony.xwork2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
@@ -228,7 +230,7 @@ public class DocumentPreview2Action extends ActionSupport {
 		List<EFormData> allEForms = EFormUtil.listPatientEformsCurrent(Integer.valueOf(demographicNo), true);
         request.setAttribute("allEForms", allEForms);
 
-        mergeSoftDeletedAttachedDocs(loggedInInfo, demographicNo, requestId, null);
+        populateAttachedContext(loggedInInfo, demographicNo, requestId, null);
 
         return "fetchDocuments";
     }
@@ -243,7 +245,7 @@ public class DocumentPreview2Action extends ActionSupport {
 		List<EFormData> allEForms = documentAttachmentManager.getAllEFormsExpectFdid(loggedInInfo, Integer.parseInt(demographicNo), Integer.parseInt(fdid));
 		request.setAttribute("allEForms", allEForms);
 
-        mergeSoftDeletedAttachedDocs(loggedInInfo, demographicNo, null, fdid);
+        populateAttachedContext(loggedInInfo, demographicNo, null, fdid);
 
         return "fetchDocuments";
     }
@@ -272,17 +274,36 @@ public class DocumentPreview2Action extends ActionSupport {
     }
 
     /**
-     * Merges soft-deleted attached documents into the existing document lists so
-     * they render naturally in the attachment manager JSP in the correct section.
+     * Populates attached-doc context for the attachment manager JSP so it can render
+     * pre-checked state and cross-provider visibility server-side.
+     *
+     * Sets three request attributes that the JSP consumes:
+     * <ul>
+     *   <li>{@code attachedDocumentIds}: Set&lt;String&gt; of all doc IDs currently attached to the
+     *       consult/eform. Used by the JSP to render checkboxes with {@code checked} and the
+     *       {@code _pre_check} class directly, bypassing the legacy client-side #id lookup.</li>
+     *   <li>{@code foreignPrivateDocIds}: Set&lt;String&gt; of private provider docs attached by a
+     *       different provider than the current user. Rendered greyed with "(other provider)"
+     *       so the current user sees what's attached and can uncheck to remove.</li>
+     *   <li>Merges soft-deleted attached docs into {@code allDocuments}/{@code providerPrivateDocs}/
+     *       {@code providerPublicDocs} so they appear in their correct section marked as deleted.</li>
+     *   <li>Merges active cross-provider private docs into {@code providerPrivateDocs} so they're
+     *       visible to non-owner providers who need to manage the existing attachment.</li>
+     * </ul>
      *
      * @param loggedInInfo LoggedInInfo the logged-in user's session information
      * @param demographicNo String the patient's demographic number
      * @param requestId String the consultation request ID, or null for eForm context
      * @param fdid String the eForm data ID, or null for consultation context
-     * @since 2026-02-20
+     * @since 2026-04-20
      */
     @SuppressWarnings("unchecked")
-    private void mergeSoftDeletedAttachedDocs(LoggedInInfo loggedInInfo, String demographicNo, String requestId, String fdid) {
+    private void populateAttachedContext(LoggedInInfo loggedInInfo, String demographicNo, String requestId, String fdid) {
+        Set<String> attachedDocumentIds = new HashSet<>();
+        Set<String> foreignPrivateDocIds = new HashSet<>();
+        request.setAttribute("attachedDocumentIds", attachedDocumentIds);
+        request.setAttribute("foreignPrivateDocIds", foreignPrivateDocIds);
+
         List<EDoc> attachedDocs;
         if (requestId != null) {
             attachedDocs = EDocUtil.listDocs(loggedInInfo, demographicNo, requestId, EDocUtil.ATTACHED);
@@ -301,28 +322,62 @@ public class DocumentPreview2Action extends ActionSupport {
         List<EDoc> providerPublicDocs = (List<EDoc>) request.getAttribute("providerPublicDocs");
 
         if (allDocuments == null || providerPrivateDocs == null || providerPublicDocs == null) {
+            logger.warn("populateAttachedContext: expected document list attributes missing; skipping merge");
             return;
         }
 
-        // Only soft-deleted docs need merging — active docs are already in the lists
+        Set<String> allDocumentIds = collectDocIds(allDocuments);
+        Set<String> myPrivateDocIds = collectDocIds(providerPrivateDocs);
+        Set<String> publicDocIds = collectDocIds(providerPublicDocs);
+        String currentProviderNo = loggedInInfo.getLoggedInProviderNo();
+
         for (EDoc attachedDoc : attachedDocs) {
-            if (attachedDoc.getStatus() != 'D') {
+            String docId = attachedDoc.getDocId();
+            attachedDocumentIds.add(docId);
+
+            boolean isDeleted = attachedDoc.getStatus() == 'D';
+            boolean alreadyRendered = allDocumentIds.contains(docId)
+                    || myPrivateDocIds.contains(docId)
+                    || publicDocIds.contains(docId);
+
+            // Active + already in some list: nothing to merge. listDocs(ATTACHED)
+            // doesn't populate module, so membership is how we classify here.
+            if (!isDeleted && alreadyRendered) {
                 continue;
             }
-            EDoc fullDoc = EDocUtil.getEDocFromDocId(attachedDoc.getDocId());
+
+            EDoc fullDoc = EDocUtil.getEDocFromDocId(docId);
             if (fullDoc.getDocId() == null || fullDoc.getDocId().isEmpty()) {
                 continue;
             }
+
             if (EDocUtil.isProviderModule(fullDoc.getModule())) {
-                if ("1".equals(fullDoc.getDocPublic())) {
-                    providerPublicDocs.add(fullDoc);
+                boolean isPublic = "1".equals(fullDoc.getDocPublic());
+                if (isPublic) {
+                    if (isDeleted) {
+                        providerPublicDocs.add(fullDoc);
+                    }
+                    // active public is already in the global list
                 } else {
                     providerPrivateDocs.add(fullDoc);
+                    boolean ownedByCurrent = currentProviderNo != null
+                            && currentProviderNo.equals(fullDoc.getModuleId());
+                    if (!ownedByCurrent) {
+                        foreignPrivateDocIds.add(docId);
+                    }
                 }
-            } else {
+            } else if (isDeleted) {
                 allDocuments.add(fullDoc);
             }
         }
+    }
+
+    private static Set<String> collectDocIds(List<EDoc> docs) {
+        Set<String> ids = new HashSet<>();
+        for (EDoc doc : docs) {
+            ids.add(doc.getDocId());
+        }
+        return ids;
     }
 
     /**

--- a/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
+++ b/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
@@ -222,10 +222,13 @@ public class DocumentPreview2Action extends ActionSupport {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
 
         String demographicNo = StringUtils.isNullOrEmpty(request.getParameter("demographicNo")) ? "0" : request.getParameter("demographicNo");
+        String requestId = StringUtils.isNullOrEmpty(request.getParameter("requestId")) ? null : request.getParameter("requestId");
 
         populateCommonDocs(loggedInInfo, demographicNo);
 		List<EFormData> allEForms = EFormUtil.listPatientEformsCurrent(Integer.valueOf(demographicNo), true);
         request.setAttribute("allEForms", allEForms);
+
+        mergeSoftDeletedAttachedDocs(loggedInInfo, demographicNo, requestId, null);
 
         return "fetchDocuments";
     }
@@ -239,6 +242,8 @@ public class DocumentPreview2Action extends ActionSupport {
         populateCommonDocs(loggedInInfo, demographicNo);
 		List<EFormData> allEForms = documentAttachmentManager.getAllEFormsExpectFdid(loggedInInfo, Integer.parseInt(demographicNo), Integer.parseInt(fdid));
 		request.setAttribute("allEForms", allEForms);
+
+        mergeSoftDeletedAttachedDocs(loggedInInfo, demographicNo, null, fdid);
 
         return "fetchDocuments";
     }
@@ -267,14 +272,64 @@ public class DocumentPreview2Action extends ActionSupport {
     }
 
     /**
+     * Merges soft-deleted attached documents into the existing document lists so
+     * they render naturally in the attachment manager JSP in the correct section.
+     *
+     * @param loggedInInfo LoggedInInfo the logged-in user's session information
+     * @param demographicNo String the patient's demographic number
+     * @param requestId String the consultation request ID, or null for eForm context
+     * @param fdid String the eForm data ID, or null for consultation context
+     * @since 2026-02-20
+     */
+    @SuppressWarnings("unchecked")
+    private void mergeSoftDeletedAttachedDocs(LoggedInInfo loggedInInfo, String demographicNo, String requestId, String fdid) {
+        List<EDoc> attachedDocs;
+        if (requestId != null) {
+            attachedDocs = EDocUtil.listDocs(loggedInInfo, demographicNo, requestId, EDocUtil.ATTACHED);
+        } else if (fdid != null) {
+            attachedDocs = EDocUtil.listDocsAttachedToEForm(loggedInInfo, demographicNo, fdid, EDocUtil.ATTACHED);
+        } else {
+            return;
+        }
+
+        if (attachedDocs == null || attachedDocs.isEmpty()) {
+            return;
+        }
+
+        List<EDoc> allDocuments = (List<EDoc>) request.getAttribute("allDocuments");
+        List<EDoc> providerPrivateDocs = (List<EDoc>) request.getAttribute("providerPrivateDocs");
+        List<EDoc> providerPublicDocs = (List<EDoc>) request.getAttribute("providerPublicDocs");
+
+        // Only soft-deleted docs need merging — active docs are already in the lists
+        for (EDoc attachedDoc : attachedDocs) {
+            if (attachedDoc.getStatus() != 'D') {
+                continue;
+            }
+            EDoc fullDoc = EDocUtil.getEDocFromDocId(attachedDoc.getDocId());
+            if (fullDoc.getDocId() == null || fullDoc.getDocId().isEmpty()) {
+                continue;
+            }
+            if (EDocUtil.isProviderModule(fullDoc.getModule())) {
+                if ("1".equals(fullDoc.getDocPublic())) {
+                    providerPublicDocs.add(fullDoc);
+                } else {
+                    providerPrivateDocs.add(fullDoc);
+                }
+            } else {
+                allDocuments.add(fullDoc);
+            }
+        }
+    }
+
+    /**
      * Populate common documents like EDocs, Labs, Forms, HRM documents
      * @param loggedInInfo Information about the logged-in user
      * @param demographicNo Demographic number of the patient
      */
     private void populateCommonDocs(LoggedInInfo loggedInInfo, String demographicNo) {
         List<EDoc> allDocuments = EDocUtil.listDocs(loggedInInfo, "demographic", demographicNo, null, EDocUtil.PRIVATE, EDocUtil.EDocSort.OBSERVATIONDATE);
-        List<EDoc> providerPrivateDocs = EDocUtil.getProviderPrivateDocs(loggedInInfo);
-        List<EDoc> providerPublicDocs = EDocUtil.getProviderPublicDocs(loggedInInfo);
+        List<EDoc> providerPrivateDocs = new ArrayList<>(EDocUtil.getProviderPrivateDocs(loggedInInfo));
+        List<EDoc> providerPublicDocs = new ArrayList<>(EDocUtil.getProviderPublicDocs(loggedInInfo));
         ArrayList<HashMap<String,? extends Object>> allHRMDocuments = HRMUtil.listHRMDocuments(loggedInInfo, "report_date", false, demographicNo,false);
         List<AttachmentLabResultData> allLabsSortedByVersions = documentAttachmentManager.getAllLabsSortedByVersions(loggedInInfo, demographicNo);
         List<EctFormData.PatientForm> allForms = formsManager.getEncounterFormsbyDemographicNumber(loggedInInfo, Integer.parseInt(demographicNo), false, true);

--- a/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
+++ b/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
@@ -220,6 +220,32 @@ public class DocumentPreview2Action extends ActionSupport {
         }
     }
 
+    /**
+     * Fetches all consultation-related documents for a specified patient.
+     *
+     * Retrieves comprehensive medical documentation for consultation workflows including
+     * electronic documents, hospital reports, laboratory results sorted by versions,
+     * encounter forms, and current electronic forms. The documents are populated as
+     * request attributes for rendering in the consultation document selection interface.
+     *
+     * Expected request parameters:
+     * - demographicNo: String the patient's demographic number (defaults to "0" if not provided)
+     * - requestId: String the consultation request ID (optional; enables attached-state rendering)
+     *
+     * Request attributes set:
+     * - allDocuments: List&lt;EDoc&gt; all electronic documents for the patient
+     * - providerPrivateDocs: List&lt;EDoc&gt; the current provider's private eDocs (plus any foreign
+     *   cross-provider private docs attached to this consult)
+     * - providerPublicDocs: List&lt;EDoc&gt; all public provider eDocs
+     * - allHRMDocuments: ArrayList&lt;HashMap&lt;String,? extends Object&gt;&gt; all HRM documents
+     * - allLabsSortedByVersions: List&lt;AttachmentLabResultData&gt; lab results sorted by versions
+     * - allForms: List&lt;EctFormData.PatientForm&gt; all encounter forms
+     * - allEForms: List&lt;EFormData&gt; all current electronic forms
+     * - attachedDocumentIds: Set&lt;String&gt; doc IDs already attached to this consult
+     * - foreignPrivateDocIds: Set&lt;String&gt; attached private docs not owned by the current provider
+     *
+     * @return String "fetchDocuments" result name for Struts2 result mapping
+     */
     public String fetchConsultDocuments() {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
 
@@ -230,11 +256,37 @@ public class DocumentPreview2Action extends ActionSupport {
 		List<EFormData> allEForms = EFormUtil.listPatientEformsCurrent(Integer.valueOf(demographicNo), true);
         request.setAttribute("allEForms", allEForms);
 
-        populateAttachedContext(loggedInInfo, demographicNo, requestId, null);
+        populateAttachedContextForConsult(loggedInInfo, demographicNo, requestId);
 
         return "fetchDocuments";
     }
 
+    /**
+     * Fetches electronic form documents for a specified patient, excluding a specific form.
+     *
+     * Retrieves comprehensive medical documentation similar to fetchConsultDocuments, but
+     * filters out a specific electronic form by form data ID (fdid). This is typically used
+     * when attaching documents to an existing eForm to prevent self-reference. The documents
+     * are populated as request attributes for rendering in the document selection interface.
+     *
+     * Expected request parameters:
+     * - demographicNo: String the patient's demographic number (defaults to "0" if not provided)
+     * - fdid: String the form data ID to exclude from the eForm list (defaults to "0" if not provided)
+     *
+     * Request attributes set:
+     * - allDocuments: List&lt;EDoc&gt; all electronic documents for the patient
+     * - providerPrivateDocs: List&lt;EDoc&gt; the current provider's private eDocs (plus any foreign
+     *   cross-provider private docs attached to this eForm)
+     * - providerPublicDocs: List&lt;EDoc&gt; all public provider eDocs
+     * - allHRMDocuments: ArrayList&lt;HashMap&lt;String,? extends Object&gt;&gt; all HRM documents
+     * - allLabsSortedByVersions: List&lt;AttachmentLabResultData&gt; lab results sorted by versions
+     * - allForms: List&lt;EctFormData.PatientForm&gt; all encounter forms
+     * - allEForms: List&lt;EFormData&gt; all electronic forms excluding the specified fdid
+     * - attachedDocumentIds: Set&lt;String&gt; doc IDs already attached to this eForm
+     * - foreignPrivateDocIds: Set&lt;String&gt; attached private docs not owned by the current provider
+     *
+     * @return String "fetchDocuments" result name for Struts2 result mapping
+     */
     public String fetchEFormDocuments() {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
 
@@ -245,7 +297,7 @@ public class DocumentPreview2Action extends ActionSupport {
 		List<EFormData> allEForms = documentAttachmentManager.getAllEFormsExpectFdid(loggedInInfo, Integer.parseInt(demographicNo), Integer.parseInt(fdid));
 		request.setAttribute("allEForms", allEForms);
 
-        populateAttachedContext(loggedInInfo, demographicNo, null, fdid);
+        populateAttachedContextForEForm(loggedInInfo, demographicNo, fdid);
 
         return "fetchDocuments";
     }
@@ -274,46 +326,66 @@ public class DocumentPreview2Action extends ActionSupport {
     }
 
     /**
-     * Populates attached-doc context for the attachment manager JSP so it can render
-     * pre-checked state and cross-provider visibility server-side.
+     * Populates attached-doc context for a consultation's attachment manager.
      *
-     * Sets three request attributes that the JSP consumes:
+     * @param loggedInInfo  LoggedInInfo the logged-in user's session information
+     * @param demographicNo String the patient's demographic number
+     * @param requestId     String the consultation request ID
+     * @since 2026-04-20
+     * @see #mergeAttachedContext for the full list of request attributes set and merge semantics
+     */
+    private void populateAttachedContextForConsult(LoggedInInfo loggedInInfo, String demographicNo, String requestId) {
+        mergeAttachedContext(loggedInInfo,
+                EDocUtil.listDocs(loggedInInfo, demographicNo, requestId, EDocUtil.ATTACHED));
+    }
+
+    /**
+     * Populates attached-doc context for an eForm's attachment manager.
+     *
+     * @param loggedInInfo  LoggedInInfo the logged-in user's session information
+     * @param demographicNo String the patient's demographic number
+     * @param fdid          String the eForm data ID
+     * @since 2026-04-20
+     * @see #mergeAttachedContext for the full list of request attributes set and merge semantics
+     */
+    private void populateAttachedContextForEForm(LoggedInInfo loggedInInfo, String demographicNo, String fdid) {
+        mergeAttachedContext(loggedInInfo,
+                EDocUtil.listDocsAttachedToEForm(loggedInInfo, demographicNo, fdid, EDocUtil.ATTACHED));
+    }
+
+    /**
+     * Shared merge logic for attached-doc context, independent of whether the context
+     * is a consultation or an eForm. Populates two request attributes and merges
+     * docs that need to be re-rendered in their correct section.
+     *
+     * Sets:
      * <ul>
-     *   <li>{@code attachedDocumentIds}: Set&lt;String&gt; of all doc IDs currently attached to the
-     *       consult/eform. Used by the JSP to render checkboxes with {@code checked} and the
+     *   <li>{@code attachedDocumentIds}: Set&lt;String&gt; of all doc IDs currently attached.
+     *       The JSP uses this to render checkboxes with {@code checked} and the
      *       {@code _pre_check} class directly, bypassing the legacy client-side #id lookup.</li>
      *   <li>{@code foreignPrivateDocIds}: Set&lt;String&gt; of private provider docs attached by a
      *       different provider than the current user. Rendered greyed with "(other provider)"
      *       so the current user sees what's attached and can uncheck to remove.</li>
-     *   <li>Merges soft-deleted attached docs into {@code allDocuments}/{@code providerPrivateDocs}/
-     *       {@code providerPublicDocs} so they appear in their correct section marked as deleted.</li>
-     *   <li>Merges active cross-provider private docs into {@code providerPrivateDocs} so they're
-     *       visible to non-owner providers who need to manage the existing attachment.</li>
      * </ul>
      *
+     * Merges into the existing {@code allDocuments}/{@code providerPrivateDocs}/
+     * {@code providerPublicDocs} lists so soft-deleted docs render in their section
+     * with a "(deleted)" marker, and active cross-provider private docs become
+     * visible to non-owner providers.
+     *
      * @param loggedInInfo LoggedInInfo the logged-in user's session information
-     * @param demographicNo String the patient's demographic number
-     * @param requestId String the consultation request ID, or null for eForm context
-     * @param fdid String the eForm data ID, or null for consultation context
+     * @param attachedDocs List&lt;EDoc&gt; the list of docs currently attached to the consult/eForm
      * @since 2026-04-20
      */
     @SuppressWarnings("unchecked")
-    private void populateAttachedContext(LoggedInInfo loggedInInfo, String demographicNo, String requestId, String fdid) {
+    private void mergeAttachedContext(LoggedInInfo loggedInInfo, List<EDoc> attachedDocs) {
         Set<String> attachedDocumentIds = new HashSet<>();
         Set<String> foreignPrivateDocIds = new HashSet<>();
         request.setAttribute("attachedDocumentIds", attachedDocumentIds);
         request.setAttribute("foreignPrivateDocIds", foreignPrivateDocIds);
 
-        List<EDoc> attachedDocs;
-        if (requestId != null) {
-            attachedDocs = EDocUtil.listDocs(loggedInInfo, demographicNo, requestId, EDocUtil.ATTACHED);
-        } else if (fdid != null) {
-            attachedDocs = EDocUtil.listDocsAttachedToEForm(loggedInInfo, demographicNo, fdid, EDocUtil.ATTACHED);
-        } else {
-            return;
-        }
-
         if (attachedDocs == null || attachedDocs.isEmpty()) {
+            logger.debug("mergeAttachedContext: no attached docs for current consult/eForm; nothing to merge");
             return;
         }
 
@@ -322,13 +394,10 @@ public class DocumentPreview2Action extends ActionSupport {
         List<EDoc> providerPublicDocs = (List<EDoc>) request.getAttribute("providerPublicDocs");
 
         if (allDocuments == null || providerPrivateDocs == null || providerPublicDocs == null) {
-            logger.warn("populateAttachedContext: expected document list attributes missing; skipping merge");
+            logger.warn("mergeAttachedContext: expected document list attributes missing; skipping merge");
             return;
         }
 
-        Set<String> allDocumentIds = collectDocIds(allDocuments);
-        Set<String> myPrivateDocIds = collectDocIds(providerPrivateDocs);
-        Set<String> publicDocIds = collectDocIds(providerPublicDocs);
         String currentProviderNo = loggedInInfo.getLoggedInProviderNo();
 
         for (EDoc attachedDoc : attachedDocs) {
@@ -336,48 +405,30 @@ public class DocumentPreview2Action extends ActionSupport {
             attachedDocumentIds.add(docId);
 
             boolean isDeleted = attachedDoc.getStatus() == 'D';
-            boolean alreadyRendered = allDocumentIds.contains(docId)
-                    || myPrivateDocIds.contains(docId)
-                    || publicDocIds.contains(docId);
+            boolean isProvider = EDocUtil.isProviderModule(attachedDoc.getModule());
+            boolean ownedByCurrent = currentProviderNo != null
+                    && currentProviderNo.equals(attachedDoc.getModuleId());
 
-            // Active + already in some list: nothing to merge. listDocs(ATTACHED)
-            // doesn't populate module, so membership is how we classify here.
-            if (!isDeleted && alreadyRendered) {
+            // Patient doc: only deleted ones need re-injecting (active is already listed).
+            if (!isProvider) {
+                if (isDeleted) allDocuments.add(attachedDoc);
                 continue;
             }
 
-            EDoc fullDoc = EDocUtil.getEDocFromDocId(docId);
-            if (fullDoc.getDocId() == null || fullDoc.getDocId().isEmpty()) {
+            // Public provider doc: only deleted ones need re-injecting (active is global).
+            if ("1".equals(attachedDoc.getDocPublic())) {
+                if (isDeleted) providerPublicDocs.add(attachedDoc);
                 continue;
             }
 
-            if (EDocUtil.isProviderModule(fullDoc.getModule())) {
-                boolean isPublic = "1".equals(fullDoc.getDocPublic());
-                if (isPublic) {
-                    if (isDeleted) {
-                        providerPublicDocs.add(fullDoc);
-                    }
-                    // active public is already in the global list
-                } else {
-                    providerPrivateDocs.add(fullDoc);
-                    boolean ownedByCurrent = currentProviderNo != null
-                            && currentProviderNo.equals(fullDoc.getModuleId());
-                    if (!ownedByCurrent) {
-                        foreignPrivateDocIds.add(docId);
-                    }
-                }
-            } else if (isDeleted) {
-                allDocuments.add(fullDoc);
-            }
-        }
-    }
+            // Private provider doc: active-own is already in the list; skip it.
+            if (!isDeleted && ownedByCurrent) continue;
 
-    private static Set<String> collectDocIds(List<EDoc> docs) {
-        Set<String> ids = new HashSet<>();
-        for (EDoc doc : docs) {
-            ids.add(doc.getDocId());
+            // Remaining cases all merge into providerPrivateDocs:
+            //   own-deleted, active cross-provider, deleted cross-provider.
+            providerPrivateDocs.add(attachedDoc);
+            if (!ownedByCurrent) foreignPrivateDocIds.add(docId);
         }
-        return ids;
     }
 
     /**

--- a/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
+++ b/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
@@ -389,19 +389,24 @@ public class DocumentPreview2Action extends ActionSupport {
             return;
         }
 
+        // attachedDocumentIds drives JSP pre-checking and is useful even when the
+        // per-section lists aren't loaded — populate it unconditionally.
+        for (EDoc attachedDoc : attachedDocs) {
+            attachedDocumentIds.add(attachedDoc.getDocId());
+        }
+
         List<EDoc> allDocuments = (List<EDoc>) request.getAttribute("allDocuments");
         List<EDoc> providerPrivateDocs = (List<EDoc>) request.getAttribute("providerPrivateDocs");
         List<EDoc> providerPublicDocs = (List<EDoc>) request.getAttribute("providerPublicDocs");
 
         if (allDocuments == null || providerPrivateDocs == null || providerPublicDocs == null) {
-            logger.warn("mergeAttachedContext: expected document list attributes missing; skipping merge");
+            logger.warn("mergeAttachedContext: expected document list attributes missing; skipping section merge");
             return;
         }
 
         String currentProviderNo = loggedInInfo.getLoggedInProviderNo();
 
         for (EDoc attachedDoc : attachedDocs) {
-            attachedDocumentIds.add(attachedDoc.getDocId());
             mergeSingleAttachedDoc(
                     attachedDoc,
                     currentProviderNo,

--- a/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
+++ b/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
@@ -273,8 +273,7 @@ public class DocumentPreview2Action extends ActionSupport {
      */
     private void populateCommonDocs(LoggedInInfo loggedInInfo, String demographicNo) {
         List<EDoc> allDocuments = EDocUtil.listDocs(loggedInInfo, "demographic", demographicNo, null, EDocUtil.PRIVATE, EDocUtil.EDocSort.OBSERVATIONDATE);
-        String providerNo = loggedInInfo.getLoggedInProviderNo();
-        List<EDoc> providerPrivateDocs = EDocUtil.listDocs(loggedInInfo, "providers", providerNo, null, EDocUtil.PRIVATE, EDocUtil.EDocSort.OBSERVATIONDATE);
+        List<EDoc> providerPrivateDocs = EDocUtil.getProviderPrivateDocs(loggedInInfo);
         ArrayList<HashMap<String,? extends Object>> allHRMDocuments = HRMUtil.listHRMDocuments(loggedInInfo, "report_date", false, demographicNo,false);
         List<AttachmentLabResultData> allLabsSortedByVersions = documentAttachmentManager.getAllLabsSortedByVersions(loggedInInfo, demographicNo);
         List<EctFormData.PatientForm> allForms = formsManager.getEncounterFormsbyDemographicNumber(loggedInInfo, Integer.parseInt(demographicNo), false, true);

--- a/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
+++ b/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
@@ -255,7 +255,7 @@ public class DocumentPreview2Action extends ActionSupport {
         }
 
         String demographicNo = StringUtils.isNullOrEmpty(request.getParameter("demographicNo")) ? "0" : request.getParameter("demographicNo");
-        String requestId = StringUtils.isNullOrEmpty(request.getParameter("requestId")) ? null : request.getParameter("requestId");
+        String requestId = positiveIntParamOrNull(request.getParameter("requestId"));
 
         populateCommonDocs(loggedInInfo, demographicNo);
 		List<EFormData> allEForms = EFormUtil.listPatientEformsCurrent(Integer.valueOf(demographicNo), true);
@@ -299,13 +299,15 @@ public class DocumentPreview2Action extends ActionSupport {
         }
 
         String demographicNo = StringUtils.isNullOrEmpty(request.getParameter("demographicNo")) ? "0" : request.getParameter("demographicNo");
-        String fdid = StringUtils.isNullOrEmpty(request.getParameter("fdid")) ? "0" : request.getParameter("fdid");
+        String rawFdid = request.getParameter("fdid");
+        String fdidForEformList = StringUtils.isNullOrEmpty(rawFdid) ? "0" : rawFdid;
+        String fdidForAttached = positiveIntParamOrNull(rawFdid);
 
         populateCommonDocs(loggedInInfo, demographicNo);
-		List<EFormData> allEForms = documentAttachmentManager.getAllEFormsExpectFdid(loggedInInfo, Integer.parseInt(demographicNo), Integer.parseInt(fdid));
+		List<EFormData> allEForms = documentAttachmentManager.getAllEFormsExpectFdid(loggedInInfo, Integer.parseInt(demographicNo), Integer.parseInt(fdidForEformList));
 		request.setAttribute("allEForms", allEForms);
 
-        populateAttachedContextForEForm(loggedInInfo, demographicNo, fdid);
+        populateAttachedContextForEForm(loggedInInfo, demographicNo, fdidForAttached);
 
         return "fetchDocuments";
     }
@@ -333,66 +335,40 @@ public class DocumentPreview2Action extends ActionSupport {
         }
     }
 
-    /**
-     * Populates attached-doc context for a consultation's attachment manager.
-     *
-     * @param loggedInInfo  LoggedInInfo the logged-in user's session information
-     * @param demographicNo String the patient's demographic number
-     * @param requestId     String the consultation request ID
-     * @since 2026-04-20
-     * @see #mergeAttachedContext for the full list of request attributes set and merge semantics
-     */
+    /** @see #mergeAttachedContext */
     private void populateAttachedContextForConsult(LoggedInInfo loggedInInfo, String demographicNo, String requestId) {
-        // Guard against missing requestId: fromIntString(null)==0 would otherwise
-        // issue a wasted query for requestId=0. Passing null to mergeAttachedContext
-        // still initializes the empty request attributes the JSP depends on.
         List<EDoc> attachedDocs = (requestId != null)
                 ? EDocUtil.listDocs(loggedInInfo, demographicNo, requestId, EDocUtil.ATTACHED)
                 : null;
         mergeAttachedContext(loggedInInfo, attachedDocs);
     }
 
-    /**
-     * Populates attached-doc context for an eForm's attachment manager.
-     *
-     * @param loggedInInfo  LoggedInInfo the logged-in user's session information
-     * @param demographicNo String the patient's demographic number
-     * @param fdid          String the eForm data ID
-     * @since 2026-04-20
-     * @see #mergeAttachedContext for the full list of request attributes set and merge semantics
-     */
+    /** @see #mergeAttachedContext */
     private void populateAttachedContextForEForm(LoggedInInfo loggedInInfo, String demographicNo, String fdid) {
-        // Skip the query when fdid is missing or the "0" sentinel (default for
-        // callers that don't bind to a specific eForm); mergeAttachedContext
-        // still initializes the empty request attributes the JSP depends on.
-        List<EDoc> attachedDocs = (fdid != null && !"0".equals(fdid))
+        List<EDoc> attachedDocs = (fdid != null)
                 ? EDocUtil.listDocsAttachedToEForm(loggedInInfo, demographicNo, fdid, EDocUtil.ATTACHED)
                 : null;
         mergeAttachedContext(loggedInInfo, attachedDocs);
     }
 
+    /** Returns {@code value} if it parses as a positive integer, else null. Treats "null"/empty/non-numeric as absent. */
+    private static String positiveIntParamOrNull(String value) {
+        if (StringUtils.isNullOrEmpty(value)) return null;
+        String trimmed = value.trim();
+        if (trimmed.isEmpty() || "null".equalsIgnoreCase(trimmed)) return null;
+        try {
+            return Integer.parseInt(trimmed) > 0 ? trimmed : null;
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
     /**
-     * Shared merge logic for attached-doc context, independent of whether the context
-     * is a consultation or an eForm. Populates two request attributes and merges
-     * docs that need to be re-rendered in their correct section.
+     * Sets {@code attachedDocumentIds} and {@code foreignPrivateDocIds} request
+     * attributes, and merges deleted/cross-provider docs into the existing
+     * {@code allDocuments} / {@code providerPrivateDocs} / {@code providerPublicDocs}
+     * lists so the JSP can render them in the right section with the right markers.
      *
-     * Sets:
-     * <ul>
-     *   <li>{@code attachedDocumentIds}: Set&lt;String&gt; of all doc IDs currently attached.
-     *       The JSP uses this to render checkboxes with {@code checked} and the
-     *       {@code _pre_check} class directly, bypassing the legacy client-side #id lookup.</li>
-     *   <li>{@code foreignPrivateDocIds}: Set&lt;String&gt; of private provider docs attached by a
-     *       different provider than the current user. Rendered greyed with "(other provider)"
-     *       so the current user sees what's attached and can uncheck to remove.</li>
-     * </ul>
-     *
-     * Merges into the existing {@code allDocuments}/{@code providerPrivateDocs}/
-     * {@code providerPublicDocs} lists so soft-deleted docs render in their section
-     * with a "(deleted)" marker, and active cross-provider private docs become
-     * visible to non-owner providers.
-     *
-     * @param loggedInInfo LoggedInInfo the logged-in user's session information
-     * @param attachedDocs List&lt;EDoc&gt; the list of docs currently attached to the consult/eForm
      * @since 2026-04-20
      */
     @SuppressWarnings("unchecked")
@@ -403,7 +379,7 @@ public class DocumentPreview2Action extends ActionSupport {
         request.setAttribute("foreignPrivateDocIds", foreignPrivateDocIds);
 
         if (attachedDocs == null || attachedDocs.isEmpty()) {
-            logger.debug("mergeAttachedContext: no attached docs for current consult/eForm; nothing to merge");
+            logger.debug("mergeAttachedContext: no attached docs; nothing to merge");
             return;
         }
 
@@ -420,30 +396,28 @@ public class DocumentPreview2Action extends ActionSupport {
 
         for (EDoc attachedDoc : attachedDocs) {
             String docId = attachedDoc.getDocId();
-            attachedDocumentIds.add(docId);
+            // Dedupe by docId: the CtlDocument join can yield one tuple per ctl row for a doc.
+            if (!attachedDocumentIds.add(docId)) {
+                continue;
+            }
 
             boolean isDeleted = attachedDoc.getStatus() == 'D';
             boolean isProvider = EDocUtil.isProviderModule(attachedDoc.getModule());
             boolean ownedByCurrent = currentProviderNo != null
                     && currentProviderNo.equals(attachedDoc.getModuleId());
 
-            // Patient doc: only deleted ones need re-injecting (active is already listed).
+            // Patient doc: only deleted ones need re-injecting.
             if (!isProvider) {
                 if (isDeleted) allDocuments.add(attachedDoc);
                 continue;
             }
-
-            // Public provider doc: only deleted ones need re-injecting (active is global).
+            // Public provider doc: only deleted ones need re-injecting.
             if ("1".equals(attachedDoc.getDocPublic())) {
                 if (isDeleted) providerPublicDocs.add(attachedDoc);
                 continue;
             }
-
-            // Private provider doc: active-own is already in the list; skip it.
+            // Private provider doc: skip active-own (already listed); merge everything else.
             if (!isDeleted && ownedByCurrent) continue;
-
-            // Remaining cases all merge into providerPrivateDocs:
-            //   own-deleted, active cross-provider, deleted cross-provider.
             providerPrivateDocs.add(attachedDoc);
             if (!ownedByCurrent) foreignPrivateDocIds.add(docId);
         }

--- a/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
+++ b/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
@@ -300,6 +300,10 @@ public class DocumentPreview2Action extends ActionSupport {
         List<EDoc> providerPrivateDocs = (List<EDoc>) request.getAttribute("providerPrivateDocs");
         List<EDoc> providerPublicDocs = (List<EDoc>) request.getAttribute("providerPublicDocs");
 
+        if (allDocuments == null || providerPrivateDocs == null || providerPublicDocs == null) {
+            return;
+        }
+
         // Only soft-deleted docs need merging — active docs are already in the lists
         for (EDoc attachedDoc : attachedDocs) {
             if (attachedDoc.getStatus() != 'D') {
@@ -327,7 +331,7 @@ public class DocumentPreview2Action extends ActionSupport {
      * @param demographicNo Demographic number of the patient
      */
     private void populateCommonDocs(LoggedInInfo loggedInInfo, String demographicNo) {
-        List<EDoc> allDocuments = EDocUtil.listDocs(loggedInInfo, "demographic", demographicNo, null, EDocUtil.PRIVATE, EDocUtil.EDocSort.OBSERVATIONDATE);
+        List<EDoc> allDocuments = new ArrayList<>(EDocUtil.listDocs(loggedInInfo, "demographic", demographicNo, null, EDocUtil.PRIVATE, EDocUtil.EDocSort.OBSERVATIONDATE));
         List<EDoc> providerPrivateDocs = new ArrayList<>(EDocUtil.getProviderPrivateDocs(loggedInInfo));
         List<EDoc> providerPublicDocs = new ArrayList<>(EDocUtil.getProviderPublicDocs(loggedInInfo));
         ArrayList<HashMap<String,? extends Object>> allHRMDocuments = HRMUtil.listHRMDocuments(loggedInInfo, "report_date", false, demographicNo,false);

--- a/src/main/java/ca/openosp/openo/eform/data/EForm.java
+++ b/src/main/java/ca/openosp/openo/eform/data/EForm.java
@@ -1023,8 +1023,11 @@ public class EForm extends EFormBase {
 	}
 
     public void addHiddenAttachments(List<String> attachedDocumentIds, List<String> attachedEFormIds, List<String> attachedHRMDocumentIds, List<String> attachedLabIds, List<EctFormData.PatientForm> attachedForms) {
+        // data-delegate-type="doc" lets the toolbar JS resolve by name+value
+        // so provider-section checkboxes (publicDocNo*, privateDocNo*) match too.
+        Map<String, String> docProps = Collections.singletonMap("data-delegate-type", "doc");
         for (String docId : attachedDocumentIds) {
-            addHiddenInputElement("delegate_docNo" + docId, "docNo", "delegateAttachment", docId, null);
+            addHiddenInputElement("delegate_docNo" + docId, "docNo", "delegateAttachment", docId, docProps);
         }
 
         for (String eformId : attachedEFormIds) {

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/ConsultationAttachDocs2Action.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/ConsultationAttachDocs2Action.java
@@ -105,6 +105,8 @@ public class ConsultationAttachDocs2Action extends ActionSupport {
         //Get all DOCUMENT information for demographic, along with which are already attached
         List<String> attachedDocumentIds = new ArrayList<String>();
         List<EDoc> allDocuments = EDocUtil.listDocs(loggedInInfo, "demographic", demographicNo, null, EDocUtil.PRIVATE, EDocUtil.EDocSort.OBSERVATIONDATE);
+        String providerNo = loggedInInfo.getLoggedInProviderNo();
+        List<EDoc> providerPrivateDocs = EDocUtil.listDocs(loggedInInfo, "providers", providerNo, null, EDocUtil.PRIVATE, EDocUtil.EDocSort.OBSERVATIONDATE);
         List<EDoc> attachedDocuments = EDocUtil.listDocs(loggedInInfo, demographicNo, requestId, EDocUtil.ATTACHED);
         if (attachedDocuments != null) {
             for (EDoc document : attachedDocuments) {
@@ -159,6 +161,7 @@ public class ConsultationAttachDocs2Action extends ActionSupport {
 
 
         request.setAttribute("allDocuments", allDocuments);
+        request.setAttribute("providerPrivateDocs", providerPrivateDocs);
         request.setAttribute("allLabs", allLabs);
         request.setAttribute("allForms", allForms);
         request.setAttribute("allEForms", allEForms);

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/ConsultationAttachDocs2Action.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/ConsultationAttachDocs2Action.java
@@ -105,8 +105,7 @@ public class ConsultationAttachDocs2Action extends ActionSupport {
         //Get all DOCUMENT information for demographic, along with which are already attached
         List<String> attachedDocumentIds = new ArrayList<String>();
         List<EDoc> allDocuments = EDocUtil.listDocs(loggedInInfo, "demographic", demographicNo, null, EDocUtil.PRIVATE, EDocUtil.EDocSort.OBSERVATIONDATE);
-        String providerNo = loggedInInfo.getLoggedInProviderNo();
-        List<EDoc> providerPrivateDocs = EDocUtil.listDocs(loggedInInfo, "providers", providerNo, null, EDocUtil.PRIVATE, EDocUtil.EDocSort.OBSERVATIONDATE);
+        List<EDoc> providerPrivateDocs = EDocUtil.getProviderPrivateDocs(loggedInInfo);
         List<EDoc> attachedDocuments = EDocUtil.listDocs(loggedInInfo, demographicNo, requestId, EDocUtil.ATTACHED);
         if (attachedDocuments != null) {
             for (EDoc document : attachedDocuments) {

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/ConsultationAttachDocs2Action.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/ConsultationAttachDocs2Action.java
@@ -105,8 +105,6 @@ public class ConsultationAttachDocs2Action extends ActionSupport {
         //Get all DOCUMENT information for demographic, along with which are already attached
         List<String> attachedDocumentIds = new ArrayList<String>();
         List<EDoc> allDocuments = EDocUtil.listDocs(loggedInInfo, "demographic", demographicNo, null, EDocUtil.PRIVATE, EDocUtil.EDocSort.OBSERVATIONDATE);
-        List<EDoc> providerPrivateDocs = EDocUtil.getProviderPrivateDocs(loggedInInfo);
-        List<EDoc> providerPublicDocs = EDocUtil.getProviderPublicDocs(loggedInInfo);
         List<EDoc> attachedDocuments = EDocUtil.listDocs(loggedInInfo, demographicNo, requestId, EDocUtil.ATTACHED);
         if (attachedDocuments != null) {
             for (EDoc document : attachedDocuments) {
@@ -161,8 +159,6 @@ public class ConsultationAttachDocs2Action extends ActionSupport {
 
 
         request.setAttribute("allDocuments", allDocuments);
-        request.setAttribute("providerPrivateDocs", providerPrivateDocs);
-        request.setAttribute("providerPublicDocs", providerPublicDocs);
         request.setAttribute("allLabs", allLabs);
         request.setAttribute("allForms", allForms);
         request.setAttribute("allEForms", allEForms);

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/ConsultationAttachDocs2Action.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/ConsultationAttachDocs2Action.java
@@ -106,6 +106,7 @@ public class ConsultationAttachDocs2Action extends ActionSupport {
         List<String> attachedDocumentIds = new ArrayList<String>();
         List<EDoc> allDocuments = EDocUtil.listDocs(loggedInInfo, "demographic", demographicNo, null, EDocUtil.PRIVATE, EDocUtil.EDocSort.OBSERVATIONDATE);
         List<EDoc> providerPrivateDocs = EDocUtil.getProviderPrivateDocs(loggedInInfo);
+        List<EDoc> providerPublicDocs = EDocUtil.getProviderPublicDocs(loggedInInfo);
         List<EDoc> attachedDocuments = EDocUtil.listDocs(loggedInInfo, demographicNo, requestId, EDocUtil.ATTACHED);
         if (attachedDocuments != null) {
             for (EDoc document : attachedDocuments) {
@@ -161,6 +162,7 @@ public class ConsultationAttachDocs2Action extends ActionSupport {
 
         request.setAttribute("allDocuments", allDocuments);
         request.setAttribute("providerPrivateDocs", providerPrivateDocs);
+        request.setAttribute("providerPublicDocs", providerPublicDocs);
         request.setAttribute("allLabs", allLabs);
         request.setAttribute("allForms", allForms);
         request.setAttribute("allEForms", allEForms);

--- a/src/main/java/ca/openosp/openo/utility/WebUtils.java
+++ b/src/main/java/ca/openosp/openo/utility/WebUtils.java
@@ -80,6 +80,38 @@ public final class WebUtils {
         return temp != null && (temp.equalsIgnoreCase("on") || temp.equalsIgnoreCase("true") || temp.equalsIgnoreCase("checked"));
     }
 
+    /**
+     * Returns {@code value} when it parses as a positive integer; otherwise {@code null}.
+     * Treats empty/blank and the literal string {@code "null"} as absent (JSPs in this
+     * codebase commonly round-trip null identifiers as {@code String.valueOf(null)}).
+     *
+     * @param value String the raw request parameter value
+     * @return String the original value if it represents a positive integer, else {@code null}
+     */
+    public static String positiveIntParamOrNull(String value) {
+        if (value == null) return null;
+        String trimmed = value.trim();
+        if (trimmed.isEmpty() || "null".equalsIgnoreCase(trimmed)) return null;
+        try {
+            return Integer.parseInt(trimmed) > 0 ? trimmed : null;
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Like {@link #positiveIntParamOrNull(String)} but returns {@code defaultValue}
+     * when {@code value} is missing or not a positive integer.
+     *
+     * @param value        String the raw request parameter value
+     * @param defaultValue String the value to return when {@code value} is absent or invalid
+     * @return String the parsed positive integer (as a string) or {@code defaultValue}
+     */
+    public static String positiveIntParamOrDefault(String value, String defaultValue) {
+        String parsed = positiveIntParamOrNull(value);
+        return parsed != null ? parsed : defaultValue;
+    }
+
     public static String renderMessagesAsHtml(HttpSession session, String messageKey, String styleClass, String style, String id, String name) {
         ArrayList<String> messages = popMessages(session, messageKey);
         StringBuilder sb = new StringBuilder();

--- a/src/main/webapp/documentManager/attachDocument.jsp
+++ b/src/main/webapp/documentManager/attachDocument.jsp
@@ -637,7 +637,7 @@
                                                ${isAttached ? 'checked="checked" data-pre-attached="true"' : ''}
                                                title="${e:forHtmlAttribute(document.description)}"/>
                                         <label for="privateDocNo${document.docId}"><c:out
-                                                value="${ document.description } ${ document.observationDate }"/><c:if test="${isDeleted}"> (deleted)</c:if><c:if test="${isForeign}"> (other provider)</c:if></label>
+                                                value="${ document.description } ${ document.observationDate }"/><c:if test="${isDeleted}"> (deleted)</c:if><c:if test="${isForeign}"> (attached by another provider)</c:if></label>
                                         <button class="preview-button" type="button" title="Preview"
                                                 onclick="getPdf('DOC', '${document.docId}', 'method=renderEDocPDF&eDocId=${document.docId}')">
                                             Preview

--- a/src/main/webapp/documentManager/attachDocument.jsp
+++ b/src/main/webapp/documentManager/attachDocument.jsp
@@ -366,6 +366,42 @@
                     </tr>
                 </c:if>
 
+                <c:if test="${not empty providerPrivateDocs }">
+                    <tr>
+                        <td><h2>Private Documents</h2></td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <ul id="providerDocumentList" style="list-style-type: none;padding:0px;">
+                                <li class="selectAllHeading ${providerPrivateDocs.size() > 20 ? 'flex' : ''}">
+                                    <input id="selectAllProviderDocuments" type="checkbox"
+                                           onclick="toggleSelectAll(this, 'providerDocument_');" value="providerDocument_check"
+                                           title="Select/un-select all private documents."/>
+                                    <label for="selectAllProviderDocuments">Select all</label>
+                                    <button class="show-all-button ${providerPrivateDocs.size() > 20 ? '' : 'hide'}"
+                                            type="button" title="Show ${providerPrivateDocs.size() - 20} More Private Documents"
+                                            onclick="showAll(this, 'providerDoc')">Show ${providerPrivateDocs.size() - 20} More
+                                        Private Documents
+                                    </button>
+                                </li>
+                                <c:forEach items="${ providerPrivateDocs }" var="document" varStatus="loop">
+                                    <li class="providerDoc ${loop.index > 19 ? 'hide' : ''}">
+                                        <input class="providerDocument_check document_check" type="checkbox" name="docNo"
+                                               id="providerDocNo${document.docId}" value="${document.docId}"
+                                               title="${ document.description }"/>
+                                        <label for="providerDocNo${document.docId}"><c:out
+                                                value="${ document.description } ${ document.observationDate }"/></label>
+                                        <button class="preview-button" type="button" title="Preview"
+                                                onclick="getPdf('DOC', '${document.docId}', 'method=renderEDocPDF&eDocId=${document.docId}')">
+                                            Preview
+                                        </button>
+                                    </li>
+                                </c:forEach>
+                            </ul>
+                        </td>
+                    </tr>
+                </c:if>
+
                 <c:if test="${not empty allLabsSortedByVersions }">
                     <tr>
                         <td><h2>Labs</h2></td>

--- a/src/main/webapp/documentManager/attachDocument.jsp
+++ b/src/main/webapp/documentManager/attachDocument.jsp
@@ -340,12 +340,12 @@
                                 <li class="selectAllHeading ${allDocuments.size() > 20 ? 'flex' : ''}">
                                     <input id="selectAllDocuments" type="checkbox"
                                            onclick="toggleSelectAll(this, 'document_');" value="document_check"
-                                           title="Select/un-select all documents."/>
+                                           title="Select/un-select all patient documents."/>
                                     <label for="selectAllDocuments">Select all</label>
                                     <button class="show-all-button ${allDocuments.size() > 20 ? '' : 'hide'}"
-                                            type="button" title="Show ${allDocuments.size() - 20} More Documents"
+                                            type="button" title="Show ${allDocuments.size() - 20} More Patient Documents"
                                             onclick="showAll(this, 'doc')">Show ${allDocuments.size() - 20} More
-                                        Documents
+                                        Patient Documents
                                     </button>
                                 </li>
                                 <c:forEach items="${ allDocuments }" var="document" varStatus="loop">
@@ -376,12 +376,12 @@
                                 <li class="selectAllHeading ${providerPrivateDocs.size() > 20 ? 'flex' : ''}">
                                     <input id="selectAllProviderDocuments" type="checkbox"
                                            onclick="toggleSelectAll(this, 'providerDocument_');" value="providerDocument_check"
-                                           title="Select/un-select all private documents."/>
+                                           title="Select/un-select all provider documents."/>
                                     <label for="selectAllProviderDocuments">Select all</label>
                                     <button class="show-all-button ${providerPrivateDocs.size() > 20 ? '' : 'hide'}"
-                                            type="button" title="Show ${providerPrivateDocs.size() - 20} More Private Documents"
+                                            type="button" title="Show ${providerPrivateDocs.size() - 20} More Provider Documents"
                                             onclick="showAll(this, 'providerDoc')">Show ${providerPrivateDocs.size() - 20} More
-                                        Private Documents
+                                        Provider Documents
                                     </button>
                                 </li>
                                 <c:forEach items="${ providerPrivateDocs }" var="document" varStatus="loop">

--- a/src/main/webapp/documentManager/attachDocument.jsp
+++ b/src/main/webapp/documentManager/attachDocument.jsp
@@ -381,7 +381,7 @@
                                 <c:forEach items="${ allEForms }" var="eForm" varStatus="loop">
                                     <li class="eForm ${loop.index > 4 ? 'hide' : ''}">
                                         <input class="eForm_check attachable_check" type="checkbox" name="eFormNo"
-                                               id="eFormNo${ eForm.id }" value="${eForm.id}" title="${eForm.formName}"/>
+                                               id="eFormNo${ eForm.id }" value="${eForm.id}" title="${e:forHtmlAttribute(eForm.formName)}"/>
                                         <label for="eFormNo${eForm.id}">
                                             <c:out value="${eForm.subject.length() > 0 ? eForm.subject : eForm.formName} ${ eForm.getFormDate() }"/>
                                         </label>
@@ -520,7 +520,7 @@
                                 <c:forEach items="${ allHRMDocuments }" var="hrm" varStatus="loop">
                                     <li class="hrm ${loop.index > 19 ? 'hide' : ''}">
                                         <input class="hrm_check attachable_check" type="checkbox" name="hrmNo" id="hrmNo${ hrm['id'] }"
-                                               value="${hrm['id']}" title="${hrm['name']}"/>
+                                               value="${hrm['id']}" title="${e:forHtmlAttribute(hrm['name'])}"/>
                                         <label for="hrmNo${hrm['id']}">
                                             <c:out value="${ hrm['name'] } ${ hrm['report_date'] }"/>
                                         </label>
@@ -555,7 +555,7 @@
                                     <li class="form ${loop.index > 19 ? 'hide' : ''}">
                                         <input class="form_check attachable_check" type="checkbox" name="formNo"
                                                id="formNo${ form.formId }" value="${form.formId}"
-                                               title="${form.formName}"/>
+                                               title="${e:forHtmlAttribute(form.formName)}"/>
                                         <label for="formNo${form.formId}">
                                             <c:out value="${ form.formName } ${ form.getEdited() }"/>
                                         </label>

--- a/src/main/webapp/documentManager/attachDocument.jsp
+++ b/src/main/webapp/documentManager/attachDocument.jsp
@@ -187,6 +187,11 @@
         .attachmentContainer .caret-down {
             transform: rotate(45deg) !important;
         }
+
+        .deleted-doc label {
+            color: #888 !important;
+            font-style: italic;
+        }
     </style>
 
     <script type="text/javascript">
@@ -350,12 +355,13 @@
                                     </button>
                                 </li>
                                 <c:forEach items="${ allDocuments }" var="document" varStatus="loop">
-                                    <li class="doc ${loop.index > 19 ? 'hide' : ''}">
+                                    <c:set var="isDeleted" value="${fn:contains(document.status, 'D')}"/>
+                                    <li class="doc ${loop.index > 19 ? 'hide' : ''} ${isDeleted ? 'deleted-doc' : ''}">
                                         <input class="document_check" type="checkbox" name="docNo"
                                                id="docNo${document.docId}" value="${document.docId}"
                                                title="${e:forHtmlAttribute(document.description)}"/>
                                         <label for="docNo${document.docId}"><c:out
-                                                value="${ document.description } ${ document.observationDate }"/></label>
+                                                value="${ document.description } ${ document.observationDate }"/><c:if test="${isDeleted}"> (deleted)</c:if></label>
                                         <button class="preview-button" type="button" title="Preview"
                                                 onclick="getPdf('DOC', '${document.docId}', 'method=renderEDocPDF&eDocId=${document.docId}')">
                                             Preview
@@ -386,12 +392,13 @@
                                     </button>
                                 </li>
                                 <c:forEach items="${ providerPrivateDocs }" var="document" varStatus="loop">
-                                    <li class="providerPrivateDoc ${loop.index > 19 ? 'hide' : ''}">
+                                    <c:set var="isDeleted" value="${fn:contains(document.status, 'D')}"/>
+                                    <li class="providerPrivateDoc ${loop.index > 19 ? 'hide' : ''} ${isDeleted ? 'deleted-doc' : ''}">
                                         <input class="providerPrivateDocument_check" type="checkbox" name="docNo"
                                                id="providerPrivateDocNo${document.docId}" value="${document.docId}"
                                                title="${e:forHtmlAttribute(document.description)}"/>
                                         <label for="providerPrivateDocNo${document.docId}"><c:out
-                                                value="${ document.description } ${ document.observationDate }"/></label>
+                                                value="${ document.description } ${ document.observationDate }"/><c:if test="${isDeleted}"> (deleted)</c:if></label>
                                         <button class="preview-button" type="button" title="Preview"
                                                 onclick="getPdf('DOC', '${document.docId}', 'method=renderEDocPDF&eDocId=${document.docId}')">
                                             Preview
@@ -422,12 +429,13 @@
                                     </button>
                                 </li>
                                 <c:forEach items="${ providerPublicDocs }" var="document" varStatus="loop">
-                                    <li class="providerPublicDoc ${loop.index > 19 ? 'hide' : ''}">
+                                    <c:set var="isDeleted" value="${fn:contains(document.status, 'D')}"/>
+                                    <li class="providerPublicDoc ${loop.index > 19 ? 'hide' : ''} ${isDeleted ? 'deleted-doc' : ''}">
                                         <input class="providerPublicDocument_check" type="checkbox" name="docNo"
                                                id="providerPublicDocNo${document.docId}" value="${document.docId}"
                                                title="${e:forHtmlAttribute(document.description)}"/>
                                         <label for="providerPublicDocNo${document.docId}"><c:out
-                                                value="${ document.description } ${ document.observationDate }"/></label>
+                                                value="${ document.description } ${ document.observationDate }"/><c:if test="${isDeleted}"> (deleted)</c:if></label>
                                         <button class="preview-button" type="button" title="Preview"
                                                 onclick="getPdf('DOC', '${document.docId}', 'method=renderEDocPDF&eDocId=${document.docId}')">
                                             Preview

--- a/src/main/webapp/documentManager/attachDocument.jsp
+++ b/src/main/webapp/documentManager/attachDocument.jsp
@@ -47,6 +47,7 @@
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
+<%@ taglib uri="https://www.owasp.org/index.php/OWASP_Java_Encoder_Project" prefix="e" %>
 
 <!DOCTYPE html >
 <html>
@@ -352,7 +353,7 @@
                                     <li class="doc ${loop.index > 19 ? 'hide' : ''}">
                                         <input class="document_check" type="checkbox" name="docNo"
                                                id="docNo${document.docId}" value="${document.docId}"
-                                               title="${ document.description }"/>
+                                               title="${e:forHtmlAttribute(document.description)}"/>
                                         <label for="docNo${document.docId}"><c:out
                                                 value="${ document.description } ${ document.observationDate }"/></label>
                                         <button class="preview-button" type="button" title="Preview"
@@ -386,9 +387,9 @@
                                 </li>
                                 <c:forEach items="${ providerPrivateDocs }" var="document" varStatus="loop">
                                     <li class="providerDoc ${loop.index > 19 ? 'hide' : ''}">
-                                        <input class="providerDocument_check document_check" type="checkbox" name="docNo"
+                                        <input class="providerDocument_check" type="checkbox" name="docNo"
                                                id="providerDocNo${document.docId}" value="${document.docId}"
-                                               title="${ document.description }"/>
+                                               title="${e:forHtmlAttribute(document.description)}"/>
                                         <label for="providerDocNo${document.docId}"><c:out
                                                 value="${ document.description } ${ document.observationDate }"/></label>
                                         <button class="preview-button" type="button" title="Preview"

--- a/src/main/webapp/documentManager/attachDocument.jsp
+++ b/src/main/webapp/documentManager/attachDocument.jsp
@@ -188,7 +188,8 @@
             transform: rotate(45deg) !important;
         }
 
-        .deleted-doc label {
+        .deleted-doc label,
+        .foreign-doc label {
             color: #888 !important;
             font-style: italic;
         }
@@ -356,83 +357,11 @@
                                 </li>
                                 <c:forEach items="${ allDocuments }" var="document" varStatus="loop">
                                     <c:set var="isDeleted" value="${fn:contains(document.status, 'D')}"/>
+                                    <c:set var="isAttached" value="${not empty attachedDocumentIds and attachedDocumentIds.contains(document.docId)}"/>
                                     <li class="doc ${loop.index > 19 ? 'hide' : ''} ${isDeleted ? 'deleted-doc' : ''}">
-                                        <input class="document_check" type="checkbox" name="docNo"
+                                        <input class="document_${isAttached ? 'pre_check' : 'check'}" type="checkbox" name="docNo"
                                                id="docNo${document.docId}" value="${document.docId}"
-                                               title="${e:forHtmlAttribute(document.description)}"/>
-                                        <label for="docNo${document.docId}"><c:out
-                                                value="${ document.description } ${ document.observationDate }"/><c:if test="${isDeleted}"> (deleted)</c:if></label>
-                                        <button class="preview-button" type="button" title="Preview"
-                                                onclick="getPdf('DOC', '${document.docId}', 'method=renderEDocPDF&eDocId=${document.docId}')">
-                                            Preview
-                                        </button>
-                                    </li>
-                                </c:forEach>
-                            </ul>
-                        </td>
-                    </tr>
-                </c:if>
-
-                <c:if test="${not empty providerPrivateDocs }">
-                    <tr>
-                        <td><h2>Private Provider Documents</h2></td>
-                    </tr>
-                    <tr>
-                        <td>
-                            <ul id="providerPrivateDocumentList" style="list-style-type: none;padding:0px;">
-                                <li class="selectAllHeading ${providerPrivateDocs.size() > 20 ? 'flex' : ''}">
-                                    <input id="selectAllProviderPrivateDocuments" type="checkbox"
-                                           onclick="toggleSelectAll(this, 'providerPrivateDocument_');" value="providerPrivateDocument_check"
-                                           title="Select/un-select all private provider documents."/>
-                                    <label for="selectAllProviderPrivateDocuments">Select all</label>
-                                    <button class="show-all-button ${providerPrivateDocs.size() > 20 ? '' : 'hide'}"
-                                            type="button" title="Show ${providerPrivateDocs.size() - 20} More Private Provider Documents"
-                                            onclick="showAll(this, 'providerPrivateDoc')">Show ${providerPrivateDocs.size() - 20} More
-                                        Private Provider Documents
-                                    </button>
-                                </li>
-                                <c:forEach items="${ providerPrivateDocs }" var="document" varStatus="loop">
-                                    <c:set var="isDeleted" value="${fn:contains(document.status, 'D')}"/>
-                                    <li class="providerPrivateDoc ${loop.index > 19 ? 'hide' : ''} ${isDeleted ? 'deleted-doc' : ''}">
-                                        <input class="providerPrivateDocument_check" type="checkbox" name="docNo"
-                                               id="docNo${document.docId}" value="${document.docId}"
-                                               title="${e:forHtmlAttribute(document.description)}"/>
-                                        <label for="docNo${document.docId}"><c:out
-                                                value="${ document.description } ${ document.observationDate }"/><c:if test="${isDeleted}"> (deleted)</c:if></label>
-                                        <button class="preview-button" type="button" title="Preview"
-                                                onclick="getPdf('DOC', '${document.docId}', 'method=renderEDocPDF&eDocId=${document.docId}')">
-                                            Preview
-                                        </button>
-                                    </li>
-                                </c:forEach>
-                            </ul>
-                        </td>
-                    </tr>
-                </c:if>
-
-                <c:if test="${not empty providerPublicDocs }">
-                    <tr>
-                        <td><h2>Public Provider Documents</h2></td>
-                    </tr>
-                    <tr>
-                        <td>
-                            <ul id="providerPublicDocumentList" style="list-style-type: none;padding:0px;">
-                                <li class="selectAllHeading ${providerPublicDocs.size() > 20 ? 'flex' : ''}">
-                                    <input id="selectAllProviderPublicDocuments" type="checkbox"
-                                           onclick="toggleSelectAll(this, 'providerPublicDocument_');" value="providerPublicDocument_check"
-                                           title="Select/un-select all public provider documents."/>
-                                    <label for="selectAllProviderPublicDocuments">Select all</label>
-                                    <button class="show-all-button ${providerPublicDocs.size() > 20 ? '' : 'hide'}"
-                                            type="button" title="Show ${providerPublicDocs.size() - 20} More Public Provider Documents"
-                                            onclick="showAll(this, 'providerPublicDoc')">Show ${providerPublicDocs.size() - 20} More
-                                        Public Provider Documents
-                                    </button>
-                                </li>
-                                <c:forEach items="${ providerPublicDocs }" var="document" varStatus="loop">
-                                    <c:set var="isDeleted" value="${fn:contains(document.status, 'D')}"/>
-                                    <li class="providerPublicDoc ${loop.index > 19 ? 'hide' : ''} ${isDeleted ? 'deleted-doc' : ''}">
-                                        <input class="providerPublicDocument_check" type="checkbox" name="docNo"
-                                               id="docNo${document.docId}" value="${document.docId}"
+                                               ${isAttached ? 'checked="checked" data-pre-attached="true"' : ''}
                                                title="${e:forHtmlAttribute(document.description)}"/>
                                         <label for="docNo${document.docId}"><c:out
                                                 value="${ document.description } ${ document.observationDate }"/><c:if test="${isDeleted}"> (deleted)</c:if></label>
@@ -573,6 +502,85 @@
                                         </label>
                                         <button class="preview-button" type="button" title="Preview"
                                                 onclick="getPdf('FORM', '${form.formId}', 'method=renderFormPDF&formId=${form.formId}&formName=${form.formName}&demographicNo=${form.getDemoNo()}')">
+                                            Preview
+                                        </button>
+                                    </li>
+                                </c:forEach>
+                            </ul>
+                        </td>
+                    </tr>
+                </c:if>
+
+                <c:if test="${not empty providerPublicDocs }">
+                    <tr>
+                        <td><h2>Public eDocs</h2></td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <ul id="providerPublicDocumentList" style="list-style-type: none;padding:0px;">
+                                <li class="selectAllHeading ${providerPublicDocs.size() > 20 ? 'flex' : ''}">
+                                    <input id="selectAllProviderPublicDocuments" type="checkbox"
+                                           onclick="toggleSelectAll(this, 'providerPublicDocument_');" value="providerPublicDocument_check"
+                                           title="Select/un-select all public eDocs."/>
+                                    <label for="selectAllProviderPublicDocuments">Select all</label>
+                                    <button class="show-all-button ${providerPublicDocs.size() > 20 ? '' : 'hide'}"
+                                            type="button" title="Show ${providerPublicDocs.size() - 20} More Public eDocs"
+                                            onclick="showAll(this, 'providerPublicDoc')">Show ${providerPublicDocs.size() - 20} More
+                                        Public eDocs
+                                    </button>
+                                </li>
+                                <c:forEach items="${ providerPublicDocs }" var="document" varStatus="loop">
+                                    <c:set var="isDeleted" value="${fn:contains(document.status, 'D')}"/>
+                                    <c:set var="isAttached" value="${not empty attachedDocumentIds and attachedDocumentIds.contains(document.docId)}"/>
+                                    <li class="providerPublicDoc ${loop.index > 19 ? 'hide' : ''} ${isDeleted ? 'deleted-doc' : ''}">
+                                        <input class="providerPublicDocument_${isAttached ? 'pre_check' : 'check'}" type="checkbox" name="docNo"
+                                               id="publicDocNo${document.docId}" value="${document.docId}"
+                                               ${isAttached ? 'checked="checked" data-pre-attached="true"' : ''}
+                                               title="${e:forHtmlAttribute(document.description)}"/>
+                                        <label for="publicDocNo${document.docId}"><c:out
+                                                value="${ document.description } ${ document.observationDate }"/><c:if test="${isDeleted}"> (deleted)</c:if></label>
+                                        <button class="preview-button" type="button" title="Preview"
+                                                onclick="getPdf('DOC', '${document.docId}', 'method=renderEDocPDF&eDocId=${document.docId}')">
+                                            Preview
+                                        </button>
+                                    </li>
+                                </c:forEach>
+                            </ul>
+                        </td>
+                    </tr>
+                </c:if>
+
+                <c:if test="${not empty providerPrivateDocs }">
+                    <tr>
+                        <td><h2>Private eDocs</h2></td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <ul id="providerPrivateDocumentList" style="list-style-type: none;padding:0px;">
+                                <li class="selectAllHeading ${providerPrivateDocs.size() > 20 ? 'flex' : ''}">
+                                    <input id="selectAllProviderPrivateDocuments" type="checkbox"
+                                           onclick="toggleSelectAll(this, 'providerPrivateDocument_');" value="providerPrivateDocument_check"
+                                           title="Select/un-select all private eDocs."/>
+                                    <label for="selectAllProviderPrivateDocuments">Select all</label>
+                                    <button class="show-all-button ${providerPrivateDocs.size() > 20 ? '' : 'hide'}"
+                                            type="button" title="Show ${providerPrivateDocs.size() - 20} More Private eDocs"
+                                            onclick="showAll(this, 'providerPrivateDoc')">Show ${providerPrivateDocs.size() - 20} More
+                                        Private eDocs
+                                    </button>
+                                </li>
+                                <c:forEach items="${ providerPrivateDocs }" var="document" varStatus="loop">
+                                    <c:set var="isDeleted" value="${fn:contains(document.status, 'D')}"/>
+                                    <c:set var="isAttached" value="${not empty attachedDocumentIds and attachedDocumentIds.contains(document.docId)}"/>
+                                    <c:set var="isForeign" value="${not empty foreignPrivateDocIds and foreignPrivateDocIds.contains(document.docId)}"/>
+                                    <li class="providerPrivateDoc ${loop.index > 19 ? 'hide' : ''} ${isDeleted ? 'deleted-doc' : ''} ${isForeign ? 'foreign-doc' : ''}">
+                                        <input class="providerPrivateDocument_${isAttached ? 'pre_check' : 'check'}" type="checkbox" name="docNo"
+                                               id="privateDocNo${document.docId}" value="${document.docId}"
+                                               ${isAttached ? 'checked="checked" data-pre-attached="true"' : ''}
+                                               title="${e:forHtmlAttribute(document.description)}"/>
+                                        <label for="privateDocNo${document.docId}"><c:out
+                                                value="${ document.description } ${ document.observationDate }"/><c:if test="${isDeleted}"> (deleted)</c:if><c:if test="${isForeign}"> (other provider)</c:if></label>
+                                        <button class="preview-button" type="button" title="Preview"
+                                                onclick="getPdf('DOC', '${document.docId}', 'method=renderEDocPDF&eDocId=${document.docId}')">
                                             Preview
                                         </button>
                                     </li>

--- a/src/main/webapp/documentManager/attachDocument.jsp
+++ b/src/main/webapp/documentManager/attachDocument.jsp
@@ -294,6 +294,39 @@
             showButton.classList.add('hide');
             showButton.parentNode.classList.remove('flex');
         }
+
+        /**
+         * Helpers shared by consult and eForm attach flows. Defined here so both
+         * parents can call them from their beforeClose handlers without needing
+         * a separate script include. Safe because the dialog is guaranteed loaded
+         * when beforeClose fires.
+         */
+
+        /** Warn on new (not pre-attached) private eDoc selections; returns false to abort the close. */
+        function confirmPrivateDocsIfAny(formSelector) {
+            var newPrivate = jQuery(formSelector)
+                .find(".providerPrivateDocument_check:checked:not(input[disabled='disabled'])")
+                .not('[data-pre-attached="true"]');
+            if (newPrivate.length === 0) return true;
+            return confirm("You have selected " + newPrivate.length +
+                " private eDoc(s) for attachment.\n\n" +
+                "Private documents are personal to your account. " +
+                "Attaching them will make them visible to anyone with access to this patient's record.\n\n" +
+                "Select OK to confirm, or Cancel to go back.");
+        }
+
+        /** Build a hidden delegate input from a checked attachment checkbox. */
+        function buildDelegateInput($element) {
+            var input = jQuery("<input />", {
+                type: 'hidden',
+                name: $element.attr('name'),
+                value: $element.val(),
+                id: "delegate_" + $element.attr('id'),
+                class: 'delegateAttachment'
+            });
+            if ($element.attr('name') === 'docNo') input.attr('data-delegate-type', 'doc');
+            return input;
+        }
     </script>
 
 </head>
@@ -321,7 +354,7 @@
                                 </li>
                                 <c:forEach items="${ allEForms }" var="eForm" varStatus="loop">
                                     <li class="eForm ${loop.index > 4 ? 'hide' : ''}">
-                                        <input class="eForm_check" type="checkbox" name="eFormNo"
+                                        <input class="eForm_check attachable_check" type="checkbox" name="eFormNo"
                                                id="eFormNo${ eForm.id }" value="${eForm.id}" title="${eForm.formName}"/>
                                         <label for="eFormNo${eForm.id}">
                                             <c:out value="${eForm.subject.length() > 0 ? eForm.subject : eForm.formName} ${ eForm.getFormDate() }"/>
@@ -359,7 +392,7 @@
                                     <c:set var="isDeleted" value="${fn:contains(document.status, 'D')}"/>
                                     <c:set var="isAttached" value="${not empty attachedDocumentIds and attachedDocumentIds.contains(document.docId)}"/>
                                     <li class="doc ${loop.index > 19 ? 'hide' : ''} ${isDeleted ? 'deleted-doc' : ''}">
-                                        <input class="document_${isAttached ? 'pre_check' : 'check'}" type="checkbox" name="docNo"
+                                        <input class="document_${isAttached ? 'pre_check' : 'check'} attachable_check" type="checkbox" name="docNo"
                                                id="docNo${document.docId}" value="${document.docId}"
                                                ${isAttached ? 'checked="checked" data-pre-attached="true"' : ''}
                                                title="${e:forHtmlAttribute(document.description)}"/>
@@ -397,7 +430,7 @@
                                     <c:set var="labName" value="${fn:substring(lab.labName, 0, 30)}"/>
                                     <c:set var="totalVersions" value="${fn:length(lab.labVersionIds)}"/>
                                     <li class="lab ${loop.index > 19 ? 'hide' : ''}">
-                                        <input class="lab_check" type="checkbox" name="labNo"
+                                        <input class="lab_check attachable_check" type="checkbox" name="labNo"
                                                id="labNo${ lab.segmentID }" value="${lab.segmentID}"
                                                title="<c:out value='${ labName }' />"/>
                                         <label for="labNo${lab.segmentID}" title="<c:out value='${ labName }' />"><c:out
@@ -415,7 +448,7 @@
                                             <c:forEach items="${ lab.labVersionIds }" var="version"
                                                        varStatus="versionLoop">
                                                 <li>
-                                                    <input class="lab_check"
+                                                    <input class="lab_check attachable_check"
                                                            data-version="${totalVersions - versionLoop.index}"
                                                            type="checkbox" name="labNo" id="labNo${ version.key }"
                                                            value="${version.key}"
@@ -460,7 +493,7 @@
                                 </li>
                                 <c:forEach items="${ allHRMDocuments }" var="hrm" varStatus="loop">
                                     <li class="hrm ${loop.index > 19 ? 'hide' : ''}">
-                                        <input class="hrm_check" type="checkbox" name="hrmNo" id="hrmNo${ hrm['id'] }"
+                                        <input class="hrm_check attachable_check" type="checkbox" name="hrmNo" id="hrmNo${ hrm['id'] }"
                                                value="${hrm['id']}" title="${hrm['name']}"/>
                                         <label for="hrmNo${hrm['id']}">
                                             <c:out value="${ hrm['name'] } ${ hrm['report_date'] }"/>
@@ -494,7 +527,7 @@
                                 </li>
                                 <c:forEach items="${ allForms }" var="form" varStatus="loop">
                                     <li class="form ${loop.index > 19 ? 'hide' : ''}">
-                                        <input class="form_check" type="checkbox" name="formNo"
+                                        <input class="form_check attachable_check" type="checkbox" name="formNo"
                                                id="formNo${ form.formId }" value="${form.formId}"
                                                title="${form.formName}"/>
                                         <label for="formNo${form.formId}">
@@ -533,7 +566,7 @@
                                     <c:set var="isDeleted" value="${fn:contains(document.status, 'D')}"/>
                                     <c:set var="isAttached" value="${not empty attachedDocumentIds and attachedDocumentIds.contains(document.docId)}"/>
                                     <li class="providerPublicDoc ${loop.index > 19 ? 'hide' : ''} ${isDeleted ? 'deleted-doc' : ''}">
-                                        <input class="providerPublicDocument_${isAttached ? 'pre_check' : 'check'}" type="checkbox" name="docNo"
+                                        <input class="providerPublicDocument_${isAttached ? 'pre_check' : 'check'} attachable_check" type="checkbox" name="docNo"
                                                id="publicDocNo${document.docId}" value="${document.docId}"
                                                ${isAttached ? 'checked="checked" data-pre-attached="true"' : ''}
                                                title="${e:forHtmlAttribute(document.description)}"/>
@@ -573,7 +606,7 @@
                                     <c:set var="isAttached" value="${not empty attachedDocumentIds and attachedDocumentIds.contains(document.docId)}"/>
                                     <c:set var="isForeign" value="${not empty foreignPrivateDocIds and foreignPrivateDocIds.contains(document.docId)}"/>
                                     <li class="providerPrivateDoc ${loop.index > 19 ? 'hide' : ''} ${isDeleted ? 'deleted-doc' : ''} ${isForeign ? 'foreign-doc' : ''}">
-                                        <input class="providerPrivateDocument_${isAttached ? 'pre_check' : 'check'}" type="checkbox" name="docNo"
+                                        <input class="providerPrivateDocument_${isAttached ? 'pre_check' : 'check'} attachable_check" type="checkbox" name="docNo"
                                                id="privateDocNo${document.docId}" value="${document.docId}"
                                                ${isAttached ? 'checked="checked" data-pre-attached="true"' : ''}
                                                title="${e:forHtmlAttribute(document.description)}"/>

--- a/src/main/webapp/documentManager/attachDocument.jsp
+++ b/src/main/webapp/documentManager/attachDocument.jsp
@@ -327,6 +327,32 @@
             if ($element.attr('name') === 'docNo') input.attr('data-delegate-type', 'doc');
             return input;
         }
+
+        /**
+         * Uncheck server-pre-checked boxes whose delegate was removed in an earlier
+         * dialog session. The delegate container (#attachDocumentList for eForm,
+         * $mainForm for consult) is the source of truth for unsaved changes.
+         * Pass swapClass=true for the consult flow which tracks state via
+         * <type>_check vs <type>_pre_check class pairs.
+         */
+        function syncPreCheckedToDelegates(delegateContainer, swapClass) {
+            jQuery('#attachDocumentsForm').find('[data-pre-attached="true"]').each(function () {
+                var $cb = jQuery(this);
+                var hasDelegate = jQuery(delegateContainer).find(
+                    '.delegateAttachment[name="' + this.name + '"][value="' + this.value + '"]'
+                ).length > 0;
+                if (hasDelegate) return;
+                $cb.prop('checked', false).removeAttr('data-pre-attached');
+                if (!swapClass) return;
+                var tokens = ($cb.attr('class') || '').split(' ');
+                for (var i = 0; i < tokens.length; i++) {
+                    if (tokens[i].indexOf('_pre_check') > 0) {
+                        $cb.removeClass(tokens[i]).addClass(tokens[i].split('_')[0] + '_check');
+                        break;
+                    }
+                }
+            });
+        }
     </script>
 
 </head>

--- a/src/main/webapp/documentManager/attachDocument.jsp
+++ b/src/main/webapp/documentManager/attachDocument.jsp
@@ -332,7 +332,7 @@
 
                 <c:if test="${not empty allDocuments }">
                     <tr>
-                        <td><h2>Documents</h2></td>
+                        <td><h2>Patient Documents</h2></td>
                     </tr>
                     <tr>
                         <td>
@@ -368,7 +368,7 @@
 
                 <c:if test="${not empty providerPrivateDocs }">
                     <tr>
-                        <td><h2>Private Documents</h2></td>
+                        <td><h2>Provider Documents</h2></td>
                     </tr>
                     <tr>
                         <td>

--- a/src/main/webapp/documentManager/attachDocument.jsp
+++ b/src/main/webapp/documentManager/attachDocument.jsp
@@ -369,28 +369,64 @@
 
                 <c:if test="${not empty providerPrivateDocs }">
                     <tr>
-                        <td><h2>Provider Documents</h2></td>
+                        <td><h2>Private Provider Documents</h2></td>
                     </tr>
                     <tr>
                         <td>
-                            <ul id="providerDocumentList" style="list-style-type: none;padding:0px;">
+                            <ul id="providerPrivateDocumentList" style="list-style-type: none;padding:0px;">
                                 <li class="selectAllHeading ${providerPrivateDocs.size() > 20 ? 'flex' : ''}">
-                                    <input id="selectAllProviderDocuments" type="checkbox"
-                                           onclick="toggleSelectAll(this, 'providerDocument_');" value="providerDocument_check"
-                                           title="Select/un-select all provider documents."/>
-                                    <label for="selectAllProviderDocuments">Select all</label>
+                                    <input id="selectAllProviderPrivateDocuments" type="checkbox"
+                                           onclick="toggleSelectAll(this, 'providerPrivateDocument_');" value="providerPrivateDocument_check"
+                                           title="Select/un-select all private provider documents."/>
+                                    <label for="selectAllProviderPrivateDocuments">Select all</label>
                                     <button class="show-all-button ${providerPrivateDocs.size() > 20 ? '' : 'hide'}"
-                                            type="button" title="Show ${providerPrivateDocs.size() - 20} More Provider Documents"
-                                            onclick="showAll(this, 'providerDoc')">Show ${providerPrivateDocs.size() - 20} More
-                                        Provider Documents
+                                            type="button" title="Show ${providerPrivateDocs.size() - 20} More Private Provider Documents"
+                                            onclick="showAll(this, 'providerPrivateDoc')">Show ${providerPrivateDocs.size() - 20} More
+                                        Private Provider Documents
                                     </button>
                                 </li>
                                 <c:forEach items="${ providerPrivateDocs }" var="document" varStatus="loop">
-                                    <li class="providerDoc ${loop.index > 19 ? 'hide' : ''}">
-                                        <input class="providerDocument_check" type="checkbox" name="docNo"
-                                               id="providerDocNo${document.docId}" value="${document.docId}"
+                                    <li class="providerPrivateDoc ${loop.index > 19 ? 'hide' : ''}">
+                                        <input class="providerPrivateDocument_check" type="checkbox" name="docNo"
+                                               id="providerPrivateDocNo${document.docId}" value="${document.docId}"
                                                title="${e:forHtmlAttribute(document.description)}"/>
-                                        <label for="providerDocNo${document.docId}"><c:out
+                                        <label for="providerPrivateDocNo${document.docId}"><c:out
+                                                value="${ document.description } ${ document.observationDate }"/></label>
+                                        <button class="preview-button" type="button" title="Preview"
+                                                onclick="getPdf('DOC', '${document.docId}', 'method=renderEDocPDF&eDocId=${document.docId}')">
+                                            Preview
+                                        </button>
+                                    </li>
+                                </c:forEach>
+                            </ul>
+                        </td>
+                    </tr>
+                </c:if>
+
+                <c:if test="${not empty providerPublicDocs }">
+                    <tr>
+                        <td><h2>Public Provider Documents</h2></td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <ul id="providerPublicDocumentList" style="list-style-type: none;padding:0px;">
+                                <li class="selectAllHeading ${providerPublicDocs.size() > 20 ? 'flex' : ''}">
+                                    <input id="selectAllProviderPublicDocuments" type="checkbox"
+                                           onclick="toggleSelectAll(this, 'providerPublicDocument_');" value="providerPublicDocument_check"
+                                           title="Select/un-select all public provider documents."/>
+                                    <label for="selectAllProviderPublicDocuments">Select all</label>
+                                    <button class="show-all-button ${providerPublicDocs.size() > 20 ? '' : 'hide'}"
+                                            type="button" title="Show ${providerPublicDocs.size() - 20} More Public Provider Documents"
+                                            onclick="showAll(this, 'providerPublicDoc')">Show ${providerPublicDocs.size() - 20} More
+                                        Public Provider Documents
+                                    </button>
+                                </li>
+                                <c:forEach items="${ providerPublicDocs }" var="document" varStatus="loop">
+                                    <li class="providerPublicDoc ${loop.index > 19 ? 'hide' : ''}">
+                                        <input class="providerPublicDocument_check" type="checkbox" name="docNo"
+                                               id="providerPublicDocNo${document.docId}" value="${document.docId}"
+                                               title="${e:forHtmlAttribute(document.description)}"/>
+                                        <label for="providerPublicDocNo${document.docId}"><c:out
                                                 value="${ document.description } ${ document.observationDate }"/></label>
                                         <button class="preview-button" type="button" title="Preview"
                                                 onclick="getPdf('DOC', '${document.docId}', 'method=renderEDocPDF&eDocId=${document.docId}')">

--- a/src/main/webapp/documentManager/attachDocument.jsp
+++ b/src/main/webapp/documentManager/attachDocument.jsp
@@ -395,9 +395,9 @@
                                     <c:set var="isDeleted" value="${fn:contains(document.status, 'D')}"/>
                                     <li class="providerPrivateDoc ${loop.index > 19 ? 'hide' : ''} ${isDeleted ? 'deleted-doc' : ''}">
                                         <input class="providerPrivateDocument_check" type="checkbox" name="docNo"
-                                               id="providerPrivateDocNo${document.docId}" value="${document.docId}"
+                                               id="docNo${document.docId}" value="${document.docId}"
                                                title="${e:forHtmlAttribute(document.description)}"/>
-                                        <label for="providerPrivateDocNo${document.docId}"><c:out
+                                        <label for="docNo${document.docId}"><c:out
                                                 value="${ document.description } ${ document.observationDate }"/><c:if test="${isDeleted}"> (deleted)</c:if></label>
                                         <button class="preview-button" type="button" title="Preview"
                                                 onclick="getPdf('DOC', '${document.docId}', 'method=renderEDocPDF&eDocId=${document.docId}')">
@@ -432,9 +432,9 @@
                                     <c:set var="isDeleted" value="${fn:contains(document.status, 'D')}"/>
                                     <li class="providerPublicDoc ${loop.index > 19 ? 'hide' : ''} ${isDeleted ? 'deleted-doc' : ''}">
                                         <input class="providerPublicDocument_check" type="checkbox" name="docNo"
-                                               id="providerPublicDocNo${document.docId}" value="${document.docId}"
+                                               id="docNo${document.docId}" value="${document.docId}"
                                                title="${e:forHtmlAttribute(document.description)}"/>
-                                        <label for="providerPublicDocNo${document.docId}"><c:out
+                                        <label for="docNo${document.docId}"><c:out
                                                 value="${ document.description } ${ document.observationDate }"/><c:if test="${isDeleted}"> (deleted)</c:if></label>
                                         <button class="preview-button" type="button" title="Preview"
                                                 onclick="getPdf('DOC', '${document.docId}', 'method=renderEDocPDF&eDocId=${document.docId}')">

--- a/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
+++ b/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
@@ -230,6 +230,7 @@ jQuery(document).on('click', '*[data-poload]', function () {
                     element = addFormIfNotFound(data, demographicNo, delegate);
                 }
                 element.attr("checked", true);
+                element.data("pre-attached", true);
 
                 // Expand list if selected lab is older version
                 if (element.attr('data-version')) {
@@ -259,9 +260,10 @@ jQuery(document).on('click', '*[data-poload]', function () {
         beforeClose: function (event, ui) {
             // before the dialog is closed:
 
-            // warn if private provider documents are selected
+            // warn if NEW private provider documents are selected (not pre-attached ones)
             var privateProviderDocsChecked = jQuery('#attachDocumentsForm')
-                .find(".providerPrivateDocument_check:checked:not(input[disabled='disabled'])");
+                .find(".providerPrivateDocument_check:checked:not(input[disabled='disabled'])")
+                .filter(function() { return !jQuery(this).data("pre-attached"); });
             if (privateProviderDocsChecked.length > 0) {
                 if (!confirm("You have selected " + privateProviderDocsChecked.length +
                     " private provider document(s) for attachment.\n\n" +

--- a/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
+++ b/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
@@ -244,6 +244,18 @@ jQuery(document).on('click', '*[data-poload]', function () {
                     expandLabVersionList(element.parent().parent().parent().find('.collapse-arrow'));
                 }
             });
+
+            // Uncheck server-pre-checked boxes whose delegate was removed in an
+            // earlier dialog session (unsaved uncheck — #attachDocumentList wins).
+            jQuery('#attachDocumentsForm').find('[data-pre-attached="true"]').each(function () {
+                const $cb = jQuery(this);
+                const hasDelegate = jQuery('#attachDocumentList').find(
+                    '.delegateAttachment[name="' + this.name + '"][value="' + this.value + '"]'
+                ).length > 0;
+                if (!hasDelegate) {
+                    $cb.prop('checked', false).removeAttr('data-pre-attached');
+                }
+            });
         }
     }).dialog({
         title: title,
@@ -278,8 +290,7 @@ jQuery(document).on('click', '*[data-poload]', function () {
             }
             jQuery('#attachDocumentList').empty();
 
-            // Dedupe by name+value: a doc with multiple ctl bindings can appear
-            // in multiple sections (patient + provider) with shared name="docNo".
+            // Cross-section dedupe: same docNo can render in patient + provider sections.
             const seenDelegates = new Set();
             jQuery('#attachDocumentsForm').find(
                 ".attachable_check:checkbox:checked:not(input[disabled='disabled'])"

--- a/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
+++ b/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
@@ -278,10 +278,17 @@ jQuery(document).on('click', '*[data-poload]', function () {
             }
             jQuery('#attachDocumentList').empty();
 
+            // Dedupe by name+value: a doc with multiple ctl bindings can appear
+            // in multiple sections (patient + provider) with shared name="docNo".
+            const seenDelegates = new Set();
             jQuery('#attachDocumentsForm').find(
                 ".attachable_check:checkbox:checked:not(input[disabled='disabled'])"
             ).each(function () {
-                jQuery('#attachDocumentList').append(buildDelegateInput(jQuery(this)));
+                const $el = jQuery(this);
+                const key = $el.attr('name') + "::" + $el.val();
+                if (seenDelegates.has(key)) return;
+                seenDelegates.add(key);
+                jQuery('#attachDocumentList').append(buildDelegateInput($el));
             });
 
             // show total attachments

--- a/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
+++ b/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
@@ -245,17 +245,7 @@ jQuery(document).on('click', '*[data-poload]', function () {
                 }
             });
 
-            // Uncheck server-pre-checked boxes whose delegate was removed in an
-            // earlier dialog session (unsaved uncheck — #attachDocumentList wins).
-            jQuery('#attachDocumentsForm').find('[data-pre-attached="true"]').each(function () {
-                const $cb = jQuery(this);
-                const hasDelegate = jQuery('#attachDocumentList').find(
-                    '.delegateAttachment[name="' + this.name + '"][value="' + this.value + '"]'
-                ).length > 0;
-                if (!hasDelegate) {
-                    $cb.prop('checked', false).removeAttr('data-pre-attached');
-                }
-            });
+            syncPreCheckedToDelegates('#attachDocumentList', false);
         }
     }).dialog({
         title: title,

--- a/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
+++ b/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
@@ -221,7 +221,10 @@ jQuery(document).on('click', '*[data-poload]', function () {
                 let delegate = "#" + this.id.split("_")[1];
                 let element = jQuery('#attachDocumentsForm').find(delegate);
                 if (element.length === 0 && delegate.startsWith('#docNo')) {
-                    element = jQuery('#attachDocumentsForm').find(delegate.replace('#docNo', '#providerDocNo'));
+                    element = jQuery('#attachDocumentsForm').find(delegate.replace('#docNo', '#providerPrivateDocNo'));
+                }
+                if (element.length === 0 && delegate.startsWith('#docNo')) {
+                    element = jQuery('#attachDocumentsForm').find(delegate.replace('#docNo', '#providerPublicDocNo'));
                 }
                 if (element.length === 0) {
                     element = addFormIfNotFound(data, demographicNo, delegate);
@@ -256,6 +259,19 @@ jQuery(document).on('click', '*[data-poload]', function () {
         beforeClose: function (event, ui) {
             // before the dialog is closed:
 
+            // warn if private provider documents are selected
+            var privateProviderDocsChecked = jQuery('#attachDocumentsForm')
+                .find(".providerPrivateDocument_check:checked:not(input[disabled='disabled'])");
+            if (privateProviderDocsChecked.length > 0) {
+                if (!confirm("You have selected " + privateProviderDocsChecked.length +
+                    " private provider document(s) for attachment.\n\n" +
+                    "Private documents are personal to your account. " +
+                    "Attaching them will make them visible to anyone with access to this patient's record.\n\n" +
+                    "Are you sure you want to attach these private documents?")) {
+                    return false;
+                }
+            }
+
             // check if list exists, if yes then empty it otherwise create new
             if (jQuery('#attachDocumentList').length === 0) {
                 const attachDocumentList = jQuery('<div>', {'id': 'attachDocumentList'});
@@ -264,7 +280,7 @@ jQuery(document).on('click', '*[data-poload]', function () {
             jQuery('#attachDocumentList').empty();
 
             // pass the checked documents to the eForm document list(attachDocumentList)
-            jQuery('#attachDocumentsForm').find(".document_check:checked:not(input[disabled='disabled']), .providerDocument_check:checked:not(input[disabled='disabled']), .lab_check:checked:not(input[disabled='disabled']), .form_check:checked:not(input[disabled='disabled']), .eForm_check:checked:not(input[disabled='disabled']), .hrm_check:checked:not(input[disabled='disabled'])"
+            jQuery('#attachDocumentsForm').find(".document_check:checked:not(input[disabled='disabled']), .providerPrivateDocument_check:checked:not(input[disabled='disabled']), .providerPublicDocument_check:checked:not(input[disabled='disabled']), .lab_check:checked:not(input[disabled='disabled']), .form_check:checked:not(input[disabled='disabled']), .eForm_check:checked:not(input[disabled='disabled']), .hrm_check:checked:not(input[disabled='disabled'])"
             ).each(function (index, data) {
                 let element = jQuery(this);
                 let input = jQuery("<input />", {

--- a/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
+++ b/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
@@ -200,24 +200,6 @@ function remoteSave() {
 	return false;
 }
 
-/** True if the delegate id prefix is one of the DOC sections. */
-function isDocDelegateKey(delegateKey) {
-    return /^(docNo|privateDocNo|publicDocNo)\d/.test(delegateKey);
-}
-
-/** Warn on new private eDoc selections; returns false to abort the close. */
-function confirmPrivateDocsIfAny(formSelector) {
-    var newPrivate = jQuery(formSelector)
-        .find(".providerPrivateDocument_check:checked:not(input[disabled='disabled'])")
-        .filter(function () { return !jQuery(this).data("pre-attached"); });
-    if (newPrivate.length === 0) return true;
-    return confirm("You have selected " + newPrivate.length +
-        " private eDoc(s) for attachment.\n\n" +
-        "Private documents are personal to your account. " +
-        "Attaching them will make them visible to anyone with access to this patient's record.\n\n" +
-        "Select OK to confirm, or Cancel to go back.");
-}
-
 /**
  * Triggers the eForm attach function
  */
@@ -240,14 +222,13 @@ jQuery(document).on('click', '*[data-poload]', function () {
 
                 // DOC sections share name="docNo" with distinct ids; look up by name+value.
                 // Skip if server-pre-attached; else mark as unsaved client-side selection.
-                if (isDocDelegateKey(delegateKey)) {
+                if (jQuery(this).data("delegate-type") === "doc") {
                     let docValue = this.value;
                     let matches = jQuery('#attachDocumentsForm').find('input[name="docNo"][value="' + docValue + '"]');
                     if (matches.filter('[data-pre-attached="true"]').length > 0) {
                         return;
                     }
-                    matches.prop("checked", true);
-                    matches.attr("data-pre-attached", "true").data("pre-attached", true);
+                    matches.prop("checked", true).attr("data-pre-attached", "true");
                     return;
                 }
 
@@ -256,8 +237,7 @@ jQuery(document).on('click', '*[data-poload]', function () {
                 if (element.length === 0) {
                     element = addFormIfNotFound(data, demographicNo, delegate);
                 }
-                element.attr("checked", true);
-                element.data("pre-attached", true);
+                element.prop("checked", true).attr("data-pre-attached", "true");
 
                 // Expand list if selected lab is older version
                 if (element.attr('data-version')) {
@@ -298,20 +278,10 @@ jQuery(document).on('click', '*[data-poload]', function () {
             }
             jQuery('#attachDocumentList').empty();
 
-            // Two suffix selectors so both new and server-pre-attached checkboxes are rebuilt.
             jQuery('#attachDocumentsForm').find(
-                "[class$='_check']:checkbox:checked:not(input[disabled='disabled']), " +
-                "[class$='_pre_check']:checkbox:checked:not(input[disabled='disabled'])"
-            ).each(function (index, data) {
-                let element = jQuery(this);
-                let input = jQuery("<input />", {
-                    type: 'hidden',
-                    name: element.attr('name'),
-                    value: element.val(),
-                    id: "delegate_" + element.attr('id'),
-                    class: 'delegateAttachment'
-                });
-                jQuery('#attachDocumentList').append(input);
+                ".attachable_check:checkbox:checked:not(input[disabled='disabled'])"
+            ).each(function () {
+                jQuery('#attachDocumentList').append(buildDelegateInput(jQuery(this)));
             });
 
             // show total attachments
@@ -336,7 +306,7 @@ function addFormIfNotFound(form, demographicNo, delegate) {
     const formDate = document.getElementById("entry_" + formId).getAttribute('data-formDate');
 
     const checkbox = jQuery('<input>', {
-        class: 'form_check',
+        class: 'form_check attachable_check',
         type: 'checkbox',
         name: checkboxName,
         id: formId,

--- a/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
+++ b/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
@@ -267,7 +267,7 @@ jQuery(document).on('click', '*[data-poload]', function () {
                     " private provider document(s) for attachment.\n\n" +
                     "Private documents are personal to your account. " +
                     "Attaching them will make them visible to anyone with access to this patient's record.\n\n" +
-                    "Are you sure you want to attach these private documents?")) {
+                    "Select OK to confirm, or Cancel to go back.")) {
                     return false;
                 }
             }

--- a/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
+++ b/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
@@ -201,6 +201,31 @@ function remoteSave() {
 }
 
 /**
+ * Keys prefix the delegate_<key> id on attachment rows for DOC-type items.
+ * These are now pre-rendered server-side, so the pre-check JS skips them.
+ */
+function isDocDelegateKey(delegateKey) {
+    return /^(docNo|privateDocNo|publicDocNo)\d/.test(delegateKey);
+}
+
+/**
+ * Prompts when new (not pre-attached) private eDocs are selected, warning the
+ * provider that attachment makes their personal docs visible to others with
+ * record access. Returns true to proceed, false to abort dialog close.
+ */
+function confirmPrivateDocsIfAny(formSelector) {
+    var newPrivate = jQuery(formSelector)
+        .find(".providerPrivateDocument_check:checked:not(input[disabled='disabled'])")
+        .filter(function () { return !jQuery(this).data("pre-attached"); });
+    if (newPrivate.length === 0) return true;
+    return confirm("You have selected " + newPrivate.length +
+        " private eDoc(s) for attachment.\n\n" +
+        "Private documents are personal to your account. " +
+        "Attaching them will make them visible to anyone with access to this patient's record.\n\n" +
+        "Select OK to confirm, or Cancel to go back.");
+}
+
+/**
  * Triggers the eForm attach function
  */
 jQuery(document).on('click', '*[data-poload]', function () {
@@ -218,7 +243,13 @@ jQuery(document).on('click', '*[data-poload]', function () {
             eformFloatingToolbar.classList.add("disabled-toolbar");
 
             jQuery('#attachDocumentList').find(".delegateAttachment").each(function (index, data) {
-                let delegate = "#" + this.id.split("_")[1];
+                let delegateKey = this.id.split("_")[1];
+                // DOC delegates (docNo/privateDocNo/publicDocNo) are pre-rendered
+                // server-side with checked + _pre_check + data-pre-attached.
+                if (isDocDelegateKey(delegateKey)) {
+                    return;
+                }
+                let delegate = "#" + delegateKey;
                 let element = jQuery('#attachDocumentsForm').find(delegate);
                 if (element.length === 0) {
                     element = addFormIfNotFound(data, demographicNo, delegate);
@@ -254,18 +285,8 @@ jQuery(document).on('click', '*[data-poload]', function () {
         beforeClose: function (event, ui) {
             // before the dialog is closed:
 
-            // warn if NEW private provider documents are selected (not pre-attached ones)
-            var privateProviderDocsChecked = jQuery('#attachDocumentsForm')
-                .find(".providerPrivateDocument_check:checked:not(input[disabled='disabled'])")
-                .filter(function() { return !jQuery(this).data("pre-attached"); });
-            if (privateProviderDocsChecked.length > 0) {
-                if (!confirm("You have selected " + privateProviderDocsChecked.length +
-                    " private provider document(s) for attachment.\n\n" +
-                    "Private documents are personal to your account. " +
-                    "Attaching them will make them visible to anyone with access to this patient's record.\n\n" +
-                    "Select OK to confirm, or Cancel to go back.")) {
-                    return false;
-                }
+            if (!confirmPrivateDocsIfAny('#attachDocumentsForm')) {
+                return false;
             }
 
             // check if list exists, if yes then empty it otherwise create new
@@ -275,8 +296,11 @@ jQuery(document).on('click', '*[data-poload]', function () {
             }
             jQuery('#attachDocumentList').empty();
 
-            // pass the checked documents to the eForm document list(attachDocumentList)
-            jQuery('#attachDocumentsForm').find(".document_check:checked:not(input[disabled='disabled']), .providerPrivateDocument_check:checked:not(input[disabled='disabled']), .providerPublicDocument_check:checked:not(input[disabled='disabled']), .lab_check:checked:not(input[disabled='disabled']), .form_check:checked:not(input[disabled='disabled']), .eForm_check:checked:not(input[disabled='disabled']), .hrm_check:checked:not(input[disabled='disabled'])"
+            // Match both "<type>_check" (new) and "<type>_pre_check" (server-
+            // rendered pre-attached) so pre-existing DOC attachments are preserved
+            // when the list is rebuilt from the selected items.
+            jQuery('#attachDocumentsForm').find(
+                "[class$='_check']:checkbox:checked:not(input[disabled='disabled'])"
             ).each(function (index, data) {
                 let element = jQuery(this);
                 let input = jQuery("<input />", {

--- a/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
+++ b/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
@@ -296,11 +296,12 @@ jQuery(document).on('click', '*[data-poload]', function () {
             }
             jQuery('#attachDocumentList').empty();
 
-            // Match both "<type>_check" (new) and "<type>_pre_check" (server-
-            // rendered pre-attached) so pre-existing DOC attachments are preserved
-            // when the list is rebuilt from the selected items.
+            // Match both "<type>_check" (new selection) and "<type>_pre_check"
+            // (server-rendered pre-attached) so pre-existing DOC attachments are
+            // preserved when the list is rebuilt. Two suffix selectors cover both.
             jQuery('#attachDocumentsForm').find(
-                "[class$='_check']:checkbox:checked:not(input[disabled='disabled'])"
+                "[class$='_check']:checkbox:checked:not(input[disabled='disabled']), " +
+                "[class$='_pre_check']:checkbox:checked:not(input[disabled='disabled'])"
             ).each(function (index, data) {
                 let element = jQuery(this);
                 let input = jQuery("<input />", {

--- a/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
+++ b/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
@@ -220,12 +220,6 @@ jQuery(document).on('click', '*[data-poload]', function () {
             jQuery('#attachDocumentList').find(".delegateAttachment").each(function (index, data) {
                 let delegate = "#" + this.id.split("_")[1];
                 let element = jQuery('#attachDocumentsForm').find(delegate);
-                if (element.length === 0 && delegate.startsWith('#docNo')) {
-                    element = jQuery('#attachDocumentsForm').find(delegate.replace('#docNo', '#providerPrivateDocNo'));
-                }
-                if (element.length === 0 && delegate.startsWith('#docNo')) {
-                    element = jQuery('#attachDocumentsForm').find(delegate.replace('#docNo', '#providerPublicDocNo'));
-                }
                 if (element.length === 0) {
                     element = addFormIfNotFound(data, demographicNo, delegate);
                 }

--- a/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
+++ b/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
@@ -200,19 +200,12 @@ function remoteSave() {
 	return false;
 }
 
-/**
- * Keys prefix the delegate_<key> id on attachment rows for DOC-type items.
- * These are now pre-rendered server-side, so the pre-check JS skips them.
- */
+/** True if the delegate id prefix is one of the DOC sections. */
 function isDocDelegateKey(delegateKey) {
     return /^(docNo|privateDocNo|publicDocNo)\d/.test(delegateKey);
 }
 
-/**
- * Prompts when new (not pre-attached) private eDocs are selected, warning the
- * provider that attachment makes their personal docs visible to others with
- * record access. Returns true to proceed, false to abort dialog close.
- */
+/** Warn on new private eDoc selections; returns false to abort the close. */
 function confirmPrivateDocsIfAny(formSelector) {
     var newPrivate = jQuery(formSelector)
         .find(".providerPrivateDocument_check:checked:not(input[disabled='disabled'])")
@@ -244,11 +237,20 @@ jQuery(document).on('click', '*[data-poload]', function () {
 
             jQuery('#attachDocumentList').find(".delegateAttachment").each(function (index, data) {
                 let delegateKey = this.id.split("_")[1];
-                // DOC delegates (docNo/privateDocNo/publicDocNo) are pre-rendered
-                // server-side with checked + _pre_check + data-pre-attached.
+
+                // DOC sections share name="docNo" with distinct ids; look up by name+value.
+                // Skip if server-pre-attached; else mark as unsaved client-side selection.
                 if (isDocDelegateKey(delegateKey)) {
+                    let docValue = this.value;
+                    let matches = jQuery('#attachDocumentsForm').find('input[name="docNo"][value="' + docValue + '"]');
+                    if (matches.filter('[data-pre-attached="true"]').length > 0) {
+                        return;
+                    }
+                    matches.prop("checked", true);
+                    matches.attr("data-pre-attached", "true").data("pre-attached", true);
                     return;
                 }
+
                 let delegate = "#" + delegateKey;
                 let element = jQuery('#attachDocumentsForm').find(delegate);
                 if (element.length === 0) {
@@ -296,9 +298,7 @@ jQuery(document).on('click', '*[data-poload]', function () {
             }
             jQuery('#attachDocumentList').empty();
 
-            // Match both "<type>_check" (new selection) and "<type>_pre_check"
-            // (server-rendered pre-attached) so pre-existing DOC attachments are
-            // preserved when the list is rebuilt. Two suffix selectors cover both.
+            // Two suffix selectors so both new and server-pre-attached checkboxes are rebuilt.
             jQuery('#attachDocumentsForm').find(
                 "[class$='_check']:checkbox:checked:not(input[disabled='disabled']), " +
                 "[class$='_pre_check']:checkbox:checked:not(input[disabled='disabled'])"

--- a/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
+++ b/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
@@ -220,6 +220,9 @@ jQuery(document).on('click', '*[data-poload]', function () {
             jQuery('#attachDocumentList').find(".delegateAttachment").each(function (index, data) {
                 let delegate = "#" + this.id.split("_")[1];
                 let element = jQuery('#attachDocumentsForm').find(delegate);
+                if (element.length === 0 && delegate.startsWith('#docNo')) {
+                    element = jQuery('#attachDocumentsForm').find(delegate.replace('#docNo', '#providerDocNo'));
+                }
                 if (element.length === 0) {
                     element = addFormIfNotFound(data, demographicNo, delegate);
                 }
@@ -261,7 +264,7 @@ jQuery(document).on('click', '*[data-poload]', function () {
             jQuery('#attachDocumentList').empty();
 
             // pass the checked documents to the eForm document list(attachDocumentList)
-            jQuery('#attachDocumentsForm').find(".document_check:checked:not(input[disabled='disabled']), .lab_check:checked:not(input[disabled='disabled']), .form_check:checked:not(input[disabled='disabled']), .eForm_check:checked:not(input[disabled='disabled']), .hrm_check:checked:not(input[disabled='disabled'])"
+            jQuery('#attachDocumentsForm').find(".document_check:checked:not(input[disabled='disabled']), .providerDocument_check:checked:not(input[disabled='disabled']), .lab_check:checked:not(input[disabled='disabled']), .form_check:checked:not(input[disabled='disabled']), .eForm_check:checked:not(input[disabled='disabled']), .hrm_check:checked:not(input[disabled='disabled'])"
             ).each(function (index, data) {
                 let element = jQuery(this);
                 let input = jQuery("<input />", {

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp
@@ -3219,7 +3219,7 @@ if (userAgent != null) {
 
                         // warn if private provider documents are selected
                         var privateProviderDocsChecked = jQuery('#attachDocumentsForm')
-                            .find(".providerPrivateDocument_check:checked:not(input[disabled='disabled']), .providerPrivateDocument_pre_check:checked:not(input[disabled='disabled'])");
+                            .find(".providerPrivateDocument_check:checked:not(input[disabled='disabled'])");
                         if (privateProviderDocsChecked.length > 0) {
                             if (!confirm("You have selected " + privateProviderDocsChecked.length +
                                 " private provider document(s) for attachment.\n\n" +

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp
@@ -3237,10 +3237,16 @@ if (userAgent != null) {
                             return false;
                         }
 
+                        // Dedupe by name+value: a doc with multiple ctl bindings can appear
+                        // in multiple sections (patient + provider) with shared name="docNo".
+                        var seenDelegates = {};
                         // pass the checked elements to the consultation request form
                         jQuery('#attachDocumentsForm').find(".document_check:checked:not(input[disabled='disabled']), .providerPrivateDocument_check:checked:not(input[disabled='disabled']), .providerPublicDocument_check:checked:not(input[disabled='disabled']), .lab_check:checked:not(input[disabled='disabled']), .form_check:checked:not(input[disabled='disabled']), .eForm_check:checked:not(input[disabled='disabled']), .hrm_check:checked:not(input[disabled='disabled'])"
                         ).each(function (index, data) {
                             var element = jQuery(this);
+                            var key = element.attr('name') + "::" + element.val();
+                            if (seenDelegates[key]) return;
+                            seenDelegates[key] = true;
                             var input = buildDelegateInput(element);
                             // entry_ row id uses name+value (not checkbox id) so the three DOC sections share a row key.
                             var row = jQuery("<tr>", {id: "entry_" + element.attr("name") + element.val()});

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp
@@ -3170,7 +3170,14 @@ if (userAgent != null) {
                 jQuery("#attachDocumentDisplay").load(trigger.data('poload'), function (response, status, xhr) {
                     if (status === "success") {
                         $mainForm.find(".delegateAttachment").each(function (index, data) {
-                            let delegate = "#" + this.id.split("_")[1];
+                            let delegateKey = this.id.split("_")[1];
+                            // DOC delegates (docNo/privateDocNo/publicDocNo) are
+                            // pre-rendered server-side with _pre_check class and
+                            // data-pre-attached. Skip client-side marking.
+                            if (/^(docNo|privateDocNo|publicDocNo)\d/.test(delegateKey)) {
+                                return;
+                            }
+                            let delegate = "#" + delegateKey;
                             let element = jQuery('#attachDocumentsForm').find(delegate);
                             if (element.length === 0) {
                                 element = addFormIfNotFound(data, '<%=demo%>', delegate);
@@ -3211,17 +3218,17 @@ if (userAgent != null) {
                     beforeClose: function (event, ui) {
                         // before the dialog is closed:
 
-                        // warn if private provider documents are selected
-                        var privateProviderDocsChecked = jQuery('#attachDocumentsForm')
-                            .find(".providerPrivateDocument_check:checked:not(input[disabled='disabled'])");
-                        if (privateProviderDocsChecked.length > 0) {
-                            if (!confirm("You have selected " + privateProviderDocsChecked.length +
-                                " private provider document(s) for attachment.\n\n" +
+                        // warn on NEW (not pre-attached) private eDoc selections
+                        var newPrivate = jQuery('#attachDocumentsForm')
+                            .find(".providerPrivateDocument_check:checked:not(input[disabled='disabled'])")
+                            .filter(function () { return !jQuery(this).data("pre-attached"); });
+                        if (newPrivate.length > 0 &&
+                            !confirm("You have selected " + newPrivate.length +
+                                " private eDoc(s) for attachment.\n\n" +
                                 "Private documents are personal to your account. " +
                                 "Attaching them will make them visible to anyone with access to this patient's record.\n\n" +
                                 "Select OK to confirm, or Cancel to go back.")) {
-                                return false;
-                            }
+                            return false;
                         }
 
                         // pass the checked elements to the consultation request form
@@ -3267,7 +3274,9 @@ if (userAgent != null) {
 
                             if (!checkedElement.is(':checked')) {
                                 var checkedElementClass = checkedElement.attr("class");
-                                $mainForm.find("#entry_" + checkedElement.attr("id")).remove();
+                                // Entry row id uses name+value (stable across
+                                // sections with different checkbox id prefixes).
+                                $mainForm.find("#entry_" + checkedElement.attr("name") + checkedElement.val()).remove();
                                 checkedElement.attr("class", checkedElementClass.split("_")[0] + "_check");
                             }
                         });

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp
@@ -3172,6 +3172,9 @@ if (userAgent != null) {
                         $mainForm.find(".delegateAttachment").each(function (index, data) {
                             let delegate = "#" + this.id.split("_")[1];
                             let element = jQuery('#attachDocumentsForm').find(delegate);
+                            if (element.length === 0 && delegate.startsWith('#docNo')) {
+                                element = jQuery('#attachDocumentsForm').find(delegate.replace('#docNo', '#providerDocNo'));
+                            }
                             if (element.length === 0) {
                                 element = addFormIfNotFound(data, '<%=demo%>', delegate);
                             }
@@ -3212,7 +3215,7 @@ if (userAgent != null) {
                         // before the dialog is closed:
 
                         // pass the checked elements to the consultation request form
-                        jQuery('#attachDocumentsForm').find(".document_check:checked:not(input[disabled='disabled']), .lab_check:checked:not(input[disabled='disabled']), .form_check:checked:not(input[disabled='disabled']), .eForm_check:checked:not(input[disabled='disabled']), .hrm_check:checked:not(input[disabled='disabled'])"
+                        jQuery('#attachDocumentsForm').find(".document_check:checked:not(input[disabled='disabled']), .providerDocument_check:checked:not(input[disabled='disabled']), .lab_check:checked:not(input[disabled='disabled']), .form_check:checked:not(input[disabled='disabled']), .eForm_check:checked:not(input[disabled='disabled']), .hrm_check:checked:not(input[disabled='disabled'])"
                         ).each(function (index, data) {
                             var element = jQuery(this);
                             var input = jQuery("<input />", {
@@ -3249,7 +3252,7 @@ if (userAgent != null) {
                         });
 
                         // remove unchecked elements from the request form.
-                        jQuery('#attachDocumentsForm').find(".document_pre_check:not(input[disabled='disabled']), .lab_pre_check:not(input[disabled='disabled']), .form_pre_check:not(input[disabled='disabled']), .eForm_pre_check:not(input[disabled='disabled']), .hrm_pre_check:not(input[disabled='disabled'])").each(function (index, data) {
+                        jQuery('#attachDocumentsForm').find(".document_pre_check:not(input[disabled='disabled']), .providerDocument_pre_check:not(input[disabled='disabled']), .lab_pre_check:not(input[disabled='disabled']), .form_pre_check:not(input[disabled='disabled']), .eForm_pre_check:not(input[disabled='disabled']), .hrm_pre_check:not(input[disabled='disabled'])").each(function (index, data) {
                             var checkedElement = jQuery(this);
 
                             if (!checkedElement.is(':checked')) {

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp
@@ -3205,6 +3205,25 @@ if (userAgent != null) {
                             }
                         });
 
+                        // Uncheck (and revert _pre_check → _check on) server-pre-checked boxes
+                        // whose delegate was removed in an earlier dialog session ($mainForm wins).
+                        jQuery('#attachDocumentsForm').find('[data-pre-attached="true"]').each(function () {
+                            var $cb = jQuery(this);
+                            var hasDelegate = $mainForm.find(
+                                '.delegateAttachment[name="' + this.name + '"][value="' + this.value + '"]'
+                            ).length > 0;
+                            if (!hasDelegate) {
+                                $cb.prop('checked', false).removeAttr('data-pre-attached');
+                                var tokens = ($cb.attr('class') || '').split(' ');
+                                for (var i = 0; i < tokens.length; i++) {
+                                    if (tokens[i].indexOf('_pre_check') > 0) {
+                                        $cb.removeClass(tokens[i]).addClass(tokens[i].split('_')[0] + '_check');
+                                        break;
+                                    }
+                                }
+                            }
+                        });
+
                         // Disable all EncounterForm (form) checkboxes in the attachment window if a consultation request is created using OceanMD.
                         if (typeof disableFields !== 'undefined' && disableFields === true) {
                             jQuery("#formList input[type='checkbox']").prop("disabled", true);
@@ -3237,8 +3256,7 @@ if (userAgent != null) {
                             return false;
                         }
 
-                        // Dedupe by name+value: a doc with multiple ctl bindings can appear
-                        // in multiple sections (patient + provider) with shared name="docNo".
+                        // Cross-section dedupe: same docNo can render in patient + provider sections.
                         var seenDelegates = {};
                         // pass the checked elements to the consultation request form
                         jQuery('#attachDocumentsForm').find(".document_check:checked:not(input[disabled='disabled']), .providerPrivateDocument_check:checked:not(input[disabled='disabled']), .providerPublicDocument_check:checked:not(input[disabled='disabled']), .lab_check:checked:not(input[disabled='disabled']), .form_check:checked:not(input[disabled='disabled']), .eForm_check:checked:not(input[disabled='disabled']), .hrm_check:checked:not(input[disabled='disabled'])"

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp
@@ -3205,24 +3205,7 @@ if (userAgent != null) {
                             }
                         });
 
-                        // Uncheck (and revert _pre_check → _check on) server-pre-checked boxes
-                        // whose delegate was removed in an earlier dialog session ($mainForm wins).
-                        jQuery('#attachDocumentsForm').find('[data-pre-attached="true"]').each(function () {
-                            var $cb = jQuery(this);
-                            var hasDelegate = $mainForm.find(
-                                '.delegateAttachment[name="' + this.name + '"][value="' + this.value + '"]'
-                            ).length > 0;
-                            if (!hasDelegate) {
-                                $cb.prop('checked', false).removeAttr('data-pre-attached');
-                                var tokens = ($cb.attr('class') || '').split(' ');
-                                for (var i = 0; i < tokens.length; i++) {
-                                    if (tokens[i].indexOf('_pre_check') > 0) {
-                                        $cb.removeClass(tokens[i]).addClass(tokens[i].split('_')[0] + '_check');
-                                        break;
-                                    }
-                                }
-                            }
-                        });
+                        syncPreCheckedToDelegates($mainForm, true);
 
                         // Disable all EncounterForm (form) checkboxes in the attachment window if a consultation request is created using OceanMD.
                         if (typeof disableFields !== 'undefined' && disableFields === true) {

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp
@@ -3171,12 +3171,22 @@ if (userAgent != null) {
                     if (status === "success") {
                         $mainForm.find(".delegateAttachment").each(function (index, data) {
                             let delegateKey = this.id.split("_")[1];
-                            // DOC delegates (docNo/privateDocNo/publicDocNo) are
-                            // pre-rendered server-side with _pre_check class and
-                            // data-pre-attached. Skip client-side marking.
+
+                            // DOC sections share name="docNo" with distinct ids; look up by name+value.
+                            // Skip if server-pre-attached; else mark as unsaved client-side selection.
                             if (/^(docNo|privateDocNo|publicDocNo)\d/.test(delegateKey)) {
+                                let docValue = this.value;
+                                let matches = jQuery('#attachDocumentsForm').find('input[name="docNo"][value="' + docValue + '"]');
+                                if (matches.filter('[data-pre-attached="true"]').length > 0) {
+                                    return;
+                                }
+                                matches.prop("checked", true);
+                                let cls = matches.attr("class");
+                                if (cls) matches.attr("class", cls.split("_")[0] + "_pre_check");
+                                matches.attr("data-pre-attached", "true").data("pre-attached", true);
                                 return;
                             }
+
                             let delegate = "#" + delegateKey;
                             let element = jQuery('#attachDocumentsForm').find(delegate);
                             if (element.length === 0) {
@@ -3242,6 +3252,7 @@ if (userAgent != null) {
                                 id: "delegate_" + element.attr('id'),
                                 class: 'delegateAttachment'
                             });
+                            // entry_ row id uses name+value (not checkbox id) so the three DOC sections share a row key.
                             var row = jQuery("<tr>", {id: "entry_" + element.attr("name") + element.val()});
                             var column = jQuery("<td>");
                             var target = "#attachedDocumentsTable";
@@ -3274,14 +3285,9 @@ if (userAgent != null) {
 
                             if (!checkedElement.is(':checked')) {
                                 var checkedElementClass = checkedElement.attr("class");
-                                // Entry row id uses name+value (stable across
-                                // sections with different checkbox id prefixes).
                                 $mainForm.find("#entry_" + checkedElement.attr("name") + checkedElement.val()).remove();
                                 checkedElement.attr("class", checkedElementClass.split("_")[0] + "_check");
-                                // Once an unchecked pre-attached item is re-checked
-                                // within the same session, it should behave as a
-                                // new selection (e.g. trigger the private-doc
-                                // warning), so drop the pre-attached marker.
+                                // Drop pre-attached so a subsequent re-check fires the private-doc warning.
                                 checkedElement.removeAttr("data-pre-attached");
                                 checkedElement.removeData("pre-attached");
                             }

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp
@@ -3278,6 +3278,12 @@ if (userAgent != null) {
                                 // sections with different checkbox id prefixes).
                                 $mainForm.find("#entry_" + checkedElement.attr("name") + checkedElement.val()).remove();
                                 checkedElement.attr("class", checkedElementClass.split("_")[0] + "_check");
+                                // Once an unchecked pre-attached item is re-checked
+                                // within the same session, it should behave as a
+                                // new selection (e.g. trigger the private-doc
+                                // warning), so drop the pre-attached marker.
+                                checkedElement.removeAttr("data-pre-attached");
+                                checkedElement.removeData("pre-attached");
                             }
                         });
 

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp
@@ -3225,7 +3225,7 @@ if (userAgent != null) {
                                 " private provider document(s) for attachment.\n\n" +
                                 "Private documents are personal to your account. " +
                                 "Attaching them will make them visible to anyone with access to this patient's record.\n\n" +
-                                "Are you sure you want to attach these private documents?")) {
+                                "Select OK to confirm, or Cancel to go back.")) {
                                 return false;
                             }
                         }
@@ -3241,7 +3241,7 @@ if (userAgent != null) {
                                 id: "delegate_" + element.attr('id'),
                                 class: 'delegateAttachment'
                             });
-                            var row = jQuery("<tr>", {id: "entry_" + element.attr("id")});
+                            var row = jQuery("<tr>", {id: "entry_" + element.attr("name") + element.val()});
                             var column = jQuery("<td>");
                             var target = "#attachedDocumentsTable";
 
@@ -3273,7 +3273,7 @@ if (userAgent != null) {
 
                             if (!checkedElement.is(':checked')) {
                                 var checkedElementClass = checkedElement.attr("class");
-                                $mainForm.find("#entry_" + checkedElement.attr("id")).remove();
+                                $mainForm.find("#entry_" + checkedElement.attr("name") + checkedElement.val()).remove();
                                 checkedElement.attr("class", checkedElementClass.split("_")[0] + "_check");
                             }
                         });

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp
@@ -1970,6 +1970,7 @@ if (userAgent != null) {
                                                             <c:out value="${ attachedDocument.description }"/>
                                                             <input name="docNo" value="${ attachedDocument.docId }"
                                                                    id="delegate_docNo${ attachedDocument.docId }"
+                                                                   data-delegate-type="doc"
                                                                    class="delegateAttachment" type="hidden">
                                                         </td>
                                                     </tr>
@@ -3174,16 +3175,19 @@ if (userAgent != null) {
 
                             // DOC sections share name="docNo" with distinct ids; look up by name+value.
                             // Skip if server-pre-attached; else mark as unsaved client-side selection.
-                            if (/^(docNo|privateDocNo|publicDocNo)\d/.test(delegateKey)) {
+                            if (jQuery(this).data("delegate-type") === "doc") {
                                 let docValue = this.value;
                                 let matches = jQuery('#attachDocumentsForm').find('input[name="docNo"][value="' + docValue + '"]');
                                 if (matches.filter('[data-pre-attached="true"]').length > 0) {
                                     return;
                                 }
                                 matches.prop("checked", true);
-                                let cls = matches.attr("class");
-                                if (cls) matches.attr("class", cls.split("_")[0] + "_pre_check");
-                                matches.attr("data-pre-attached", "true").data("pre-attached", true);
+                                matches.each(function () {
+                                    let $m = jQuery(this);
+                                    let oldType = $m.attr("class").split(" ")[0];
+                                    $m.removeClass(oldType).addClass(oldType.split("_")[0] + "_pre_check");
+                                });
+                                matches.attr("data-pre-attached", "true");
                                 return;
                             }
 
@@ -3192,8 +3196,8 @@ if (userAgent != null) {
                             if (element.length === 0) {
                                 element = addFormIfNotFound(data, '<%=demo%>', delegate);
                             }
-                            let elementClassType = element.attr("class").split("_")[0];
-                            element.attr("checked", true).attr("class", elementClassType + "_pre_check");
+                            let oldType = element.attr("class").split(" ")[0];
+                            element.attr("checked", true).removeClass(oldType).addClass(oldType.split("_")[0] + "_pre_check");
 
                             // Expand list if selected lab is older version
                             if (element.attr('data-version')) {
@@ -3229,15 +3233,7 @@ if (userAgent != null) {
                         // before the dialog is closed:
 
                         // warn on NEW (not pre-attached) private eDoc selections
-                        var newPrivate = jQuery('#attachDocumentsForm')
-                            .find(".providerPrivateDocument_check:checked:not(input[disabled='disabled'])")
-                            .filter(function () { return !jQuery(this).data("pre-attached"); });
-                        if (newPrivate.length > 0 &&
-                            !confirm("You have selected " + newPrivate.length +
-                                " private eDoc(s) for attachment.\n\n" +
-                                "Private documents are personal to your account. " +
-                                "Attaching them will make them visible to anyone with access to this patient's record.\n\n" +
-                                "Select OK to confirm, or Cancel to go back.")) {
+                        if (!confirmPrivateDocsIfAny('#attachDocumentsForm')) {
                             return false;
                         }
 
@@ -3245,13 +3241,7 @@ if (userAgent != null) {
                         jQuery('#attachDocumentsForm').find(".document_check:checked:not(input[disabled='disabled']), .providerPrivateDocument_check:checked:not(input[disabled='disabled']), .providerPublicDocument_check:checked:not(input[disabled='disabled']), .lab_check:checked:not(input[disabled='disabled']), .form_check:checked:not(input[disabled='disabled']), .eForm_check:checked:not(input[disabled='disabled']), .hrm_check:checked:not(input[disabled='disabled'])"
                         ).each(function (index, data) {
                             var element = jQuery(this);
-                            var input = jQuery("<input />", {
-                                type: 'hidden',
-                                name: element.attr('name'),
-                                value: element.val(),
-                                id: "delegate_" + element.attr('id'),
-                                class: 'delegateAttachment'
-                            });
+                            var input = buildDelegateInput(element);
                             // entry_ row id uses name+value (not checkbox id) so the three DOC sections share a row key.
                             var row = jQuery("<tr>", {id: "entry_" + element.attr("name") + element.val()});
                             var column = jQuery("<td>");
@@ -3284,12 +3274,11 @@ if (userAgent != null) {
                             var checkedElement = jQuery(this);
 
                             if (!checkedElement.is(':checked')) {
-                                var checkedElementClass = checkedElement.attr("class");
+                                var oldType = checkedElement.attr("class").split(" ")[0];
                                 $mainForm.find("#entry_" + checkedElement.attr("name") + checkedElement.val()).remove();
-                                checkedElement.attr("class", checkedElementClass.split("_")[0] + "_check");
+                                checkedElement.removeClass(oldType).addClass(oldType.split("_")[0] + "_check");
                                 // Drop pre-attached so a subsequent re-check fires the private-doc warning.
                                 checkedElement.removeAttr("data-pre-attached");
-                                checkedElement.removeData("pre-attached");
                             }
                         });
 

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp
@@ -3172,12 +3172,6 @@ if (userAgent != null) {
                         $mainForm.find(".delegateAttachment").each(function (index, data) {
                             let delegate = "#" + this.id.split("_")[1];
                             let element = jQuery('#attachDocumentsForm').find(delegate);
-                            if (element.length === 0 && delegate.startsWith('#docNo')) {
-                                element = jQuery('#attachDocumentsForm').find(delegate.replace('#docNo', '#providerPrivateDocNo'));
-                            }
-                            if (element.length === 0 && delegate.startsWith('#docNo')) {
-                                element = jQuery('#attachDocumentsForm').find(delegate.replace('#docNo', '#providerPublicDocNo'));
-                            }
                             if (element.length === 0) {
                                 element = addFormIfNotFound(data, '<%=demo%>', delegate);
                             }
@@ -3273,7 +3267,7 @@ if (userAgent != null) {
 
                             if (!checkedElement.is(':checked')) {
                                 var checkedElementClass = checkedElement.attr("class");
-                                $mainForm.find("#entry_" + checkedElement.attr("name") + checkedElement.val()).remove();
+                                $mainForm.find("#entry_" + checkedElement.attr("id")).remove();
                                 checkedElement.attr("class", checkedElementClass.split("_")[0] + "_check");
                             }
                         });

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp
@@ -3173,7 +3173,10 @@ if (userAgent != null) {
                             let delegate = "#" + this.id.split("_")[1];
                             let element = jQuery('#attachDocumentsForm').find(delegate);
                             if (element.length === 0 && delegate.startsWith('#docNo')) {
-                                element = jQuery('#attachDocumentsForm').find(delegate.replace('#docNo', '#providerDocNo'));
+                                element = jQuery('#attachDocumentsForm').find(delegate.replace('#docNo', '#providerPrivateDocNo'));
+                            }
+                            if (element.length === 0 && delegate.startsWith('#docNo')) {
+                                element = jQuery('#attachDocumentsForm').find(delegate.replace('#docNo', '#providerPublicDocNo'));
                             }
                             if (element.length === 0) {
                                 element = addFormIfNotFound(data, '<%=demo%>', delegate);
@@ -3214,8 +3217,21 @@ if (userAgent != null) {
                     beforeClose: function (event, ui) {
                         // before the dialog is closed:
 
+                        // warn if private provider documents are selected
+                        var privateProviderDocsChecked = jQuery('#attachDocumentsForm')
+                            .find(".providerPrivateDocument_check:checked:not(input[disabled='disabled']), .providerPrivateDocument_pre_check:checked:not(input[disabled='disabled'])");
+                        if (privateProviderDocsChecked.length > 0) {
+                            if (!confirm("You have selected " + privateProviderDocsChecked.length +
+                                " private provider document(s) for attachment.\n\n" +
+                                "Private documents are personal to your account. " +
+                                "Attaching them will make them visible to anyone with access to this patient's record.\n\n" +
+                                "Are you sure you want to attach these private documents?")) {
+                                return false;
+                            }
+                        }
+
                         // pass the checked elements to the consultation request form
-                        jQuery('#attachDocumentsForm').find(".document_check:checked:not(input[disabled='disabled']), .providerDocument_check:checked:not(input[disabled='disabled']), .lab_check:checked:not(input[disabled='disabled']), .form_check:checked:not(input[disabled='disabled']), .eForm_check:checked:not(input[disabled='disabled']), .hrm_check:checked:not(input[disabled='disabled'])"
+                        jQuery('#attachDocumentsForm').find(".document_check:checked:not(input[disabled='disabled']), .providerPrivateDocument_check:checked:not(input[disabled='disabled']), .providerPublicDocument_check:checked:not(input[disabled='disabled']), .lab_check:checked:not(input[disabled='disabled']), .form_check:checked:not(input[disabled='disabled']), .eForm_check:checked:not(input[disabled='disabled']), .hrm_check:checked:not(input[disabled='disabled'])"
                         ).each(function (index, data) {
                             var element = jQuery(this);
                             var input = jQuery("<input />", {
@@ -3225,7 +3241,7 @@ if (userAgent != null) {
                                 id: "delegate_" + element.attr('id'),
                                 class: 'delegateAttachment'
                             });
-                            var row = jQuery("<tr>", {id: "entry_" + element.attr("name") + element.val()});
+                            var row = jQuery("<tr>", {id: "entry_" + element.attr("id")});
                             var column = jQuery("<td>");
                             var target = "#attachedDocumentsTable";
 
@@ -3252,7 +3268,7 @@ if (userAgent != null) {
                         });
 
                         // remove unchecked elements from the request form.
-                        jQuery('#attachDocumentsForm').find(".document_pre_check:not(input[disabled='disabled']), .providerDocument_pre_check:not(input[disabled='disabled']), .lab_pre_check:not(input[disabled='disabled']), .form_pre_check:not(input[disabled='disabled']), .eForm_pre_check:not(input[disabled='disabled']), .hrm_pre_check:not(input[disabled='disabled'])").each(function (index, data) {
+                        jQuery('#attachDocumentsForm').find(".document_pre_check:not(input[disabled='disabled']), .providerPrivateDocument_pre_check:not(input[disabled='disabled']), .providerPublicDocument_pre_check:not(input[disabled='disabled']), .lab_pre_check:not(input[disabled='disabled']), .form_pre_check:not(input[disabled='disabled']), .eForm_pre_check:not(input[disabled='disabled']), .hrm_pre_check:not(input[disabled='disabled'])").each(function (index, data) {
                             var checkedElement = jQuery(this);
 
                             if (!checkedElement.is(':checked')) {

--- a/src/test-modern/java/ca/openosp/openo/documentManager/DocumentAttachmentManagerMergeAttachedUnitTest.java
+++ b/src/test-modern/java/ca/openosp/openo/documentManager/DocumentAttachmentManagerMergeAttachedUnitTest.java
@@ -1,6 +1,7 @@
-package ca.openosp.openo.documentManager.actions;
+package ca.openosp.openo.documentManager;
 
-import ca.openosp.openo.documentManager.EDoc;
+import ca.openosp.openo.utility.LoggedInInfo;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -8,39 +9,50 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
- * Unit tests for {@link DocumentPreview2Action#mergeSingleAttachedDoc} — the
- * classification function that decides which section (patient / provider public /
- * provider private) an attached EDoc lands in when the attachment manager reopens
- * a saved consult or eForm. No Spring context; the method is a pure classifier.
+ * Unit tests for {@link DocumentAttachmentManagerImpl#mergeAttachedIntoSections}
+ * — the classification function that decides which section (patient / provider
+ * public / provider private) an attached EDoc lands in when the attachment
+ * manager reopens a saved consult or eForm. Exercised one doc at a time via a
+ * single-element attached list; no Spring context.
  *
  * Covers the full matrix of (module type, public flag, ownership, deleted state)
  * combinations that drive the UI's section placement and "(other provider)" label.
  */
-@DisplayName("DocumentPreview2Action.mergeSingleAttachedDoc")
+@DisplayName("DocumentAttachmentManagerImpl.mergeAttachedIntoSections")
 @Tag("unit")
 @Tag("document")
-class DocumentPreview2ActionMergeUnitTest {
+class DocumentAttachmentManagerMergeAttachedUnitTest {
 
     private static final String CURRENT_PROVIDER = "42";
     private static final String OTHER_PROVIDER = "99";
 
+    private final DocumentAttachmentManagerImpl manager = new DocumentAttachmentManagerImpl();
+
+    private LoggedInInfo loggedInInfo;
     private List<EDoc> allDocuments;
     private List<EDoc> providerPrivateDocs;
     private List<EDoc> providerPublicDocs;
+    private Set<String> attachedDocumentIds;
     private Set<String> foreignPrivateDocIds;
 
     @BeforeEach
     void resetSinks() {
+        loggedInInfo = mock(LoggedInInfo.class);
+        when(loggedInInfo.getLoggedInProviderNo()).thenReturn(CURRENT_PROVIDER);
         allDocuments = new ArrayList<>();
         providerPrivateDocs = new ArrayList<>();
         providerPublicDocs = new ArrayList<>();
+        attachedDocumentIds = new HashSet<>();
         foreignPrivateDocIds = new HashSet<>();
     }
 
@@ -52,7 +64,7 @@ class DocumentPreview2ActionMergeUnitTest {
         @DisplayName("active patient doc is a no-op — already listed in allDocuments")
         void shouldBeNoOp_whenActivePatientDoc() {
             merge(patientDoc("1", 'A'));
-            assertAllEmpty();
+            assertSectionListsEmpty();
         }
 
         @Test
@@ -75,7 +87,7 @@ class DocumentPreview2ActionMergeUnitTest {
         @DisplayName("active public provider doc is a no-op — already listed in providerPublicDocs")
         void shouldBeNoOp_whenActivePublicProviderDoc() {
             merge(providerDoc("3", 'A', true, OTHER_PROVIDER));
-            assertAllEmpty();
+            assertSectionListsEmpty();
         }
 
         @Test
@@ -98,7 +110,7 @@ class DocumentPreview2ActionMergeUnitTest {
         @DisplayName("active own private doc is a no-op — already listed in providerPrivateDocs")
         void shouldBeNoOp_whenActiveOwnPrivateDoc() {
             merge(providerDoc("5", 'A', false, CURRENT_PROVIDER));
-            assertAllEmpty();
+            assertSectionListsEmpty();
         }
 
         @Test
@@ -145,9 +157,9 @@ class DocumentPreview2ActionMergeUnitTest {
         @Test
         @DisplayName("no current provider means foreign private docs aren't misclassified as owned")
         void shouldFlagForeign_whenCurrentProviderIsNull() {
+            when(loggedInInfo.getLoggedInProviderNo()).thenReturn(null);
             EDoc doc = providerDoc("9", 'A', false, OTHER_PROVIDER);
-            DocumentPreview2Action.mergeSingleAttachedDoc(
-                    doc, null, allDocuments, providerPrivateDocs, providerPublicDocs, foreignPrivateDocIds);
+            merge(doc);
             assertThat(providerPrivateDocs).containsExactly(doc);
             assertThat(foreignPrivateDocIds).containsExactly("9");
         }
@@ -167,16 +179,30 @@ class DocumentPreview2ActionMergeUnitTest {
             assertThat(providerPrivateDocs).containsExactly(legacy);
             assertThat(foreignPrivateDocIds).containsExactly("10");
         }
+
+        @Test
+        @DisplayName("every attached doc's id is collected into attachedDocumentIds regardless of classification")
+        void shouldCollectId_whenDocIsAttached() {
+            merge(patientDoc("11", 'A'));
+            assertThat(attachedDocumentIds).containsExactly("11");
+        }
+
+        @Test
+        @DisplayName("empty attached list is a no-op across all section lists and id sets")
+        void shouldBeNoOp_whenAttachedListIsEmpty() {
+            manager.mergeAttachedIntoSections(loggedInInfo, Collections.emptyList(), allDocuments, providerPrivateDocs, providerPublicDocs, attachedDocumentIds, foreignPrivateDocIds);
+            assertSectionListsEmpty();
+            assertThat(attachedDocumentIds).isEmpty();
+        }
     }
 
     // --- helpers ---------------------------------------------------------
 
     private void merge(EDoc doc) {
-        DocumentPreview2Action.mergeSingleAttachedDoc(
-                doc, CURRENT_PROVIDER, allDocuments, providerPrivateDocs, providerPublicDocs, foreignPrivateDocIds);
+        manager.mergeAttachedIntoSections(loggedInInfo, Collections.singletonList(doc), allDocuments, providerPrivateDocs, providerPublicDocs, attachedDocumentIds, foreignPrivateDocIds);
     }
 
-    private void assertAllEmpty() {
+    private void assertSectionListsEmpty() {
         assertThat(allDocuments).isEmpty();
         assertThat(providerPrivateDocs).isEmpty();
         assertThat(providerPublicDocs).isEmpty();

--- a/src/test-modern/java/ca/openosp/openo/documentManager/DocumentAttachmentManagerValidateDocumentsUnitTest.java
+++ b/src/test-modern/java/ca/openosp/openo/documentManager/DocumentAttachmentManagerValidateDocumentsUnitTest.java
@@ -1,0 +1,190 @@
+package ca.openosp.openo.documentManager;
+
+import ca.openosp.openo.commn.dao.DocumentDao;
+import ca.openosp.openo.commn.dao.EFormDataDao;
+import ca.openosp.openo.commn.dao.PatientLabRoutingDao;
+import ca.openosp.openo.test.unit.OpenOUnitTestBase;
+import ca.openosp.openo.utility.LoggedInInfo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test matrix for {@link DocumentAttachmentManagerImpl#validateDocumentsBelongToPatient}.
+ *
+ * <p>Policy exercised here: a "D" (document) attachment is valid when it has
+ * an active {@code ctl_document} row that is either (a) demographic-scoped to
+ * this patient, or (b) provider-library scoped
+ * ({@code module IN ('provider','providers')}) — i.e. the doc lives in some
+ * provider's library (public or private eDoc). Provider-library docs are
+ * attachable by reference to any chart per PR #2295's model, so demographic-only
+ * validation (PR #2405's original shape) rejected them incorrectly on Ocean
+ * submission. This matrix pins down the fix. Both branches share the
+ * {@code c.status != 'D'} filter, enforced at the DAO level.
+ */
+@DisplayName("DocumentAttachmentManagerImpl.validateDocumentsBelongToPatient")
+@Tag("unit")
+@Tag("fast")
+@Tag("document")
+@Tag("manager")
+class DocumentAttachmentManagerValidateDocumentsUnitTest extends OpenOUnitTestBase {
+
+    private static final Integer PATIENT_DEMO_NO = 42;
+
+    // IDs are spread across distinct ranges so a single scenario's stubbing
+    // never accidentally satisfies another scenario's expectation.
+    private static final Integer PATIENT_DOC_ID = 100;
+    private static final Integer PUBLIC_EDOC_ID = 200;
+    private static final Integer OWN_PRIVATE_EDOC_ID = 300;
+    private static final Integer FOREIGN_PRIVATE_EDOC_ID = 400;
+    private static final Integer CROSS_PATIENT_DOC_ID = 500;
+
+    private DocumentDao documentDao;
+    private PatientLabRoutingDao patientLabRoutingDao;
+    private EFormDataDao eFormDataDao;
+    private LoggedInInfo loggedInInfo;
+    private DocumentAttachmentManagerImpl manager;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        documentDao = mock(DocumentDao.class);
+        patientLabRoutingDao = mock(PatientLabRoutingDao.class);
+        eFormDataDao = mock(EFormDataDao.class);
+        loggedInInfo = mock(LoggedInInfo.class);
+
+        manager = new DocumentAttachmentManagerImpl();
+        inject("documentDao", documentDao);
+        inject("patientLabRoutingDao", patientLabRoutingDao);
+        inject("eFormDataDao", eFormDataDao);
+    }
+
+    private void inject(String field, Object value) throws Exception {
+        Field f = DocumentAttachmentManagerImpl.class.getDeclaredField(field);
+        f.setAccessible(true);
+        f.set(manager, value);
+    }
+
+    private boolean validate(String... docs) {
+        return manager.validateDocumentsBelongToPatient(loggedInInfo, PATIENT_DEMO_NO, docs);
+    }
+
+    // Stubs documentDao to recognize `recognized` as attachable to PATIENT_DEMO_NO
+    // — either demographic-scoped for this patient or provider-library scoped.
+    // Any doc id outside `recognized` is treated as not found.
+    private void attachableDocs(Integer... recognized) {
+        when(documentDao.findValidAttachmentDocNos(eq(PATIENT_DEMO_NO), any()))
+                .thenAnswer(inv -> filter(inv.getArgument(1), recognized));
+    }
+
+    private static List<Integer> filter(List<Integer> requested, Integer[] allowed) {
+        List<Integer> allowedList = java.util.Arrays.asList(allowed);
+        return requested.stream().filter(allowedList::contains).collect(java.util.stream.Collectors.toList());
+    }
+
+    @Nested
+    @DisplayName("patient-scoped documents (module = 'demographic')")
+    class PatientDocs {
+
+        @Test
+        @DisplayName("returns true for a doc whose ctl row is demographic-scoped to this patient")
+        void shouldReturnTrue_whenDocBelongsToDemographic() {
+            attachableDocs(PATIENT_DOC_ID);
+            assertThat(validate("D" + PATIENT_DOC_ID)).isTrue();
+        }
+
+        @Test
+        @DisplayName("returns false for a doc whose ctl row belongs to a different demographic")
+        void shouldReturnFalse_whenDocBelongsToDifferentDemographic() {
+            // No recognized rows — doc exists in DB but isn't linked to this demographic
+            // and isn't in any provider library either.
+            attachableDocs();
+            assertThat(validate("D" + CROSS_PATIENT_DOC_ID)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("provider-library documents (module in 'provider','providers')")
+    class ProviderDocs {
+
+        @Test
+        @DisplayName("returns true for a public provider eDoc attached to the consult")
+        void shouldReturnTrue_whenDocIsPublicProviderEDoc() {
+            attachableDocs(PUBLIC_EDOC_ID);
+            assertThat(validate("D" + PUBLIC_EDOC_ID)).isTrue();
+        }
+
+        @Test
+        @DisplayName("returns true for a private eDoc from the current provider's library")
+        void shouldReturnTrue_whenDocIsOwnPrivateProviderEDoc() {
+            attachableDocs(OWN_PRIVATE_EDOC_ID);
+            assertThat(validate("D" + OWN_PRIVATE_EDOC_ID)).isTrue();
+        }
+
+        @Test
+        @DisplayName("returns true for a foreign private eDoc (another provider's library)")
+        void shouldReturnTrue_whenDocIsForeignPrivateProviderEDoc() {
+            // Policy: provider-library membership is sufficient regardless of which provider owns
+            // the doc. Matches PR #2295's reference model — shared private eDocs (clinic-wide forms,
+            // etc.) are a supported workflow, and the doc is already viewable on the consult once
+            // attached, so downstream Ocean submission doesn't add new exposure. Tighten at this
+            // boundary if that policy changes.
+            attachableDocs(FOREIGN_PRIVATE_EDOC_ID);
+            assertThat(validate("D" + FOREIGN_PRIVATE_EDOC_ID)).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("mixed attachment sets")
+    class Mixed {
+
+        @Test
+        @DisplayName("returns true when a legitimate mix of patient doc + public eDoc is submitted")
+        void shouldReturnTrue_whenMixOfPatientAndProviderDocs() {
+            attachableDocs(PATIENT_DOC_ID, PUBLIC_EDOC_ID);
+            assertThat(validate("D" + PATIENT_DOC_ID, "D" + PUBLIC_EDOC_ID)).isTrue();
+        }
+
+        @Test
+        @DisplayName("returns false when any doc is genuinely cross-patient")
+        void shouldReturnFalse_whenAnyDocIsCrossPatient() {
+            attachableDocs(PATIENT_DOC_ID);
+            assertThat(validate("D" + PATIENT_DOC_ID, "D" + CROSS_PATIENT_DOC_ID)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("malformed and empty input")
+    class EdgeCases {
+
+        @Test
+        @DisplayName("returns false when a typed id has a non-numeric suffix")
+        void shouldReturnFalse_whenTypedIdHasNonNumericSuffix() {
+            assertThat(validate("DXYZ")).isFalse();
+        }
+
+        @Test
+        @DisplayName("returns true when the document list is empty (nothing to validate)")
+        void shouldReturnTrue_whenNoDocumentsProvided() {
+            assertThat(validate()).isTrue();
+        }
+
+        @Test
+        @DisplayName("skips entries shorter than two characters without failing the whole submission")
+        void shouldReturnTrue_whenEntryIsShorterThanTwoCharacters() {
+            // A stray "D" with no id should be skipped (length < 2), not treated as malformed.
+            assertThat(validate("D")).isTrue();
+        }
+    }
+}

--- a/src/test-modern/java/ca/openosp/openo/documentManager/actions/DocumentPreview2ActionMergeUnitTest.java
+++ b/src/test-modern/java/ca/openosp/openo/documentManager/actions/DocumentPreview2ActionMergeUnitTest.java
@@ -1,0 +1,205 @@
+package ca.openosp.openo.documentManager.actions;
+
+import ca.openosp.openo.documentManager.EDoc;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link DocumentPreview2Action#mergeSingleAttachedDoc} — the
+ * classification function that decides which section (patient / provider public /
+ * provider private) an attached EDoc lands in when the attachment manager reopens
+ * a saved consult or eForm. No Spring context; the method is a pure classifier.
+ *
+ * Covers the full matrix of (module type, public flag, ownership, deleted state)
+ * combinations that drive the UI's section placement and "(other provider)" label.
+ */
+@DisplayName("DocumentPreview2Action.mergeSingleAttachedDoc")
+@Tag("unit")
+@Tag("document")
+class DocumentPreview2ActionMergeUnitTest {
+
+    private static final String CURRENT_PROVIDER = "42";
+    private static final String OTHER_PROVIDER = "99";
+
+    private List<EDoc> allDocuments;
+    private List<EDoc> providerPrivateDocs;
+    private List<EDoc> providerPublicDocs;
+    private Set<String> foreignPrivateDocIds;
+
+    @BeforeEach
+    void resetSinks() {
+        allDocuments = new ArrayList<>();
+        providerPrivateDocs = new ArrayList<>();
+        providerPublicDocs = new ArrayList<>();
+        foreignPrivateDocIds = new HashSet<>();
+    }
+
+    @Nested
+    @DisplayName("patient docs (module = demographic)")
+    class PatientDocs {
+
+        @Test
+        @DisplayName("active patient doc is a no-op — already listed in allDocuments")
+        void shouldBeNoOp_whenActivePatientDoc() {
+            merge(patientDoc("1", 'A'));
+            assertAllEmpty();
+        }
+
+        @Test
+        @DisplayName("deleted patient doc is re-injected into allDocuments so the section still renders it")
+        void shouldReInject_whenDeletedPatientDoc() {
+            EDoc doc = patientDoc("2", 'D');
+            merge(doc);
+            assertThat(allDocuments).containsExactly(doc);
+            assertThat(providerPrivateDocs).isEmpty();
+            assertThat(providerPublicDocs).isEmpty();
+            assertThat(foreignPrivateDocIds).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("public provider docs (module = providers, docPublic = 1)")
+    class PublicProviderDocs {
+
+        @Test
+        @DisplayName("active public provider doc is a no-op — already listed in providerPublicDocs")
+        void shouldBeNoOp_whenActivePublicProviderDoc() {
+            merge(providerDoc("3", 'A', true, OTHER_PROVIDER));
+            assertAllEmpty();
+        }
+
+        @Test
+        @DisplayName("deleted public provider doc is re-injected into providerPublicDocs")
+        void shouldReInject_whenDeletedPublicProviderDoc() {
+            EDoc doc = providerDoc("4", 'D', true, OTHER_PROVIDER);
+            merge(doc);
+            assertThat(providerPublicDocs).containsExactly(doc);
+            assertThat(allDocuments).isEmpty();
+            assertThat(providerPrivateDocs).isEmpty();
+            assertThat(foreignPrivateDocIds).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("private provider docs owned by the current provider")
+    class OwnPrivateProviderDocs {
+
+        @Test
+        @DisplayName("active own private doc is a no-op — already listed in providerPrivateDocs")
+        void shouldBeNoOp_whenActiveOwnPrivateDoc() {
+            merge(providerDoc("5", 'A', false, CURRENT_PROVIDER));
+            assertAllEmpty();
+        }
+
+        @Test
+        @DisplayName("deleted own private doc is re-injected into providerPrivateDocs (not marked foreign)")
+        void shouldReInject_whenDeletedOwnPrivateDoc() {
+            EDoc doc = providerDoc("6", 'D', false, CURRENT_PROVIDER);
+            merge(doc);
+            assertThat(providerPrivateDocs).containsExactly(doc);
+            assertThat(foreignPrivateDocIds)
+                    .as("doc belongs to current provider, should not be flagged foreign")
+                    .isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("private provider docs owned by a different provider (cross-provider)")
+    class ForeignPrivateProviderDocs {
+
+        @Test
+        @DisplayName("active foreign private doc is merged into providerPrivateDocs AND flagged foreign")
+        void shouldMergeAndFlag_whenActiveForeignPrivateDoc() {
+            EDoc doc = providerDoc("7", 'A', false, OTHER_PROVIDER);
+            merge(doc);
+            assertThat(providerPrivateDocs).containsExactly(doc);
+            assertThat(foreignPrivateDocIds).containsExactly("7");
+            assertThat(allDocuments).isEmpty();
+            assertThat(providerPublicDocs).isEmpty();
+        }
+
+        @Test
+        @DisplayName("deleted foreign private doc is merged into providerPrivateDocs AND flagged foreign")
+        void shouldMergeAndFlag_whenDeletedForeignPrivateDoc() {
+            EDoc doc = providerDoc("8", 'D', false, OTHER_PROVIDER);
+            merge(doc);
+            assertThat(providerPrivateDocs).containsExactly(doc);
+            assertThat(foreignPrivateDocIds).containsExactly("8");
+        }
+    }
+
+    @Nested
+    @DisplayName("edge cases")
+    class EdgeCases {
+
+        @Test
+        @DisplayName("no current provider means foreign private docs aren't misclassified as owned")
+        void shouldFlagForeign_whenCurrentProviderIsNull() {
+            EDoc doc = providerDoc("9", 'A', false, OTHER_PROVIDER);
+            DocumentPreview2Action.mergeSingleAttachedDoc(
+                    doc, null, allDocuments, providerPrivateDocs, providerPublicDocs, foreignPrivateDocIds);
+            assertThat(providerPrivateDocs).containsExactly(doc);
+            assertThat(foreignPrivateDocIds).containsExactly("9");
+        }
+
+        @Test
+        @DisplayName("legacy 'provider' module spelling is treated the same as 'providers'")
+        void shouldTreatProviderAndProvidersIdentically() {
+            EDoc legacy = new EDoc();
+            legacy.setDocId("10");
+            legacy.setStatus('A');
+            legacy.setModule("provider");
+            legacy.setModuleId(OTHER_PROVIDER);
+            legacy.setDocPublic("0");
+
+            merge(legacy);
+
+            assertThat(providerPrivateDocs).containsExactly(legacy);
+            assertThat(foreignPrivateDocIds).containsExactly("10");
+        }
+    }
+
+    // --- helpers ---------------------------------------------------------
+
+    private void merge(EDoc doc) {
+        DocumentPreview2Action.mergeSingleAttachedDoc(
+                doc, CURRENT_PROVIDER, allDocuments, providerPrivateDocs, providerPublicDocs, foreignPrivateDocIds);
+    }
+
+    private void assertAllEmpty() {
+        assertThat(allDocuments).isEmpty();
+        assertThat(providerPrivateDocs).isEmpty();
+        assertThat(providerPublicDocs).isEmpty();
+        assertThat(foreignPrivateDocIds).isEmpty();
+    }
+
+    private static EDoc patientDoc(String docId, char status) {
+        EDoc d = new EDoc();
+        d.setDocId(docId);
+        d.setStatus(status);
+        d.setModule("demographic");
+        d.setModuleId("2001");
+        d.setDocPublic("0");
+        return d;
+    }
+
+    private static EDoc providerDoc(String docId, char status, boolean isPublic, String ownerProviderNo) {
+        EDoc d = new EDoc();
+        d.setDocId(docId);
+        d.setStatus(status);
+        d.setModule("providers");
+        d.setModuleId(ownerProviderNo);
+        d.setDocPublic(isPublic ? "1" : "0");
+        return d;
+    }
+}

--- a/src/test-modern/java/ca/openosp/openo/documentManager/dao/CtlDocumentDaoFindByDocumentNosIntegrationTest.java
+++ b/src/test-modern/java/ca/openosp/openo/documentManager/dao/CtlDocumentDaoFindByDocumentNosIntegrationTest.java
@@ -1,0 +1,107 @@
+package ca.openosp.openo.documentManager.dao;
+
+import ca.openosp.openo.commn.dao.CtlDocumentDao;
+import ca.openosp.openo.commn.model.CtlDocument;
+import ca.openosp.openo.commn.model.Document;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link CtlDocumentDao#findByDocumentNos(List)} — the batch
+ * lookup used by {@code EDocUtil.enrichAttachedWithCtl} to classify many attached
+ * docs in a single query.
+ */
+@DisplayName("CtlDocumentDao.findByDocumentNos")
+@Tag("integration")
+@Tag("dao")
+@Tag("document")
+@Tag("read")
+public class CtlDocumentDaoFindByDocumentNosIntegrationTest extends DocumentDaoBaseIntegrationTest {
+
+    @Autowired
+    private CtlDocumentDao ctlDocumentDao;
+
+    @Test
+    @DisplayName("returns an empty list when the input is null")
+    void shouldReturnEmpty_whenInputIsNull() {
+        assertThat(ctlDocumentDao.findByDocumentNos(null)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("returns an empty list when the input is empty")
+    void shouldReturnEmpty_whenInputIsEmpty() {
+        assertThat(ctlDocumentDao.findByDocumentNos(Collections.emptyList())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("returns the single ctl row for a single doc")
+    void shouldReturnOneCtl_whenOneDocHasOneCtl() {
+        Integer docNo = persistDocument("Single doc", 0, Document.STATUS_ACTIVE);
+        persistCtlDocument(docNo, "provider", 42);
+
+        List<CtlDocument> result = ctlDocumentDao.findByDocumentNos(Collections.singletonList(docNo));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId().getModule()).isEqualTo("provider");
+        assertThat(result.get(0).getId().getModuleId()).isEqualTo(42);
+    }
+
+    @Test
+    @DisplayName("returns one ctl row per doc when multiple docs are requested")
+    void shouldReturnOnePerDoc_whenMultipleDocs() {
+        Integer providerDocNo = persistDocument("Provider-owned doc", 0, Document.STATUS_ACTIVE);
+        Integer patientDocNo = persistDocument("Patient-owned doc", 0, Document.STATUS_ACTIVE);
+        persistCtlDocument(providerDocNo, "providers", 42);
+        persistCtlDocument(patientDocNo, "demographic", 2001);
+
+        List<CtlDocument> result = ctlDocumentDao.findByDocumentNos(Arrays.asList(providerDocNo, patientDocNo));
+
+        assertThat(result).hasSize(2);
+        Set<String> modules = result.stream()
+                .map(c -> c.getId().getModule())
+                .collect(Collectors.toSet());
+        assertThat(modules).containsExactlyInAnyOrder("providers", "demographic");
+    }
+
+    @Test
+    @DisplayName("returns every ctl row when one doc has multiple bindings")
+    void shouldReturnAllCtls_whenDocHasMultipleBindings() {
+        Integer docNo = persistDocument("Multi-ctl doc", 0, Document.STATUS_ACTIVE);
+        persistCtlDocument(docNo, "providers", 42);
+        persistCtlDocument(docNo, "demographic", 2001);
+
+        List<CtlDocument> result = ctlDocumentDao.findByDocumentNos(Collections.singletonList(docNo));
+
+        assertThat(result)
+                .as("All bindings for the doc should surface so the caller can apply provider-wins")
+                .hasSize(2);
+        Set<String> modules = result.stream()
+                .map(c -> c.getId().getModule())
+                .collect(Collectors.toSet());
+        assertThat(modules).containsExactlyInAnyOrder("providers", "demographic");
+    }
+
+    @Test
+    @DisplayName("does not return ctl rows for doc ids that are not in the input list")
+    void shouldScopeByDocumentNos() {
+        Integer includedDocNo = persistDocument("Included doc", 0, Document.STATUS_ACTIVE);
+        Integer excludedDocNo = persistDocument("Excluded doc", 0, Document.STATUS_ACTIVE);
+        persistCtlDocument(includedDocNo, "providers", 42);
+        persistCtlDocument(excludedDocNo, "providers", 42);
+
+        List<CtlDocument> result = ctlDocumentDao.findByDocumentNos(Collections.singletonList(includedDocNo));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId().getDocumentNo()).isEqualTo(includedDocNo);
+    }
+}

--- a/src/test-modern/java/ca/openosp/openo/documentManager/dao/DocumentDaoAttachedFindIntegrationTest.java
+++ b/src/test-modern/java/ca/openosp/openo/documentManager/dao/DocumentDaoAttachedFindIntegrationTest.java
@@ -1,28 +1,23 @@
 package ca.openosp.openo.documentManager.dao;
 
 import ca.openosp.openo.commn.model.ConsultDocs;
-import ca.openosp.openo.commn.model.CtlDocument;
+import ca.openosp.openo.commn.model.ConsultResponseDoc;
 import ca.openosp.openo.commn.model.Document;
+import ca.openosp.openo.commn.model.EFormDocs;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Integration tests for DocumentDao attached-document queries that rely on
- * the (Document, ConsultDocs|EFormDocs|ConsultResponseDoc, CtlDocument) join.
- *
- * The key scenario under test: a single document_no bound to multiple
- * ctl_document rows (e.g., provider-owned doc that has also been attached
- * to a patient document record). The join fans out per ctl row and the
- * caller has to reconcile which (module, moduleId) "wins" when building
- * the EDoc view model.
+ * Integration tests for DocumentDao attached-document queries. These return
+ * (Document, AttachmentRow) tuples scoped by consult/eForm/response id. Ctl
+ * classification is handled separately in {@code EDocUtil.enrichAttachedWithCtl}
+ * and is not part of these queries' contract.
  */
 @DisplayName("DocumentDao attached-document queries")
 @Tag("integration")
@@ -32,99 +27,39 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class DocumentDaoAttachedFindIntegrationTest extends DocumentDaoBaseIntegrationTest {
 
     private static final Integer CONSULT_ID = 90001;
+    private static final Integer EFORM_FDID = 80001;
+    private static final Integer RESPONSE_ID = 70001;
     private static final Integer OWNER_PROVIDER_ID = 42;
-    private static final Integer PATIENT_DEMO_ID = 2001;
 
     @Nested
     @DisplayName("findDocsAndConsultDocsByConsultId")
     class FindDocsAndConsultDocsByConsultId {
 
         @Test
-        @DisplayName("returns one tuple when a document has a single ctl_document row")
-        void shouldReturnSingleTuple_whenDocHasOneCtlRow() {
-            Integer docNo = persistDocument("Provider-only doc", 0, Document.STATUS_ACTIVE);
+        @DisplayName("returns the attached document")
+        void shouldReturnAttachedDoc() {
+            Integer docNo = persistDocument("Attached doc", 0, Document.STATUS_ACTIVE);
             persistCtlDocument(docNo, "provider", OWNER_PROVIDER_ID);
             persistConsultDocAttachment(CONSULT_ID, docNo);
 
             List<Object[]> result = documentDao.findDocsAndConsultDocsByConsultId(CONSULT_ID);
 
             assertThat(result).hasSize(1);
-            CtlDocument ctl = (CtlDocument) result.get(0)[2];
-            assertThat(ctl.getId().getModule()).isEqualTo("provider");
-            assertThat(ctl.getId().getModuleId()).isEqualTo(OWNER_PROVIDER_ID);
+            assertThat(((Document) result.get(0)[0]).getDocumentNo()).isEqualTo(docNo);
         }
 
         @Test
-        @DisplayName("returns one tuple per attached document when multiple docs share the same consult")
-        void shouldReturnOneTuplePerDoc_whenMultipleDocsAttachedToSameConsult() {
-            Integer providerDocNo = persistDocument("Provider doc", 0, Document.STATUS_ACTIVE);
-            Integer demoDocNo = persistDocument("Demographic doc", 0, Document.STATUS_ACTIVE);
-            persistCtlDocument(providerDocNo, "provider", OWNER_PROVIDER_ID);
-            persistCtlDocument(demoDocNo, "demographic", PATIENT_DEMO_ID);
-            persistConsultDocAttachment(CONSULT_ID, providerDocNo);
-            persistConsultDocAttachment(CONSULT_ID, demoDocNo);
-
-            List<Object[]> result = documentDao.findDocsAndConsultDocsByConsultId(CONSULT_ID);
-
-            assertThat(result).hasSize(2);
-
-            Set<Integer> docNos = result.stream()
-                    .map(row -> ((Document) row[0]).getDocumentNo())
-                    .collect(Collectors.toSet());
-            assertThat(docNos).containsExactlyInAnyOrder(providerDocNo, demoDocNo);
-
-            Set<String> modules = result.stream()
-                    .map(row -> ((CtlDocument) row[2]).getId().getModule())
-                    .collect(Collectors.toSet());
-            assertThat(modules).containsExactlyInAnyOrder("provider", "demographic");
-        }
-
-        @Test
-        @DisplayName("fans out into multiple tuples when a document has multiple ctl_document rows")
-        void shouldReturnMultipleTuples_whenDocHasMultipleCtlRows() {
-            Integer docNo = persistDocument("Shared provider doc", 0, Document.STATUS_ACTIVE);
-            persistCtlDocument(docNo, "provider", OWNER_PROVIDER_ID);
-            persistCtlDocument(docNo, "demographic", PATIENT_DEMO_ID);
+        @DisplayName("returns attachments even when the doc has no ctl_document row")
+        void shouldReturnOrphan_whenDocHasNoCtlRow() {
+            Integer docNo = persistDocument("Orphan doc with no ctl row", 0, Document.STATUS_ACTIVE);
             persistConsultDocAttachment(CONSULT_ID, docNo);
 
             List<Object[]> result = documentDao.findDocsAndConsultDocsByConsultId(CONSULT_ID);
 
             assertThat(result)
-                    .as("Expected one tuple per ctl_document row for the same documentNo")
-                    .hasSize(2);
-
-            Set<String> modules = result.stream()
-                    .map(row -> ((CtlDocument) row[2]).getId().getModule())
-                    .collect(Collectors.toSet());
-            assertThat(modules).containsExactlyInAnyOrder("provider", "demographic");
-        }
-
-        @Test
-        @DisplayName("returns both module bindings regardless of insertion order when doc has multiple ctl rows")
-        void shouldReturnBothModules_whenDocHasProviderAndDemographicCtlRows() {
-            Integer docA = persistDocument("Provider-inserted-first doc", 0, Document.STATUS_ACTIVE);
-            persistCtlDocument(docA, "provider", OWNER_PROVIDER_ID);
-            persistCtlDocument(docA, "demographic", PATIENT_DEMO_ID);
-            persistConsultDocAttachment(CONSULT_ID, docA);
-
-            Integer otherConsult = CONSULT_ID + 1000;
-            Integer docB = persistDocument("Demographic-inserted-first doc", 0, Document.STATUS_ACTIVE);
-            persistCtlDocument(docB, "demographic", PATIENT_DEMO_ID + 1);
-            persistCtlDocument(docB, "provider", OWNER_PROVIDER_ID + 1);
-            persistConsultDocAttachment(otherConsult, docB);
-
-            Set<String> modulesA = documentDao.findDocsAndConsultDocsByConsultId(CONSULT_ID).stream()
-                    .map(row -> ((CtlDocument) row[2]).getId().getModule())
-                    .collect(Collectors.toSet());
-            Set<String> modulesB = documentDao.findDocsAndConsultDocsByConsultId(otherConsult).stream()
-                    .map(row -> ((CtlDocument) row[2]).getId().getModule())
-                    .collect(Collectors.toSet());
-
-            // The query has no ORDER BY, so the tuple order is DB-dependent. Assert set
-            // membership rather than a specific winner: both bindings must be present,
-            // which is what downstream callers need to classify correctly.
-            assertThat(modulesA).containsExactlyInAnyOrder("provider", "demographic");
-            assertThat(modulesB).containsExactlyInAnyOrder("provider", "demographic");
+                    .as("2-table query does not depend on CtlDocument, so orphan docs still surface")
+                    .hasSize(1);
+            assertThat(((Document) result.get(0)[0]).getDocumentNo()).isEqualTo(docNo);
         }
 
         @Test
@@ -151,6 +86,110 @@ public class DocumentDaoAttachedFindIntegrationTest extends DocumentDaoBaseInteg
             persistConsultDocAttachment(CONSULT_ID, docNo);
 
             List<Object[]> result = documentDao.findDocsAndConsultDocsByConsultId(CONSULT_ID + 1);
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("findDocsAndEFormDocsByFdid")
+    class FindDocsAndEFormDocsByFdid {
+
+        @Test
+        @DisplayName("returns the attached document")
+        void shouldReturnAttachedDoc() {
+            Integer docNo = persistDocument("Attached eform doc", 0, Document.STATUS_ACTIVE);
+            persistCtlDocument(docNo, "provider", OWNER_PROVIDER_ID);
+            persistEFormDocAttachment(EFORM_FDID, docNo);
+
+            List<Object[]> result = documentDao.findDocsAndEFormDocsByFdid(EFORM_FDID);
+
+            assertThat(result).hasSize(1);
+            assertThat(((Document) result.get(0)[0]).getDocumentNo()).isEqualTo(docNo);
+        }
+
+        @Test
+        @DisplayName("returns attachments even when the doc has no ctl_document row")
+        void shouldReturnOrphan_whenDocHasNoCtlRow() {
+            Integer docNo = persistDocument("Orphan eform doc", 0, Document.STATUS_ACTIVE);
+            persistEFormDocAttachment(EFORM_FDID, docNo);
+
+            List<Object[]> result = documentDao.findDocsAndEFormDocsByFdid(EFORM_FDID);
+
+            assertThat(result).hasSize(1);
+            assertThat(((Document) result.get(0)[0]).getDocumentNo()).isEqualTo(docNo);
+        }
+
+        @Test
+        @DisplayName("skips docs marked deleted on the eform_docs row")
+        void shouldSkipSoftDeletedAttachments() {
+            Integer docNo = persistDocument("Soft-deleted eform attachment", 0, Document.STATUS_ACTIVE);
+            persistCtlDocument(docNo, "provider", OWNER_PROVIDER_ID);
+
+            EFormDocs ed = new EFormDocs(EFORM_FDID, docNo, EFormDocs.DOCTYPE_DOC, "999998");
+            ed.setDeleted(EFormDocs.DELETED);
+            entityManager.persist(ed);
+            entityManager.flush();
+
+            List<Object[]> result = documentDao.findDocsAndEFormDocsByFdid(EFORM_FDID);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("does not return attachments for a different fdid")
+        void shouldScopeByFdid() {
+            Integer docNo = persistDocument("Other eform doc", 0, Document.STATUS_ACTIVE);
+            persistCtlDocument(docNo, "provider", OWNER_PROVIDER_ID);
+            persistEFormDocAttachment(EFORM_FDID, docNo);
+
+            List<Object[]> result = documentDao.findDocsAndEFormDocsByFdid(EFORM_FDID + 1);
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("findDocsAndConsultResponseDocsByConsultId")
+    class FindDocsAndConsultResponseDocsByConsultId {
+
+        @Test
+        @DisplayName("returns the attached document")
+        void shouldReturnAttachedDoc() {
+            Integer docNo = persistDocument("Attached response doc", 0, Document.STATUS_ACTIVE);
+            persistCtlDocument(docNo, "provider", OWNER_PROVIDER_ID);
+            persistConsultResponseDocAttachment(RESPONSE_ID, docNo);
+
+            List<Object[]> result = documentDao.findDocsAndConsultResponseDocsByConsultId(RESPONSE_ID);
+
+            assertThat(result).hasSize(1);
+            assertThat(((Document) result.get(0)[0]).getDocumentNo()).isEqualTo(docNo);
+        }
+
+        @Test
+        @DisplayName("skips docs marked deleted on the consult_response_doc row")
+        void shouldSkipSoftDeletedAttachments() {
+            Integer docNo = persistDocument("Soft-deleted response attachment", 0, Document.STATUS_ACTIVE);
+            persistCtlDocument(docNo, "provider", OWNER_PROVIDER_ID);
+
+            ConsultResponseDoc crd = new ConsultResponseDoc(RESPONSE_ID, docNo, ConsultResponseDoc.DOCTYPE_DOC, "999998");
+            crd.setDeleted(ConsultResponseDoc.DELETED);
+            entityManager.persist(crd);
+            entityManager.flush();
+
+            List<Object[]> result = documentDao.findDocsAndConsultResponseDocsByConsultId(RESPONSE_ID);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("does not return attachments for a different response id")
+        void shouldScopeByResponseId() {
+            Integer docNo = persistDocument("Other response doc", 0, Document.STATUS_ACTIVE);
+            persistCtlDocument(docNo, "provider", OWNER_PROVIDER_ID);
+            persistConsultResponseDocAttachment(RESPONSE_ID, docNo);
+
+            List<Object[]> result = documentDao.findDocsAndConsultResponseDocsByConsultId(RESPONSE_ID + 1);
 
             assertThat(result).isEmpty();
         }

--- a/src/test-modern/java/ca/openosp/openo/documentManager/dao/DocumentDaoAttachedFindIntegrationTest.java
+++ b/src/test-modern/java/ca/openosp/openo/documentManager/dao/DocumentDaoAttachedFindIntegrationTest.java
@@ -55,6 +55,31 @@ public class DocumentDaoAttachedFindIntegrationTest extends DocumentDaoBaseInteg
         }
 
         @Test
+        @DisplayName("returns one tuple per attached document when multiple docs share the same consult")
+        void shouldReturnOneTuplePerDoc_whenMultipleDocsAttachedToSameConsult() {
+            Integer providerDocNo = persistDocument("Provider doc", 0, Document.STATUS_ACTIVE);
+            Integer demoDocNo = persistDocument("Demographic doc", 0, Document.STATUS_ACTIVE);
+            persistCtlDocument(providerDocNo, "provider", OWNER_PROVIDER_ID);
+            persistCtlDocument(demoDocNo, "demographic", PATIENT_DEMO_ID);
+            persistConsultDocAttachment(CONSULT_ID, providerDocNo);
+            persistConsultDocAttachment(CONSULT_ID, demoDocNo);
+
+            List<Object[]> result = documentDao.findDocsAndConsultDocsByConsultId(CONSULT_ID);
+
+            assertThat(result).hasSize(2);
+
+            Set<Integer> docNos = result.stream()
+                    .map(row -> ((Document) row[0]).getDocumentNo())
+                    .collect(Collectors.toSet());
+            assertThat(docNos).containsExactlyInAnyOrder(providerDocNo, demoDocNo);
+
+            Set<String> modules = result.stream()
+                    .map(row -> ((CtlDocument) row[2]).getId().getModule())
+                    .collect(Collectors.toSet());
+            assertThat(modules).containsExactlyInAnyOrder("provider", "demographic");
+        }
+
+        @Test
         @DisplayName("fans out into multiple tuples when a document has multiple ctl_document rows")
         void shouldReturnMultipleTuples_whenDocHasMultipleCtlRows() {
             Integer docNo = persistDocument("Shared provider doc", 0, Document.STATUS_ACTIVE);
@@ -75,8 +100,8 @@ public class DocumentDaoAttachedFindIntegrationTest extends DocumentDaoBaseInteg
         }
 
         @Test
-        @DisplayName("first-tuple is always the 'demographic' ctl row when both demographic and provider bindings exist")
-        void shouldAlwaysReturnDemographicFirst_whenDocHasProviderAndDemographicCtlRows() {
+        @DisplayName("returns both module bindings regardless of insertion order when doc has multiple ctl rows")
+        void shouldReturnBothModules_whenDocHasProviderAndDemographicCtlRows() {
             Integer docA = persistDocument("Provider-inserted-first doc", 0, Document.STATUS_ACTIVE);
             persistCtlDocument(docA, "provider", OWNER_PROVIDER_ID);
             persistCtlDocument(docA, "demographic", PATIENT_DEMO_ID);
@@ -88,18 +113,18 @@ public class DocumentDaoAttachedFindIntegrationTest extends DocumentDaoBaseInteg
             persistCtlDocument(docB, "provider", OWNER_PROVIDER_ID + 1);
             persistConsultDocAttachment(otherConsult, docB);
 
-            String firstModuleA = ((CtlDocument) documentDao.findDocsAndConsultDocsByConsultId(CONSULT_ID).get(0)[2])
-                    .getId().getModule();
-            String firstModuleB = ((CtlDocument) documentDao.findDocsAndConsultDocsByConsultId(otherConsult).get(0)[2])
-                    .getId().getModule();
+            Set<String> modulesA = documentDao.findDocsAndConsultDocsByConsultId(CONSULT_ID).stream()
+                    .map(row -> ((CtlDocument) row[2]).getId().getModule())
+                    .collect(Collectors.toSet());
+            Set<String> modulesB = documentDao.findDocsAndConsultDocsByConsultId(otherConsult).stream()
+                    .map(row -> ((CtlDocument) row[2]).getId().getModule())
+                    .collect(Collectors.toSet());
 
-            // H2 orders by composite PK (module, module_id, document_no), so 'demographic'
-            // always precedes 'provider' alphabetically. A "first-wins" dedup in the caller
-            // therefore classifies provider-owned docs as patient docs whenever the doc
-            // also has a demographic ctl_document binding. This is the misclassification
-            // bug the EDocUtil.listDocs dedup needs to solve.
-            assertThat(firstModuleA).isEqualTo("demographic");
-            assertThat(firstModuleB).isEqualTo("demographic");
+            // The query has no ORDER BY, so the tuple order is DB-dependent. Assert set
+            // membership rather than a specific winner: both bindings must be present,
+            // which is what downstream callers need to classify correctly.
+            assertThat(modulesA).containsExactlyInAnyOrder("provider", "demographic");
+            assertThat(modulesB).containsExactlyInAnyOrder("provider", "demographic");
         }
 
         @Test

--- a/src/test-modern/java/ca/openosp/openo/documentManager/dao/DocumentDaoAttachedFindIntegrationTest.java
+++ b/src/test-modern/java/ca/openosp/openo/documentManager/dao/DocumentDaoAttachedFindIntegrationTest.java
@@ -1,0 +1,133 @@
+package ca.openosp.openo.documentManager.dao;
+
+import ca.openosp.openo.commn.model.ConsultDocs;
+import ca.openosp.openo.commn.model.CtlDocument;
+import ca.openosp.openo.commn.model.Document;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for DocumentDao attached-document queries that rely on
+ * the (Document, ConsultDocs|EFormDocs|ConsultResponseDoc, CtlDocument) join.
+ *
+ * The key scenario under test: a single document_no bound to multiple
+ * ctl_document rows (e.g., provider-owned doc that has also been attached
+ * to a patient document record). The join fans out per ctl row and the
+ * caller has to reconcile which (module, moduleId) "wins" when building
+ * the EDoc view model.
+ */
+@DisplayName("DocumentDao attached-document queries")
+@Tag("integration")
+@Tag("document")
+@Tag("attached")
+@Tag("read")
+public class DocumentDaoAttachedFindIntegrationTest extends DocumentDaoBaseIntegrationTest {
+
+    private static final Integer CONSULT_ID = 90001;
+    private static final Integer OWNER_PROVIDER_ID = 42;
+    private static final Integer PATIENT_DEMO_ID = 2001;
+
+    @Nested
+    @DisplayName("findDocsAndConsultDocsByConsultId")
+    class FindDocsAndConsultDocsByConsultId {
+
+        @Test
+        @DisplayName("returns one tuple when a document has a single ctl_document row")
+        void shouldReturnSingleTuple_whenDocHasOneCtlRow() {
+            Integer docNo = persistDocument("Provider-only doc", 0, Document.STATUS_ACTIVE);
+            persistCtlDocument(docNo, "provider", OWNER_PROVIDER_ID);
+            persistConsultDocAttachment(CONSULT_ID, docNo);
+
+            List<Object[]> result = documentDao.findDocsAndConsultDocsByConsultId(CONSULT_ID);
+
+            assertThat(result).hasSize(1);
+            CtlDocument ctl = (CtlDocument) result.get(0)[2];
+            assertThat(ctl.getId().getModule()).isEqualTo("provider");
+            assertThat(ctl.getId().getModuleId()).isEqualTo(OWNER_PROVIDER_ID);
+        }
+
+        @Test
+        @DisplayName("fans out into multiple tuples when a document has multiple ctl_document rows")
+        void shouldReturnMultipleTuples_whenDocHasMultipleCtlRows() {
+            Integer docNo = persistDocument("Shared provider doc", 0, Document.STATUS_ACTIVE);
+            persistCtlDocument(docNo, "provider", OWNER_PROVIDER_ID);
+            persistCtlDocument(docNo, "demographic", PATIENT_DEMO_ID);
+            persistConsultDocAttachment(CONSULT_ID, docNo);
+
+            List<Object[]> result = documentDao.findDocsAndConsultDocsByConsultId(CONSULT_ID);
+
+            assertThat(result)
+                    .as("Expected one tuple per ctl_document row for the same documentNo")
+                    .hasSize(2);
+
+            Set<String> modules = result.stream()
+                    .map(row -> ((CtlDocument) row[2]).getId().getModule())
+                    .collect(Collectors.toSet());
+            assertThat(modules).containsExactlyInAnyOrder("provider", "demographic");
+        }
+
+        @Test
+        @DisplayName("first-tuple is always the 'demographic' ctl row when both demographic and provider bindings exist")
+        void shouldAlwaysReturnDemographicFirst_whenDocHasProviderAndDemographicCtlRows() {
+            Integer docA = persistDocument("Provider-inserted-first doc", 0, Document.STATUS_ACTIVE);
+            persistCtlDocument(docA, "provider", OWNER_PROVIDER_ID);
+            persistCtlDocument(docA, "demographic", PATIENT_DEMO_ID);
+            persistConsultDocAttachment(CONSULT_ID, docA);
+
+            Integer otherConsult = CONSULT_ID + 1000;
+            Integer docB = persistDocument("Demographic-inserted-first doc", 0, Document.STATUS_ACTIVE);
+            persistCtlDocument(docB, "demographic", PATIENT_DEMO_ID + 1);
+            persistCtlDocument(docB, "provider", OWNER_PROVIDER_ID + 1);
+            persistConsultDocAttachment(otherConsult, docB);
+
+            String firstModuleA = ((CtlDocument) documentDao.findDocsAndConsultDocsByConsultId(CONSULT_ID).get(0)[2])
+                    .getId().getModule();
+            String firstModuleB = ((CtlDocument) documentDao.findDocsAndConsultDocsByConsultId(otherConsult).get(0)[2])
+                    .getId().getModule();
+
+            // H2 orders by composite PK (module, module_id, document_no), so 'demographic'
+            // always precedes 'provider' alphabetically. A "first-wins" dedup in the caller
+            // therefore classifies provider-owned docs as patient docs whenever the doc
+            // also has a demographic ctl_document binding. This is the misclassification
+            // bug the EDocUtil.listDocs dedup needs to solve.
+            assertThat(firstModuleA).isEqualTo("demographic");
+            assertThat(firstModuleB).isEqualTo("demographic");
+        }
+
+        @Test
+        @DisplayName("skips docs marked deleted on the consultdocs row")
+        void shouldSkipSoftDeletedAttachments() {
+            Integer docNo = persistDocument("Soft-deleted attachment", 0, Document.STATUS_ACTIVE);
+            persistCtlDocument(docNo, "provider", OWNER_PROVIDER_ID);
+
+            ConsultDocs cd = new ConsultDocs(CONSULT_ID, docNo, ConsultDocs.DOCTYPE_DOC, "999998");
+            cd.setDeleted(ConsultDocs.DELETED);
+            entityManager.persist(cd);
+            entityManager.flush();
+
+            List<Object[]> result = documentDao.findDocsAndConsultDocsByConsultId(CONSULT_ID);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("does not return attachments for a different consult id")
+        void shouldScopeByRequestId() {
+            Integer docNo = persistDocument("Other consult doc", 0, Document.STATUS_ACTIVE);
+            persistCtlDocument(docNo, "provider", OWNER_PROVIDER_ID);
+            persistConsultDocAttachment(CONSULT_ID, docNo);
+
+            List<Object[]> result = documentDao.findDocsAndConsultDocsByConsultId(CONSULT_ID + 1);
+
+            assertThat(result).isEmpty();
+        }
+    }
+}

--- a/src/test-modern/java/ca/openosp/openo/documentManager/dao/DocumentDaoAttachedFindIntegrationTest.java
+++ b/src/test-modern/java/ca/openosp/openo/documentManager/dao/DocumentDaoAttachedFindIntegrationTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.util.Date;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -89,6 +90,21 @@ public class DocumentDaoAttachedFindIntegrationTest extends DocumentDaoBaseInteg
 
             assertThat(result).isEmpty();
         }
+
+        @Test
+        @DisplayName("does not return attachments with a non-DOC docType")
+        void shouldScopeByDocType() {
+            Integer docNo = persistDocument("Lab-typed attachment", 0, Document.STATUS_ACTIVE);
+            persistCtlDocument(docNo, "provider", OWNER_PROVIDER_ID);
+            ConsultDocs cd = new ConsultDocs(CONSULT_ID, docNo, ConsultDocs.DOCTYPE_LAB, "999998");
+            cd.setAttachDate(new Date());
+            entityManager.persist(cd);
+            entityManager.flush();
+
+            List<Object[]> result = documentDao.findDocsAndConsultDocsByConsultId(CONSULT_ID);
+
+            assertThat(result).isEmpty();
+        }
     }
 
     @Nested
@@ -147,6 +163,21 @@ public class DocumentDaoAttachedFindIntegrationTest extends DocumentDaoBaseInteg
 
             assertThat(result).isEmpty();
         }
+
+        @Test
+        @DisplayName("does not return attachments with a non-DOC docType")
+        void shouldScopeByDocType() {
+            Integer docNo = persistDocument("Lab-typed eform attachment", 0, Document.STATUS_ACTIVE);
+            persistCtlDocument(docNo, "provider", OWNER_PROVIDER_ID);
+            EFormDocs ed = new EFormDocs(EFORM_FDID, docNo, EFormDocs.DOCTYPE_LAB, "999998");
+            ed.setAttachDate(new Date());
+            entityManager.persist(ed);
+            entityManager.flush();
+
+            List<Object[]> result = documentDao.findDocsAndEFormDocsByFdid(EFORM_FDID);
+
+            assertThat(result).isEmpty();
+        }
     }
 
     @Nested
@@ -190,6 +221,21 @@ public class DocumentDaoAttachedFindIntegrationTest extends DocumentDaoBaseInteg
             persistConsultResponseDocAttachment(RESPONSE_ID, docNo);
 
             List<Object[]> result = documentDao.findDocsAndConsultResponseDocsByConsultId(RESPONSE_ID + 1);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("does not return attachments with a non-DOC docType")
+        void shouldScopeByDocType() {
+            Integer docNo = persistDocument("Lab-typed response attachment", 0, Document.STATUS_ACTIVE);
+            persistCtlDocument(docNo, "provider", OWNER_PROVIDER_ID);
+            ConsultResponseDoc crd = new ConsultResponseDoc(RESPONSE_ID, docNo, ConsultResponseDoc.DOCTYPE_LAB, "999998");
+            crd.setAttachDate(new Date());
+            entityManager.persist(crd);
+            entityManager.flush();
+
+            List<Object[]> result = documentDao.findDocsAndConsultResponseDocsByConsultId(RESPONSE_ID);
 
             assertThat(result).isEmpty();
         }

--- a/src/test-modern/java/ca/openosp/openo/documentManager/dao/DocumentDaoBaseIntegrationTest.java
+++ b/src/test-modern/java/ca/openosp/openo/documentManager/dao/DocumentDaoBaseIntegrationTest.java
@@ -1,0 +1,73 @@
+package ca.openosp.openo.documentManager.dao;
+
+import ca.openosp.openo.commn.dao.DocumentDao;
+import ca.openosp.openo.commn.model.ConsultDocs;
+import ca.openosp.openo.commn.model.CtlDocument;
+import ca.openosp.openo.commn.model.CtlDocumentPK;
+import ca.openosp.openo.commn.model.Document;
+import ca.openosp.openo.test.base.OpenOTestBase;
+import org.junit.jupiter.api.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.util.Date;
+
+/**
+ * Base class for DocumentDao integration tests.
+ *
+ * Provides helpers to persist Document, CtlDocument, and ConsultDocs rows in
+ * the combinations needed to exercise attached-document queries (especially
+ * the multi-ctl-row case that triggers the first-tuple-wins classification
+ * ambiguity in EDocUtil.listDocs).
+ */
+@Tag("integration")
+@Tag("database")
+@Tag("slow")
+@Tag("dao")
+@Tag("document")
+@Transactional
+public abstract class DocumentDaoBaseIntegrationTest extends OpenOTestBase {
+
+    @Autowired
+    protected DocumentDao documentDao;
+
+    @PersistenceContext(unitName = "entityManagerFactory")
+    protected EntityManager entityManager;
+
+    /** Persist a Document with sensible defaults. Returns the generated documentNo. */
+    protected Integer persistDocument(String description, int public1, char status) {
+        Document d = new Document();
+        d.setDocdesc(description);
+        d.setDocfilename(description.replace(' ', '_') + ".pdf");
+        d.setDoccreator("999998");
+        d.setResponsible("999998");
+        d.setStatus(status);
+        d.setContenttype("application/pdf");
+        d.setPublic1(public1);
+        d.setObservationdate(new Date());
+        d.setUpdatedatetime(new Date());
+        entityManager.persist(d);
+        entityManager.flush();
+        return d.getDocumentNo();
+    }
+
+    /** Create a ctl_document row binding documentNo to (module, moduleId). */
+    protected void persistCtlDocument(Integer documentNo, String module, Integer moduleId) {
+        CtlDocument ctl = new CtlDocument();
+        CtlDocumentPK pk = new CtlDocumentPK(module, moduleId, documentNo);
+        ctl.setId(pk);
+        ctl.setStatus("A");
+        entityManager.persist(ctl);
+        entityManager.flush();
+    }
+
+    /** Attach a document to a consult request. */
+    protected void persistConsultDocAttachment(Integer requestId, Integer documentNo) {
+        ConsultDocs cd = new ConsultDocs(requestId, documentNo, ConsultDocs.DOCTYPE_DOC, "999998");
+        cd.setAttachDate(new Date());
+        entityManager.persist(cd);
+        entityManager.flush();
+    }
+}

--- a/src/test-modern/java/ca/openosp/openo/documentManager/dao/DocumentDaoBaseIntegrationTest.java
+++ b/src/test-modern/java/ca/openosp/openo/documentManager/dao/DocumentDaoBaseIntegrationTest.java
@@ -2,9 +2,11 @@ package ca.openosp.openo.documentManager.dao;
 
 import ca.openosp.openo.commn.dao.DocumentDao;
 import ca.openosp.openo.commn.model.ConsultDocs;
+import ca.openosp.openo.commn.model.ConsultResponseDoc;
 import ca.openosp.openo.commn.model.CtlDocument;
 import ca.openosp.openo.commn.model.CtlDocumentPK;
 import ca.openosp.openo.commn.model.Document;
+import ca.openosp.openo.commn.model.EFormDocs;
 import ca.openosp.openo.test.base.OpenOTestBase;
 import org.junit.jupiter.api.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -68,6 +70,22 @@ public abstract class DocumentDaoBaseIntegrationTest extends OpenOTestBase {
         ConsultDocs cd = new ConsultDocs(requestId, documentNo, ConsultDocs.DOCTYPE_DOC, "999998");
         cd.setAttachDate(new Date());
         entityManager.persist(cd);
+        entityManager.flush();
+    }
+
+    /** Attach a document to an eForm instance (fdid). */
+    protected void persistEFormDocAttachment(Integer fdid, Integer documentNo) {
+        EFormDocs ed = new EFormDocs(fdid, documentNo, EFormDocs.DOCTYPE_DOC, "999998");
+        ed.setAttachDate(new Date());
+        entityManager.persist(ed);
+        entityManager.flush();
+    }
+
+    /** Attach a document to a consultation response. */
+    protected void persistConsultResponseDocAttachment(Integer responseId, Integer documentNo) {
+        ConsultResponseDoc crd = new ConsultResponseDoc(responseId, documentNo, ConsultResponseDoc.DOCTYPE_DOC, "999998");
+        crd.setAttachDate(new Date());
+        entityManager.persist(crd);
         entityManager.flush();
     }
 }

--- a/src/test-modern/java/ca/openosp/openo/documentManager/dao/DocumentDaoFindValidAttachmentDocNosIntegrationTest.java
+++ b/src/test-modern/java/ca/openosp/openo/documentManager/dao/DocumentDaoFindValidAttachmentDocNosIntegrationTest.java
@@ -1,0 +1,167 @@
+package ca.openosp.openo.documentManager.dao;
+
+import ca.openosp.openo.commn.model.CtlDocument;
+import ca.openosp.openo.commn.model.CtlDocumentPK;
+import ca.openosp.openo.commn.model.Document;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@code DocumentDao.findValidAttachmentDocNos} — the
+ * lookup the Ocean eReferral validator uses to confirm that each attached doc
+ * either belongs to the patient's chart or lives in some provider's library
+ * (public or private eDoc). Pins the DB-level contract for both branches of
+ * the query plus the shared {@code c.status != 'D'} filter.
+ */
+@DisplayName("DocumentDao.findValidAttachmentDocNos")
+@Tag("integration")
+@Tag("dao")
+@Tag("document")
+@Tag("read")
+public class DocumentDaoFindValidAttachmentDocNosIntegrationTest extends DocumentDaoBaseIntegrationTest {
+
+    private static final Integer PROVIDER_A = 42;
+    private static final Integer PROVIDER_B = 99;
+    private static final Integer PATIENT = 2001;
+    private static final Integer OTHER_PATIENT = 2002;
+
+    @Test
+    @DisplayName("returns an empty list when the input is null")
+    void shouldReturnEmpty_whenInputIsNull() {
+        assertThat(documentDao.findValidAttachmentDocNos(PATIENT, null)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("returns an empty list when the input is empty")
+    void shouldReturnEmpty_whenInputIsEmpty() {
+        assertThat(documentDao.findValidAttachmentDocNos(PATIENT, Collections.emptyList())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("returns docs demographic-scoped to this patient")
+    void shouldReturnDoc_whenCtlModuleIsDemographicForThisPatient() {
+        Integer docNo = persistDocument("Patient doc", 0, Document.STATUS_ACTIVE);
+        persistCtlDocument(docNo, "demographic", PATIENT);
+
+        List<Integer> result = documentDao.findValidAttachmentDocNos(PATIENT, Arrays.asList(docNo));
+
+        assertThat(result).containsExactly(docNo);
+    }
+
+    @Test
+    @DisplayName("does not return docs demographic-scoped to a different patient")
+    void shouldNotReturnDoc_whenCtlModuleIsDemographicForAnotherPatient() {
+        Integer docNo = persistDocument("Other patient's doc", 0, Document.STATUS_ACTIVE);
+        persistCtlDocument(docNo, "demographic", OTHER_PATIENT);
+
+        List<Integer> result = documentDao.findValidAttachmentDocNos(PATIENT, Arrays.asList(docNo));
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("returns docs with a 'providers' module ctl row regardless of owning provider")
+    void shouldReturnDoc_whenCtlModuleIsProviders() {
+        Integer docNo = persistDocument("Public eDoc", 1, Document.STATUS_ACTIVE);
+        persistCtlDocument(docNo, "providers", PROVIDER_A);
+
+        List<Integer> result = documentDao.findValidAttachmentDocNos(PATIENT, Arrays.asList(docNo));
+
+        assertThat(result).containsExactly(docNo);
+    }
+
+    @Test
+    @DisplayName("returns docs with a legacy 'provider' module ctl row")
+    void shouldReturnDoc_whenCtlModuleIsProviderLegacy() {
+        Integer docNo = persistDocument("Legacy provider doc", 0, Document.STATUS_ACTIVE);
+        persistCtlDocument(docNo, "provider", PROVIDER_B);
+
+        List<Integer> result = documentDao.findValidAttachmentDocNos(PATIENT, Arrays.asList(docNo));
+
+        assertThat(result).containsExactly(docNo);
+    }
+
+    @Test
+    @DisplayName("does not return a provider-library doc whose ctl row is soft-deleted (status='D')")
+    void shouldNotReturnDoc_whenProviderCtlRowIsSoftDeleted() {
+        // Matches the demographic branch's behaviour: a cleaned-up binding
+        // (ctl row marked 'D') no longer counts as attachable membership,
+        // even for provider-library docs. Keeps the filter symmetric.
+        Integer docNo = persistDocument("Library-deleted provider doc", 0, Document.STATUS_ACTIVE);
+        CtlDocument ctl = new CtlDocument();
+        ctl.setId(new CtlDocumentPK("provider", PROVIDER_A, docNo));
+        ctl.setStatus("D");
+        entityManager.persist(ctl);
+        entityManager.flush();
+
+        List<Integer> result = documentDao.findValidAttachmentDocNos(PATIENT, Arrays.asList(docNo));
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("does not return a patient doc whose demographic ctl row is soft-deleted")
+    void shouldNotReturnDoc_whenDemographicCtlRowIsSoftDeleted() {
+        Integer docNo = persistDocument("Detached patient doc", 0, Document.STATUS_ACTIVE);
+        CtlDocument ctl = new CtlDocument();
+        ctl.setId(new CtlDocumentPK("demographic", PATIENT, docNo));
+        ctl.setStatus("D");
+        entityManager.persist(ctl);
+        entityManager.flush();
+
+        List<Integer> result = documentDao.findValidAttachmentDocNos(PATIENT, Arrays.asList(docNo));
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("returns a mix of demographic-scoped and provider-library docs in one call")
+    void shouldReturnBoth_whenMixedDemographicAndProviderDocs() {
+        Integer patientDoc = persistDocument("Patient doc", 0, Document.STATUS_ACTIVE);
+        persistCtlDocument(patientDoc, "demographic", PATIENT);
+        Integer providerDoc = persistDocument("Shared provider doc", 1, Document.STATUS_ACTIVE);
+        persistCtlDocument(providerDoc, "providers", PROVIDER_A);
+
+        List<Integer> result = documentDao.findValidAttachmentDocNos(
+                PATIENT, Arrays.asList(patientDoc, providerDoc));
+
+        assertThat(result).containsExactlyInAnyOrder(patientDoc, providerDoc);
+    }
+
+    @Test
+    @DisplayName("does not return docs outside the requested id list")
+    void shouldScopeByDocIds() {
+        Integer requestedDoc = persistDocument("Requested", 0, Document.STATUS_ACTIVE);
+        persistCtlDocument(requestedDoc, "providers", PROVIDER_A);
+        Integer otherDoc = persistDocument("Other provider doc", 0, Document.STATUS_ACTIVE);
+        persistCtlDocument(otherDoc, "providers", PROVIDER_B);
+
+        List<Integer> result = documentDao.findValidAttachmentDocNos(PATIENT, Arrays.asList(requestedDoc));
+
+        assertThat(result).containsExactly(requestedDoc);
+    }
+
+    @Test
+    @DisplayName("returns a doc that has multiple qualifying ctl rows")
+    void shouldReturnDoc_whenDocHasMultipleQualifyingCtlRows() {
+        // A doc can legitimately have rows under both 'provider' and 'providers',
+        // or under multiple providers, or under demographic + provider. The DAO
+        // may return the id more than once; the caller wraps the result in a
+        // HashSet before its containsAll check, so cardinality is its problem.
+        // What matters here is that the doc is present in the result.
+        Integer docNo = persistDocument("Doc with two qualifying ctl rows", 0, Document.STATUS_ACTIVE);
+        persistCtlDocument(docNo, "provider", PROVIDER_A);
+        persistCtlDocument(docNo, "providers", PROVIDER_B);
+
+        List<Integer> result = documentDao.findValidAttachmentDocNos(PATIENT, Arrays.asList(docNo));
+
+        assertThat(result).contains(docNo);
+    }
+}

--- a/src/test-modern/resources/META-INF/persistence.xml
+++ b/src/test-modern/resources/META-INF/persistence.xml
@@ -29,6 +29,13 @@
         <class>ca.openosp.openo.commn.model.DemographicMerged</class>
         <class>ca.openosp.openo.PMmodule.model.ProgramQueue</class>
         <class>ca.openosp.openo.commn.model.ProfessionalSpecialist</class>
+        <!-- Document attachment entities (DocumentDao integration tests) -->
+        <class>ca.openosp.openo.commn.model.Document</class>
+        <class>ca.openosp.openo.commn.model.DocumentReview</class>
+        <class>ca.openosp.openo.commn.model.CtlDocument</class>
+        <class>ca.openosp.openo.commn.model.ConsultDocs</class>
+        <class>ca.openosp.openo.commn.model.EFormDocs</class>
+        <class>ca.openosp.openo.commn.model.ConsultResponseDoc</class>
         <!-- HBM.XML mapped entities -->
         <mapping-file>ca/openosp/openo/commn/model/Provider.hbm.xml</mapping-file>
         <mapping-file>ca/openosp/openo/commn/model/Demographic.hbm.xml</mapping-file>

--- a/src/test-modern/resources/test-context-full.xml
+++ b/src/test-modern/resources/test-context-full.xml
@@ -193,6 +193,9 @@
 
     <!-- Specialist DAOs -->
     <bean id="professionalSpecialistDao" class="ca.openosp.openo.commn.dao.ProfessionalSpecialistDaoImpl" autowire="byName" />
+    <!-- Document DAO for DocumentDao integration tests -->
+    <bean id="documentDao" class="ca.openosp.openo.commn.dao.DocumentDaoImpl" autowire="byName" />
+    <bean id="ctlDocumentDao" class="ca.openosp.openo.commn.dao.CtlDocumentDaoImpl" autowire="byName" />
 
     <!-- Additional DAOs required by TicklerManager -->
     <bean id="programAccessDAO" class="ca.openosp.openo.PMmodule.dao.ProgramAccessDAOImpl" autowire="byName" />


### PR DESCRIPTION
## Summary

Adds provider-owned documents to the attachment manager so providers can attach their own private or public eDocs to consultations and eForms, alongside the existing patient-specific documents.

## User-facing changes

- Attachment manager now shows three document sections:
  - **Patient Documents** (renamed from "Documents")
  - **Public eDocs** — shared provider library
  - **Private eDocs** — current provider's private library
- Private doc selections trigger a confirmation dialog warning that private documents will become visible to anyone with access to the record once attached. The warning only fires on *new* attachments per the spec.
- Cross-provider private-doc attachments render in italics with an `(attached by another provider)` label, so reviewing providers can see that a doc they're looking at belongs to a different provider's library.
- Soft-deleted attached docs remain retrievable and render in italics with a `(deleted)` label so they don't silently vanish from saved consults/eForms after a library cleanup.

### New consultation attachment page:

<img width="1844" height="900" alt="image" src="https://github.com/user-attachments/assets/8fe867a8-c36a-4865-b34d-6a38e0549abb" />

### Cross-provider consultation attachment page (deleted documents, attached documents by other providers):

<img width="1860" height="823" alt="image" src="https://github.com/user-attachments/assets/5d18100c-81af-4d5e-9774-078d7ab2aa29" />

### Warning popup on attachment page when attaching new private provider documents

<img width="542" height="335" alt="image" src="https://github.com/user-attachments/assets/653779b8-c0af-4ce1-a235-fe0daac2d092" />

**Note:** since both consultation and eForm's use the same base JSP for the attachment manager, I have only shown screenshots based on the consultation flow since attaching both shouldn't show any differences.

## Implementation approach

### DAO layer — unchanged shape

The 3 attached-doc DAO methods (`findDocsAndConsultDocsByConsultId`, `findDocsAndEFormDocsByFdid`, `findDocsAndConsultResponseDocsByConsultId`) are unchanged versus develop. Their pre-PR 2-column contract is preserved so the 16 downstream callers (PDF printing, fax, REST APIs, etc.) see no behavioral change.

### EDocUtil — ctl enrichment for attached docs

New `enrichAttachedWithCtl` helper runs after the DAO returns attached-doc tuples. It does one batch query via a new `CtlDocumentDao.findByDocumentNos(List<Integer>)` to fetch ctl rows for all attached docs and picks the preferred ctl per doc (provider bindings win over demographic so library docs classify correctly). Orphan docs with no ctl row pass through unclassified and fall through to the patient section.

### DocumentPreview2Action — attached-state classification

New `mergeAttachedContext` / `mergeSingleAttachedDoc` walk the attached-doc list and classify each into the correct section (patient / provider public / provider private), re-injecting soft-deleted items and flagging cross-provider private docs via `foreignPrivateDocIds`.

### JSP and JS

- Three new sections in `attachDocument.jsp` with select-all + show-more + preview + deleted/foreign markers.
- Shared helpers in the JSP `<script>` block: `confirmPrivateDocsIfAny`, `buildDelegateInput`, `syncPreCheckedToDelegates` — consumed by both the consult JSP and the eForm toolbar.
- `data-delegate-type="doc"` attribute on doc delegate inputs so the toolbar JS resolves checkboxes by name+value across the three sections (a plain `#docNo<id>` selector would only match the patient section).
- Dialog reopen sync: unchecks any server-pre-checked box whose delegate was removed in a prior dialog session (fixes the issue where an unchecked doc came back checked on reopen before the consult/eForm was saved).

## Privacy and PHI considerations

The attachment uses a **reference-based** model: attaching a provider's private doc to a consult creates a row in `consultdocs` (or `eform_docs`) pointing at the original `document_no`, not a copy.

Key property: there is **no reverse lookup** in the application code that takes a `document_no` and returns every patient/consult/eForm it's attached to. Each forward lookup (`DisplayDemographicConsultationRequests`, eForm display, etc.) is scoped to a single request/fdid, so one provider document attached to multiple patients' records never becomes cross-patient visibility through app code.

## Testing

### Automated

- `DocumentDaoAttachedFindIntegrationTest` — 14 cases across 3 nested classes covering each attached-doc query: happy path, multi-doc, orphan docs (no ctl row), soft-deleted, scope-by-id, non-DOC docType exclusion.
- `CtlDocumentDaoFindByDocumentNosIntegrationTest` — 6 cases for the new batch method: null input, empty input, single doc, multiple docs, doc with multiple ctl rows, scope-by-doc-ids.
- `DocumentPreview2ActionMergeUnitTest` — 12 cases across 5 nested classes covering the full matrix of `mergeSingleAttachedDoc` classification: patient / public provider / own private / foreign private × active / deleted, plus edge cases (null current provider, legacy "provider" vs "providers" module spelling).

### Manual smoke tests performed

Covered all scenarios from the spec's "Testing Performed" section plus several derived ones:

- Fresh attachment dialog renders all three sections ✓
- Private-doc attach triggers warning; public-doc attach does not ✓
- Warning does NOT fire when reopening a saved consult/eForm with pre-existing attachments and no changes (spec's no-change exemption) ✓
- Dialog reopen sync: uncheck → close → reopen → stays unchecked ✓
- Each provider only sees their own private docs in the picker (Provider B cannot browse Provider A's library) ✓
- Provider B sees Provider A's attached private docs with "(attached by another provider)" label ✓
- Soft-deleted attached docs remain retrievable with "(deleted)" label ✓
- eForm save → reopen → provider-section boxes still pre-checked ✓
- eForm Email workflow includes attached provider docs in the PDF ✓

### Playwright verification

Confirmed the following at the DOM level in a running dev instance:

- Dialog renders Patient Documents, Public eDocs, Private eDocs with correct items and CSS classes (`providerPrivateDoc`, `foreign-doc`, `deleted-doc`).
- `syncPreCheckedToDelegates` correctly unchecks/reverts class/strips `data-pre-attached` when delegate is missing, and leaves state alone when delegate is present.
- Cross-provider scenario on consult 106: all 6 of openodoc's private docs rendered under Private eDocs with `foreign-doc` class and "(attached by another provider)" label.

## Design decisions worth noting

- **Reference vs. copy** — reference for both eForm and consult. The spec flags this as a reviewable design question; per-workflow split ("copy for consult, reference for eForm") can be added in a follow-up once user feedback is gathered.
- **Provider-wins ctl tiebreaker** — in the hypothetical case where a doc has multiple ctl bindings, the provider binding wins so library docs classify consistently. In the current data pattern this doesn't occur (invariant: one ctl per `document_no`, verified via `GROUP BY document_no HAVING COUNT(*) > 1` → 0 rows).
- **Warning exemption on no-change** — reopening a dialog on a pre-existing private attachment and making no changes does not re-trigger the warning (matches spec).

## Summary by Sourcery

Expose provider-owned public and private eDocs alongside patient documents in the attachment manager, while keeping attachments secure and accurately classified across consult and eForm workflows.

New Features:
- Add public and private provider eDoc sections to the attachment dialog for consultations and eForms, with select-all, pagination, and preview support.
- Display visual markers and labels for deleted documents and private documents owned by other providers in the attachment manager and consuming UIs.

Bug Fixes:
- Ensure attachment selections persist correctly across dialog reopenings and that unchecked pre-attached items remain unchecked.
- Fix validation so Ocean and other workflows accept attachments that come from provider libraries as well as patient-scoped documents.

Enhancements:
- Classify attached documents into patient, provider public, and provider private sections using ctl_document data while preserving existing DAO contracts.
- Harden parameter parsing and security checks when fetching attachable documents, including explicit _edoc privilege checks.
- Escape various document- and form-derived strings in the attachment JSP to reduce XSS risk.

Tests:
- Add integration tests for DocumentDao attached-document queries and for validating attachable document IDs against demographic and provider-library scope.
- Add integration tests for CtlDocumentDao batch lookups used to enrich attached documents.
- Add unit tests covering mergeAttachedIntoSections classification logic across patient/public/private and ownership/deleted permutations.