### PR TITLE
Fix: medication stash behaving unexpectedly

### DIFF
--- a/src/main/java/ca/openosp/openo/prescript/pageUtil/RxChoosePatient2Action.java
+++ b/src/main/java/ca/openosp/openo/prescript/pageUtil/RxChoosePatient2Action.java
@@ -96,16 +96,7 @@ public final class RxChoosePatient2Action extends ActionSupport {
             bean.setProviderNo(user_no);
             bean.setDemographicNo(demographicNoInt);
         } else {
-            // Drop stash items already persisted in a prior save. A reused bean
-            // (re-open/refresh) should show a clean staging area when the only
-            // items left are leftovers from a completed save & print or save-only;
-            // unsaved drafts (script_no null) are preserved so multi-tab work
-            // staged elsewhere is not lost.
-            bean.getStashList().removeIf(rx ->
-                    rx.getScript_no() != null && !rx.getScript_no().isEmpty());
-            if (bean.getStashIndex() >= bean.getStashSize()) {
-                bean.setStashIndex(bean.getStashSize() - 1);
-            }
+            bean.removePersistedStashItems();
         }
         RxSessionBean.saveToSession(request, bean);
 

--- a/src/main/java/ca/openosp/openo/prescript/pageUtil/RxChoosePatient2Action.java
+++ b/src/main/java/ca/openosp/openo/prescript/pageUtil/RxChoosePatient2Action.java
@@ -95,6 +95,17 @@ public final class RxChoosePatient2Action extends ActionSupport {
             bean = new RxSessionBean();
             bean.setProviderNo(user_no);
             bean.setDemographicNo(demographicNoInt);
+        } else {
+            // Drop stash items already persisted in a prior save. A reused bean
+            // (re-open/refresh) should show a clean staging area when the only
+            // items left are leftovers from a completed save & print or save-only;
+            // unsaved drafts (script_no null) are preserved so multi-tab work
+            // staged elsewhere is not lost.
+            bean.getStashList().removeIf(rx ->
+                    rx.getScript_no() != null && !rx.getScript_no().isEmpty());
+            if (bean.getStashIndex() >= bean.getStashSize()) {
+                bean.setStashIndex(bean.getStashSize() - 1);
+            }
         }
         RxSessionBean.saveToSession(request, bean);
 

--- a/src/main/java/ca/openosp/openo/prescript/pageUtil/RxSessionBean.java
+++ b/src/main/java/ca/openosp/openo/prescript/pageUtil/RxSessionBean.java
@@ -355,6 +355,8 @@ public class RxSessionBean implements java.io.Serializable {
      * Called from {@link RxChoosePatient2Action} on each Rx open so a reused
      * per-patient bean shows a clean staging area after a completed save, while
      * preserving in-progress drafts staged in another tab (PR #2261 invariant).
+     *
+     * @since 2026-05-27
      */
     public void removePersistedStashItems() {
         stash.removeIf(rx -> rx.getDrugId() > 0);

--- a/src/main/java/ca/openosp/openo/prescript/pageUtil/RxSessionBean.java
+++ b/src/main/java/ca/openosp/openo/prescript/pageUtil/RxSessionBean.java
@@ -341,6 +341,28 @@ public class RxSessionBean implements java.io.Serializable {
         stash = new ArrayList();
     }
 
+    /**
+     * Drops stash items that have already been persisted in this session's
+     * save flow, leaving unsaved drafts in place. {@code drugId} is 0 until
+     * {@code rx.Save()} writes a Drug row and assigns the generated id, so
+     * {@code drugId > 0} reliably means "this stash item was persisted."
+     * <p>
+     * Note: {@code script_no} is not a safe signal here because
+     * {@link RxPrescriptionData#newPrescription(String, int, RxPrescriptionData.Prescription)}
+     * copies the original prescription's {@code script_no} into a freshly-staged
+     * re-prescription, which would cause unsaved ReRx drafts to be dropped.
+     * <p>
+     * Called from {@link RxChoosePatient2Action} on each Rx open so a reused
+     * per-patient bean shows a clean staging area after a completed save, while
+     * preserving in-progress drafts staged in another tab (PR #2261 invariant).
+     */
+    public void removePersistedStashItems() {
+        stash.removeIf(rx -> rx.getDrugId() > 0);
+        if (stashIndex >= stash.size()) {
+            stashIndex = stash.size() - 1;
+        }
+    }
+
     public HashMap<Integer, Long> getFavIdRandomIdMaps() {
         return favIdRandomIdMap;
     }

--- a/src/main/java/ca/openosp/openo/prescript/pageUtil/RxSessionBean.java
+++ b/src/main/java/ca/openosp/openo/prescript/pageUtil/RxSessionBean.java
@@ -359,8 +359,13 @@ public class RxSessionBean implements java.io.Serializable {
      * @since 2026-05-27
      */
     public void removePersistedStashItems() {
+        RxPrescriptionData.Prescription selected =
+                (stashIndex >= 0 && stashIndex < stash.size()) ? stash.get(stashIndex) : null;
         stash.removeIf(rx -> rx.getDrugId() > 0);
-        if (stashIndex >= stash.size()) {
+        if (selected != null) {
+            int newIndex = stash.indexOf(selected);
+            stashIndex = (newIndex >= 0) ? newIndex : stash.size() - 1;
+        } else if (stashIndex >= stash.size()) {
             stashIndex = stash.size() - 1;
         }
     }


### PR DESCRIPTION
## Summary

Fixes the medication stash leaving stale, already-persisted entries visible after a save → close/refresh → re-open cycle on the same patient. Also re-anchors the "currently selected" stash item by identity so it survives the cleanup without silently shifting to a different draft.

Based on this PR: https://github.com/openo-beta/Open-O/pull/2442

## Problem

When a user staged multiple prescriptions, saved them, then refreshed or closed and re-opened the Medications page for the same patient, the already-saved entries continued to appear in the staging area as if they were unsaved drafts. The session-scoped `RxSessionBean` is intentionally reused per patient (PR #2261) to preserve in-progress drafts across tabs, but it had no path to drop entries that had already been written to the database in this session — so a clean re-open showed a dirty stash.

A secondary issue surfaced during review: any cleanup that removes items from the middle of the stash list shifts the indices of survivors. `stashIndex` is just a numeric position, so a clamp-only `if (stashIndex >= size) stashIndex = size - 1` leaves the index silently pointing at a *different* item than the user originally selected, e.g. `[A(saved), B(draft), C(saved), D(draft)]` with B selected (`stashIndex=1`) becomes `[B, D]` after cleanup, but the unchanged index now highlights D.

## Solution

1. **`RxSessionBean.removePersistedStashItems()`** — drops stash entries whose `drugId > 0` (the reliable "this was persisted" signal: `drugId` stays 0 until `rx.Save()` writes a Drug row and assigns the generated id). `script_no` is unsafe here because `RxPrescriptionData.newPrescription(...)` copies it into freshly-staged re-prescriptions, which would falsely drop unsaved ReRx drafts.

2. **`RxChoosePatient2Action`** — calls `removePersistedStashItems()` on each Rx open when reusing an existing per-patient bean, so the staging area is clean after a completed save while drafts staged in another tab (the PR #2261 invariant) are preserved.

3. **Identity-based `stashIndex` re-anchor** — before `removeIf`, capture the currently-selected `Prescription` by reference; after removal, re-find it with `indexOf` and update `stashIndex` to its new position. Falls back to `size - 1` when the selected item was itself the one removed (and `size - 1 == -1` naturally handles the empty-stash case via the existing `WriteScript.jsp:82` redirect).

## Verification

Tested end-to-end against demographic 1 with 5 scenarios covering: no-removal (selection preserved), middle-selected draft survives mixed cleanup at its new index, selected-item-itself-removed fallback, and all-persisted → empty stash → redirect. In every case the rendered stash count matched `stash.size()` and the highlighted row (`tblRowSelected`) matched the expected post-cleanup `stashIndex`.

## Summary by Sourcery

Ensure prescription stash is cleaned of already-persisted items when reusing a patient-specific session while preserving valid drafts and the current selection.

Bug Fixes:
- Remove previously saved prescriptions from the medication staging area when reopening a patient so only unsaved drafts remain.
- Maintain the correct currently selected stash item after cleanup so the highlighted prescription does not silently shift to a different draft.