### PR TITLE
fix: pharmacy list phone/fax search not normalized properly

### DIFF
--- a/src/main/webapp/oscarRx/SelectPharmacy2.jsp
+++ b/src/main/webapp/oscarRx/SelectPharmacy2.jsp
@@ -201,8 +201,8 @@
                     var pharmacyNameKey = new RegExp($("#pharmacySearch").val(), "i");
                     var pharmacyCityKey = new RegExp($("#pharmacyCitySearch").val(), "i");
                     var pharmacyPostalCodeKey = new RegExp($("#pharmacyPostalCodeSearch").val(), "i");
-                    var pharmacyFaxKey = new RegExp($("#pharmacyFaxSearch").val(), "i");
-                    var pharmacyPhoneKey = new RegExp($("#pharmacyPhoneSearch").val(), "i");
+					var pharmacyFaxKey = new RegExp($("#pharmacyFaxSearch").val().replace(/\D/g, ""), "i");
+					var pharmacyPhoneKey = new RegExp($("#pharmacyPhoneSearch").val().replace(/\D/g, ""), "i");
                     var pharmacyAddressKey = new RegExp($("#pharmacyAddressSearch").val(), "i");
 
                     $("#pharmacySearch").keyup(function () {
@@ -212,7 +212,7 @@
                             if ($(value).html().toLowerCase().search(pharmacyNameKey) >= 0) {
                                 if ($(value).siblings(".city").html().search(pharmacyCityKey) >= 0) {
                                     if ($(value).siblings(".postalCode").html().search(pharmacyPostalCodeKey) >= 0) {
-                                        if ($(value).siblings(".fax").html().search(pharmacyFaxKey) >= 0) {
+                                        if ($(value).siblings(".fax").html().replace(/\D/g, "").search(pharmacyFaxKey) >= 0) {
                                             if ($(value).siblings(".fax").html().search(pharmacyAddressKey) >= 0) {
                                                 $(value).parent().show();
                                             }
@@ -230,7 +230,7 @@
                             if ($(value).html().toLowerCase().search(pharmacyCityKey) >= 0) {
                                 if ($(value).siblings(".pharmacyName").html().search(pharmacyNameKey) >= 0) {
                                     if ($(value).siblings(".postalCode").html().search(pharmacyPostalCodeKey) >= 0) {
-                                        if ($(value).siblings(".fax").html().search(pharmacyFaxKey) >= 0) {
+                                        if ($(value).siblings(".fax").html().replace(/\D/g, "").search(pharmacyFaxKey) >= 0) {
                                             if ($(value).siblings(".fax").html().search(pharmacyAddressKey) >= 0) {
                                                 $(value).parent().show();
                                             }
@@ -248,7 +248,7 @@
                             if ($(value).html().toLowerCase().search(pharmacyPostalCodeKey) >= 0) {
                                 if ($(value).siblings(".pharmacyName").html().search(pharmacyNameKey) >= 0) {
                                     if ($(value).siblings(".city").html().search(pharmacyCityKey) >= 0) {
-                                        if ($(value).siblings(".fax").html().search(pharmacyFaxKey) >= 0) {
+                                        if ($(value).siblings(".fax").html().replace(/\D/g, "").search(pharmacyFaxKey) >= 0) {
                                             $(value).parent().show();
                                         }
                                     }
@@ -261,7 +261,7 @@
                         updateSearchKeys();
                         $(".pharmacyItem").hide();
                         $.each($(".fax"), function (key, value) {
-                            if ($(value).html().search(pharmacyFaxKey) >= 0 || $(value).html().split("-").join("").search(pharmacyFaxKey) >= 0) {
+							if ($(value).html().replace(/\D/g, "").search(pharmacyFaxKey) >= 0) {
                                 if ($(value).siblings(".pharmacyName").html().search(pharmacyNameKey) >= 0) {
                                     if ($(value).siblings(".city").html().search(pharmacyCityKey) >= 0) {
                                         if ($(value).siblings(".postalCode").html().search(pharmacyPostalCodeKey) >= 0) {
@@ -277,7 +277,7 @@
                         updateSearchKeys();
                         $(".pharmacyItem").hide();
                         $.each($(".phone"), function (key, value) {
-                            if ($(value).html().search(pharmacyPhoneKey) >= 0 || $(value).html().split("-").join("").search(pharmacyPhoneKey) >= 0) {
+							if ($(value).html().replace(/\D/g, "").search(pharmacyPhoneKey) >= 0) {
                                 if ($(value).siblings(".pharmacyName").html().search(pharmacyNameKey) >= 0) {
                                     if ($(value).siblings(".city").html().search(pharmacyCityKey) >= 0) {
                                         if ($(value).siblings(".postalCode").html().search(pharmacyPostalCodeKey) >= 0) {
@@ -362,8 +362,8 @@
                         pharmacyNameKey = new RegExp($("#pharmacySearch").val(), "i");
                         pharmacyCityKey = new RegExp($("#pharmacyCitySearch").val(), "i");
                         pharmacyPostalCodeKey = new RegExp($("#pharmacyPostalCodeSearch").val(), "i");
-                        pharmacyFaxKey = new RegExp($("#pharmacyFaxSearch").val(), "i");
-                        pharmacyPhoneKey = new RegExp($("#pharmacyPhoneSearch").val(), "i");
+                        pharmacyFaxKey = new RegExp($("#pharmacyFaxSearch").val().replace(/\D/g, ""), "i");
+                        pharmacyPhoneKey = new RegExp($("#pharmacyPhoneSearch").val().replace(/\D/g, ""), "i");
                         pharmacyAddressKey = new RegExp($("#pharmacyAddressSearch").val(), "i");
                     }
                 })


### PR DESCRIPTION
## Problem
  Phone/fax search in the pharmacy list (`SelectPharmacy2.jsp`) failed to ignore non-numeric characters, so the same number in different formats (`xxxxxxxxxx`, `xxx xxx xxxx`, `(xxx) xxx xxxx`, `xxx-xxx-xxxx`) returned inconsistent or empty results. 

<img width="833" height="251" alt="image" src="https://github.com/user-attachments/assets/e1cb3f34-cbf3-485e-b757-ab2135339fcc" />
<img width="840" height="227" alt="image" src="https://github.com/user-attachments/assets/29474c68-de51-4df1-a240-d0db7e9f2809" />
<img width="822" height="216" alt="image" src="https://github.com/user-attachments/assets/56955e2c-67de-4c89-9987-9c752296898b" />


  ## Solution
  Normalize **both** the search value and the displayed value by stripping everything except digits with `.replace(/\D/g, "")`, consistently across all three places:

  - Initial regex construction
  - `updateSearchKeys()` (the missed spot)
  - The phone/fax match logic and the cross-filter checks in the name/city/postal handlers

  All formatting variations now normalize to the same digit string on both sides of the comparison and match as expected.

<img width="1930" height="1148" alt="image" src="https://github.com/user-attachments/assets/9e696fdb-697c-4fea-901a-71c3b185bc16" />

## Summary by Sourcery

Bug Fixes:
- Strip non-numeric characters from pharmacy phone and fax search inputs and displayed values so differently formatted numbers return consistent results in the pharmacy list.