### PR TITLE
fix: re-link previously removed provider when forwarding a document

### DIFF
--- a/src/main/java/ca/openosp/openo/commn/model/ProviderLabRoutingModel.java
+++ b/src/main/java/ca/openosp/openo/commn/model/ProviderLabRoutingModel.java
@@ -28,6 +28,57 @@ import org.apache.commons.lang3.StringUtils;
 @Table(name = "providerLabRouting")
 public class ProviderLabRoutingModel extends AbstractModel<Integer> implements Serializable {
 
+    /**
+     * Routing status codes stored in the {@code status} column of the
+     * {@code providerLabRouting} table. The single-character {@link #getCode() code}
+     * is what is persisted; the human-readable {@link #getDescription() description}
+     * mirrors the labels historically shown in the lab/document inbox.
+     */
+    public enum Status {
+        NEW("N", "Not Acknowledged"),
+        ACKNOWLEDGED("A", "Acknowledged"),
+        FILED("F", "Filed but not Acknowledged"),
+        REMOVED("X", "Removed"),
+        NOT_APPLICABLE("U", "N/A");
+
+        private final String code;
+        private final String description;
+
+        Status(String code, String description) {
+            this.code = code;
+            this.description = description;
+        }
+
+        /**
+         * @return String the single-character code persisted in the database
+         */
+        public String getCode() {
+            return code;
+        }
+
+        /**
+         * @return String the human-readable description for this status
+         */
+        public String getDescription() {
+            return description;
+        }
+
+        /**
+         * Resolves a persisted status code to its {@link Status}.
+         *
+         * @param code String the single-character status code (may be null)
+         * @return Status the matching status, or null if the code is unknown
+         */
+        public static Status fromCode(String code) {
+            for (Status status : values()) {
+                if (status.code.equals(code)) {
+                    return status;
+                }
+            }
+            return null;
+        }
+    }
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;

--- a/src/main/java/ca/openosp/openo/lab/ca/all/upload/ProviderLabRouting.java
+++ b/src/main/java/ca/openosp/openo/lab/ca/all/upload/ProviderLabRouting.java
@@ -110,11 +110,11 @@ public class ProviderLabRouting {
                 routeMagic(labId, ((forwardProviders.get(j)).get(0)), labType);
             }
 
+        } else {
             // A routing already exists for this provider. If it was previously
             // removed (status "X"), forwarding to the same provider must re-link
             // the document by restoring the routing's status; otherwise the
             // document stays hidden and the forward appears to do nothing.
-        } else {
             boolean reactivated = false;
             for (ProviderLabRoutingModel routing : routings) {
                 if (ProviderLabRoutingModel.Status.REMOVED.getCode().equals(routing.getStatus())) {

--- a/src/main/java/ca/openosp/openo/lab/ca/all/upload/ProviderLabRouting.java
+++ b/src/main/java/ca/openosp/openo/lab/ca/all/upload/ProviderLabRouting.java
@@ -110,17 +110,33 @@ public class ProviderLabRouting {
                 routeMagic(labId, ((forwardProviders.get(j)).get(0)), labType);
             }
 
+            // A routing already exists for this provider. If it was previously
+            // removed (status "X"), forwarding to the same provider must re-link
+            // the document by restoring the routing's status; otherwise the
+            // document stays hidden and the forward appears to do nothing.
+        } else {
+            boolean reactivated = false;
+            for (ProviderLabRoutingModel routing : routings) {
+                if (ProviderLabRoutingModel.Status.REMOVED.getCode().equals(routing.getStatus())) {
+                    routing.setStatus(fr.getStatus(provider_no));
+                    routing.setTimestamp(new Date());
+                    providerLabRoutingDao.merge(routing);
+                    reactivated = true;
+                }
+            }
+
             // If the lab has already been sent to this providers check to make sure that
             // it is set as a new lab for at least one providers if AUTO_FILE_LABS=yes is not
             // set in the oscar.properties file
-        } else if (autoFileLabs == null || !autoFileLabs.equalsIgnoreCase("yes")) {
-            List<ProviderLabRoutingModel> moreRoutings = dao.findByLabNoTypeAndStatus(labId, labType, "N");
-            if (!moreRoutings.isEmpty()) {
-                ProviderLabRoutingModel plr = providerLabRoutingDao.findByLabNoAndLabType(labId, labType);
-                if (plr != null) {
-                    plr.setStatus("N");
-                    plr.setTimestamp(new Date());
-                    providerLabRoutingDao.merge(plr);
+            if (!reactivated && (autoFileLabs == null || !autoFileLabs.equalsIgnoreCase("yes"))) {
+                List<ProviderLabRoutingModel> moreRoutings = dao.findByLabNoTypeAndStatus(labId, labType, ProviderLabRoutingModel.Status.NEW.getCode());
+                if (!moreRoutings.isEmpty()) {
+                    ProviderLabRoutingModel plr = providerLabRoutingDao.findByLabNoAndLabType(labId, labType);
+                    if (plr != null) {
+                        plr.setStatus(ProviderLabRoutingModel.Status.NEW.getCode());
+                        plr.setTimestamp(new Date());
+                        providerLabRoutingDao.merge(plr);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Issue

After removing a provider from a document, forwarding the document back to that same provider did nothing - the page refreshed but the provider was not re-linked.

<img width="749" height="644" alt="image" src="https://github.com/user-attachments/assets/bbc75e1a-9911-4027-a90b-4e164b7f0306" />


## Cause

Removing a provider does not delete its `providerLabRouting` row; it sets the row's status to `"X"` (removed), and the linked-provider list hides rows with status `"X"`. The "Forward" action routes through `ProviderLabRouting.routeMagic()`, which only created a routing when none existed. Because an `"X"` row was already present, it took the no-op branch and never restored the status - so the provider stayed hidden.


## Fix

 - `routeMagic()` now checks for an existing `"X"` (removed) routing for the provider and restores its status, so re-forwarding re-links the document.
 - Added a `Status` enum (`N`, `A`, `F`, `X`, `U`) to `ProviderLabRoutingModel` and replaced the related status string literals.

## Summary by Sourcery

Fix forwarding a document to a previously removed provider so the provider is re-linked instead of remaining hidden.

Bug Fixes:
- Restore removed provider lab routings when a document is forwarded back to the same provider so the document becomes visible again.

Enhancements:
- Introduce a typed Status enum on ProviderLabRoutingModel and replace hard-coded status string literals in routing logic.