### PR TITLE
fix: remove non-functional "Save / Write to eChart" button from New Tickler

### DIFF
--- a/src/main/webapp/tickler/ticklerAdd.jsp
+++ b/src/main/webapp/tickler/ticklerAdd.jsp
@@ -747,9 +747,6 @@
                     <td colspan="2"><input type="button" name="Button" class="btn btn-primary"
                                value="<fmt:setBundle basename="oscarResources"/><fmt:message key="tickler.ticklerAdd.btnSubmit"/>"
                                onclick="validate(this.form);">
-                        <input type="button" name="Button" class="btn btn-secondary"
-                               value="Save / Write to eChart"
-                               onclick="validate(this.form, true)">
                         <input type="button" name="Button" class="btn btn-danger"
                                value="<fmt:setBundle basename="oscarResources"/><fmt:message key="tickler.ticklerAdd.btnCancel"/>"
                                onclick="window.close()">


### PR DESCRIPTION
# Issue
  This PR https://github.com/open-osp/Open-O/pull/208 added a "Write to eChart and submit" button (later renamed to "Save / Write to eChart" in https://github.com/open-osp/Open-O/commit/cb930cc7daec8445c18a9304787cb1ab6a24832f) to the "New Tickler" window, but it doesn't actually do what it says.
  
  
<img width="713" height="587" alt="image" src="https://github.com/user-attachments/assets/e114f452-4483-4837-a4be-d01d434e5422" />

  
  ## Fix
  Removed the button from `ticklerAdd.jsp`.

## Summary by Sourcery

Bug Fixes:
- Eliminate a non-functional "Save / Write to eChart" action from the New Tickler interface to prevent misleading users.