### PR TITLE
Fix: billing Reconciliation "Settle" 404s and leaves invoices marked submitted

### DIFF
--- a/src/main/webapp/billing/CA/ON/onGenRA.jsp
+++ b/src/main/webapp/billing/CA/ON/onGenRA.jsp
@@ -178,7 +178,7 @@
                     target="_blank">Summary</a>| <a
                     href="<%= request.getContextPath() %>/billing/CA/ON/genRADesc.jsp?rano=<%=raNo%>" target="_blank">Report
             </a></td>
-            <td><%=status.compareTo("N") == 0 ? "<a href=# onClick=\"checkReconcile('../billing/CA/ON/onGenRAsettle.jsp?rano=" + raNo + "')\">Settle</a> <a href=# onClick=\"checkReconcile('../billing/CA/ON/onGenRAsettle35.jsp?rano=" + raNo + "')\">S35</a>" : status.compareTo("S") == 0 ? " <a href=# onClick=\"checkReconcile('../billing/CA/ON/onGenRAsettle35.jsp?rano=" + raNo + "')\">S35</a>" : "Processed"%>
+            <td><%=status.compareTo("N") == 0 ? "<a href=# onClick=\"checkReconcile('" + request.getContextPath() + "/billing/CA/ON/onGenRAsettle.jsp?rano=" + Encode.forUriComponent(String.valueOf(raNo)) + "')\">Settle</a> <a href=# onClick=\"checkReconcile('" + request.getContextPath() + "/billing/CA/ON/onGenRAsettle35.jsp?rano=" + Encode.forUriComponent(String.valueOf(raNo)) + "')\">S35</a>" : status.compareTo("S") == 0 ? " <a href=# onClick=\"checkReconcile('" + request.getContextPath() + "/billing/CA/ON/onGenRAsettle35.jsp?rano=" + Encode.forUriComponent(String.valueOf(raNo)) + "')\">S35</a>" : "Processed"%>
             </td>
         </tr>
         <%

--- a/src/main/webapp/billing/CA/ON/onGenRA.jsp
+++ b/src/main/webapp/billing/CA/ON/onGenRA.jsp
@@ -41,6 +41,7 @@
 <%@ page import="ca.openosp.openo.billing.ca.on.data.*" %>
 <%@ page import="ca.openosp.openo.billings.ca.on.data.JdbcBillingRAImpl" %>
 <%@ page import="ca.openosp.OscarProperties" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 <jsp:useBean id="documentBean" class="ca.openosp.DocumentBean" scope="request"/>
 
 <%

--- a/src/main/webapp/billing/CA/ON/onGenRAsettle.jsp
+++ b/src/main/webapp/billing/CA/ON/onGenRAsettle.jsp
@@ -89,9 +89,7 @@
         dao.merge(raHeader);
         recordAffected1++;
     }
-%>
 
-<script LANGUAGE="JavaScript">
-    window.location.href = '<%= request.getContextPath() %>/billing/CA/ON/genRA.jsp';
-</script>
+    response.sendRedirect(request.getContextPath() + "/billing/CA/ON/genRA.jsp");
+%>
 

--- a/src/main/webapp/billing/CA/ON/onGenRAsettle.jsp
+++ b/src/main/webapp/billing/CA/ON/onGenRAsettle.jsp
@@ -92,7 +92,6 @@
 %>
 
 <script LANGUAGE="JavaScript">
-    self.close();
-    self.opener.refresh();
+    window.location.href = '<%= request.getContextPath() %>/billing/CA/ON/genRA.jsp';
 </script>
 

--- a/src/main/webapp/billing/CA/ON/onGenRAsettle35.jsp
+++ b/src/main/webapp/billing/CA/ON/onGenRAsettle35.jsp
@@ -117,6 +117,5 @@
 %>
 
 <script LANGUAGE="JavaScript">
-    self.close();
-    self.opener.refresh();
+    window.location.href = '<%= request.getContextPath() %>/billing/CA/ON/genRA.jsp';
 </script>

--- a/src/main/webapp/billing/CA/ON/onGenRAsettle35.jsp
+++ b/src/main/webapp/billing/CA/ON/onGenRAsettle35.jsp
@@ -114,8 +114,6 @@
         dao.merge(raHeader);
         recordAffected1++;
     }
-%>
 
-<script LANGUAGE="JavaScript">
-    window.location.href = '<%= request.getContextPath() %>/billing/CA/ON/genRA.jsp';
-</script>
+    response.sendRedirect(request.getContextPath() + "/billing/CA/ON/genRA.jsp");
+%>


### PR DESCRIPTION
## Summary
Fixes the Ontario Billing Reconciliation **Settle** (and **S35**) flow so that clicking the button reliably marks the RA header and applicable invoices as settled, regardless of how the page was reached. Previously the action either 404'd or silently completed in the DB while crashing the UI, leaving users to believe nothing happened.

Original PR: https://github.com/openo-beta/Open-O/pull/2433

## Problem
Two issues in the legacy JSPs at `src/main/webapp/billing/CA/ON/`:

1. **Doubled URL → 404.** `onGenRA.jsp` built the Settle/S35 onClick URLs with a relative path (`../billing/CA/ON/onGenRAsettle.jsp`). Because the standard user entry point is `genRA.jsp`, which does a server-side `<jsp:forward>` to `onGenRA.jsp`, the browser URL stays at `/billing/CA/ON/genRA.jsp`. The `..` resolves up to `/billing/CA/` and re-appends `billing/CA/ON/…`, producing `/oscar/billing/CA/billing/CA/ON/onGenRAsettle.jsp` → 404. The JSP never executes, so neither `raheader.status` nor `billing_on_cheader1.status` is updated. The invoices stay marked "submitted" on the billing list even though the RA's payment amounts (written to `radetail` during upload) load correctly.
3. **`self.opener` is null.** When the URL did resolve (the post-upload redirect entry path), the Settle JSP finished by running:
```js
     self.close();
     self.opener.refresh();
```
This assumes the page was opened via window.open(...), but checkReconcile in onGenRA.jsp navigates the same window with location.href = url. So self.opener is null, the script throws TypeError: Cannot read properties of null (reading 'refresh'), the parent Billing Reconciliation tab never refreshes, and the user sees a blank page after a successful DB update. (Aside: even if opener were set, there is no Window.refresh() method — the real API is location.reload(). This popup wiring has been broken in principle for a long time.)

Same root cause family as commit 20eba0f697 (fix: fixed relative url 404 errors, replaced ../ to <%= request.getContextPath() %>/), which fixed this elsewhere but missed these JSPs.

## Solution
- onGenRA.jsp — Settle and S35 anchors now build absolute URLs using <%= request.getContextPath() %>/billing/CA/ON/onGenRAsettle.jsp (and onGenRAsettle35.jsp) instead of ../billing/CA/ON/.... Same pattern already used by the sibling Error/Summary/Report links in this file.
- onGenRAsettle.jsp and onGenRAsettle35.jsp — closing <script> block replaced. Instead of relying on the non-existent popup opener: window.location.href = '<%= request.getContextPath() %>/billing/CA/ON/genRA.jsp';
- The page now redirects the user back to the (now correctly updated) Billing Reconciliation list, which is the behavior the original popup flow was trying to produce.

No DAO, model, or service-layer changes — bug was entirely in the view layer.

## Test Plan

Manually verified end-to-end on develop against a clean dev DB with seeded billing_on_cheader1 fixtures:
  - Path A — via menu (Administration > Billing > Billing Reconciliation) → Settle: previously 404'd, now stays on /billing/CA/ON/genRA.jsp, no console errors, raheader.status flips N→S, non-error bills flip N→S, bills with error codes (e.g. E2) correctly held back for S35.
  - Path B — via post-upload redirect (/servlet/ca.openosp.DocumentUploadServlet) → Settle: previously fired TypeError: self.opener is null, now redirects cleanly back to Billing Reconciliation with the row showing as settled.
  - No regressions in the Error / Summary / Report links (unchanged in this PR).

## Summary by Sourcery

Fix Ontario billing reconciliation settlement flows so that Settle and S35 reliably complete and return users to the reconciliation list without errors or 404s.

Bug Fixes:
- Ensure Settle and S35 links in the Ontario billing reconciliation page use absolute, context-aware URLs to avoid 404s and double-path issues.
- Redirect the Settle and S35 JSPs back to the billing reconciliation list instead of relying on a broken window opener script that caused blank pages and JS errors.

Enhancements:
- URL-encode RA numbers when constructing Settle and S35 action URLs to safely handle special characters.