### PR TITLE
Fix Rx fax/print: 404, JS error, and collapsed print preview

### DIFF
--- a/dependencies-lock-modern.json
+++ b/dependencies-lock-modern.json
@@ -1461,11 +1461,11 @@
   }, {
     "groupId" : "net.java.dev.jna",
     "artifactId" : "jna",
-    "version" : "5.18.1",
+    "version" : "5.19.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:6Fmqe/AyJdrN0EPGf5OeklDj4iPvAxoMtncXl0Ni6d8r0dnXBOe1LnQIIw8B2Ba6t+wadF2c8v6ybr2DmAJsfg=="
+    "integrity" : "sha512:39wcr9Gn/7RBOMYsO3PSpIyW71rpXFEnWplfp31kueAGhvrLltpWXdRFH95prpe+2UHhjr5YzN2bXpC6V2iKDQ=="
   }, {
     "groupId" : "net.sf.ehcache",
     "artifactId" : "ehcache",

--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -1461,11 +1461,11 @@
   }, {
     "groupId" : "net.java.dev.jna",
     "artifactId" : "jna",
-    "version" : "5.18.1",
+    "version" : "5.19.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:6Fmqe/AyJdrN0EPGf5OeklDj4iPvAxoMtncXl0Ni6d8r0dnXBOe1LnQIIw8B2Ba6t+wadF2c8v6ybr2DmAJsfg=="
+    "integrity" : "sha512:39wcr9Gn/7RBOMYsO3PSpIyW71rpXFEnWplfp31kueAGhvrLltpWXdRFH95prpe+2UHhjr5YzN2bXpC6V2iKDQ=="
   }, {
     "groupId" : "net.sf.ehcache",
     "artifactId" : "ehcache",

--- a/src/main/java/ca/openosp/openo/form/pdfservlet/FrmCustomedPDFServlet.java
+++ b/src/main/java/ca/openosp/openo/form/pdfservlet/FrmCustomedPDFServlet.java
@@ -648,6 +648,10 @@ public class FrmCustomedPDFServlet extends HttpServlet {
                 listElem += newline;
             }
         }
+        // flush the final prescription; without this the last line (e.g. Qty/Repeats) is dropped when it has no trailing boundary token
+        if (!listElem.isEmpty()) {
+            listRx.add(listElem);
+        }
 
         // A0-A10, LEGAL, LETTER, HALFLETTER, _11x17, LEDGER, NOTE, B0-B5, ARCH_A-ARCH_E, FLSA
         // and FLSE

--- a/src/main/java/ca/openosp/openo/rx/RxPrintPreview2Action.java
+++ b/src/main/java/ca/openosp/openo/rx/RxPrintPreview2Action.java
@@ -338,7 +338,9 @@ public class RxPrintPreview2Action extends ActionSupport {
                     .replaceAll("\\\\n", "<br>");
         }
 
-        request.setAttribute("strRx", strRx.toString().replaceAll("\\\\n", "<br>"));
+        // Separate prescription lines with the platform line separator so the PDF servlet,
+        // which splits on System.getProperty("line.separator"), renders each on its own line.
+        request.setAttribute("strRx", strRx.toString().replace(";", System.lineSeparator()));
         request.setAttribute("strRxNoNewLines", strRxNoNewLines.toString());
         request.setAttribute("rxFullOutLines", rxFullOutLines);
     }

--- a/src/main/webapp/oscarRx/printRx/PreviewContent.jsp
+++ b/src/main/webapp/oscarRx/printRx/PreviewContent.jsp
@@ -85,7 +85,7 @@
 <body>
     <div topmargin="0" leftmargin="0" vlink="#0000FF" id="printableContent">
 
-    <form action="/form/formname" styleId="preview2Form">
+    <form action="${pageContext.request.contextPath}/form/formname.do" method="post" id="preview2Form">
         <input type="hidden" name="demographic_no" value="${sessionScope.RxSessionBean.demographicNo}"/>
         <table>
             <tr>
@@ -122,6 +122,7 @@
                                        value="<%= StringEscapeUtils.escapeHtml((String)request.getAttribute("patientDOBStr")) %>"/>
                                 <input type="hidden" name="pharmaFax" value="${requestScope.pharmacyFax}"/>
                                 <input type="hidden" name="pharmaName" value="${requestScope.pharmacyName}"/>
+                                <input type="hidden" name="pharmacyInfo" value="<%= Encode.forHtmlAttribute(request.getAttribute("prefPharmacyId") != null ? request.getAttribute("prefPharmacyId").toString() : "") %>"/>
                                 <input type="hidden" name="pracNo"
                                        value="<%= StringEscapeUtils.escapeHtml((String)request.getAttribute("pracNo")) %>"/>
                                 <input type="hidden" name="showPatientDOB" value="${requestScope.showPatientDOB}"/>
@@ -220,7 +221,8 @@
                                        value="${requestScope.signatureRequestId}"/>
                                 <img id="signature" style="width:260px; height:130px; object-fit: contain;"
                                      src="${requestScope.startimageUrl}" alt="digital_signature"/>
-                                <input type="hidden" name="imgFile" id="imgFile" value=""/>
+                                <input type="hidden" name="imgFile" id="imgFile" value=""
+                                       data-temp-path="<%= Encode.forHtmlAttribute(request.getAttribute("tempPath") != null ? request.getAttribute("tempPath").toString() : "") %>"/>
 
                                 <script type="text/javascript">
                                     var POLL_TIME = 2500;

--- a/src/main/webapp/oscarRx/printRx/PreviewContent.jsp
+++ b/src/main/webapp/oscarRx/printRx/PreviewContent.jsp
@@ -137,7 +137,7 @@
                                        value="<%=StringEscapeUtils.escapeHtml((String)request.getAttribute("patientChartNo"))%>"/>
                                 <input type="hidden" name="bandNumber" value="${requestScope.bandNumber}"/>
                                 <input type="hidden" name="patientPhone"
-                                       value="<fmt:message key="RxPreview.msgTel"/><%=StringEscapeUtils.escapeHtml((String)request.getAttribute("patientPhone")) %>"/>
+                                       value="<fmt:message key="RxPreview.msgTel"/>: <%=StringEscapeUtils.escapeHtml((String)request.getAttribute("patientPhone")) %>"/>
                                 <input type="hidden" name="rxDate"
                                        value="<%= StringEscapeUtils.escapeHtml((String)request.getAttribute("rxDateFormatted")) %>"/>
                                 <input type="hidden" name="sigDoctorName"

--- a/src/main/webapp/oscarRx/printRx/PrintPreview.js
+++ b/src/main/webapp/oscarRx/printRx/PrintPreview.js
@@ -52,11 +52,26 @@ function updateCurrentInteractions(myDrugRefEnabled) {
     }
 }
 
-function resetReRxDrugList(ctx) {
+/**
+ * Resolves the application context path used to build absolute request URLs.
+ * When a context path is supplied (typically threaded from the JSP via
+ * ${pageContext.request.contextPath}) it is returned unchanged; otherwise it is
+ * derived from the current location so callers that cannot inject it still produce
+ * absolute, deployment-correct URLs.
+ *
+ * @param {string} ctx the context path to use, if already known
+ * @returns {string} an absolute context path (origin + first path segment when derived)
+ */
+function resolveContextPath(ctx) {
     if (!ctx) {
         const contextPath = window.location.pathname.split('/')[1];
         ctx = window.location.origin + '/' + contextPath;
     }
+    return ctx;
+}
+
+function resetReRxDrugList(ctx) {
+    ctx = resolveContextPath(ctx);
     const url = ctx + "/oscarRx/deleteRx.do?parameterValue=clearReRxDrugList";
     const data = "";
     fetch(url, {
@@ -219,10 +234,7 @@ function writeToEncounter(ctx, print, text, prefPharmacy, providerNo, demographi
 }
 
 function openEncounter(providerNo, demographicNo, curProviderNo, userName, ctx) {
-    if (!ctx) {
-        const contextPath = window.location.pathname.split('/')[1];
-        ctx = window.location.origin + '/' + contextPath;
-    }
+    ctx = resolveContextPath(ctx);
     const windowProps = "height=710,width=1024,location=no,scrollbars=yes,menubars=no,toolbars=no,resizable=yes,screenX=50,screenY=50,top=20,left=20";
     const currentDate = new Date().toISOString().substring(0, 10);
     const url = ctx + "/oscarEncounter/IncomingEncounter.do?providerNo=" + providerNo + "&demographicNo=" + demographicNo + "&curProviderNo=" + curProviderNo + "&userName=" + userName + "&curDate=" + currentDate;
@@ -259,7 +271,14 @@ function refreshImage(imgURL, signatureImg) {
     if (document.getElementById("signature") != null) {
         document.getElementById("signature").src = imgURL;
     }
-    document.getElementById('imgFile').value = signatureImg;
+    // The PDF servlet loads the signature via Image.getInstance(imgFile), which expects a
+    // local file path (or absolute URL) - not the context-relative preview servlet URL.
+    // Submit the signature's temp file path (rendered server-side as data-temp-path),
+    // mirroring the working ViewScript2.jsp flow; fall back to the preview URL if absent.
+    const imgFileElement = document.getElementById('imgFile');
+    if (imgFileElement) {
+        imgFileElement.value = imgFileElement.dataset.tempPath || signatureImg;
+    }
 }
 
 function unloadMess() {
@@ -326,11 +345,18 @@ function closeRxPreviewBootstrapModal() {
     }
 }
 
-function onPrint2(method, scriptId, useSC, scAddress) {
+function onPrint2(method, scriptId, useSC, scAddress, ctx) {
+    ctx = resolveContextPath(ctx);
     const rxPageSize = $('printPageSize').value;
     console.log("rxPagesize  " + rxPageSize);
 
-    let action = "../form/createcustomedpdf?__title=Rx&__method=" + method + "&useSC=" + useSC + "&scAddress=" + scAddress + "&rxPageSize=" + rxPageSize + "&scriptId=" + scriptId;
+    let action = ctx
+        + "/form/createcustomedpdf?__title=Rx"
+        + "&__method=" + encodeURIComponent(method)
+        + "&useSC=" + encodeURIComponent(useSC)
+        + "&scAddress=" + encodeURIComponent(scAddress)
+        + "&rxPageSize=" + encodeURIComponent(rxPageSize)
+        + "&scriptId=" + encodeURIComponent(scriptId);
     document.getElementById("preview2Form").action = action;
     if (method !== "oscarRxFax") {
         document.getElementById("preview2Form").target = "_blank";
@@ -340,7 +366,7 @@ function onPrint2(method, scriptId, useSC, scAddress) {
     return true;
 }
 
-function sendFax(scriptId, signatureRequestId, useSC, scAddress) {
+function sendFax(scriptId, signatureRequestId, useSC, scAddress, ctx) {
     if ('function' === typeof window.onbeforeunload) {
         window.onbeforeunload = null;
     }
@@ -348,7 +374,7 @@ function sendFax(scriptId, signatureRequestId, useSC, scAddress) {
     document.getElementById('finalFax').value = faxNumber.options[faxNumber.selectedIndex].value;
     document.getElementById('pdfId').value = signatureRequestId;
 
-    onPrint2('oscarRxFax', scriptId, useSC, scAddress);
+    onPrint2('oscarRxFax', scriptId, useSC, scAddress, ctx);
 }
 
 function printPasteToParent(ctx, rxPasteAsterisk, prefPharmacy, demographicNo, providerName, providerNo, pharmacyName,

--- a/src/main/webapp/oscarRx/printRx/PrintPreview.jsp
+++ b/src/main/webapp/oscarRx/printRx/PrintPreview.jsp
@@ -182,10 +182,11 @@
                                         <button type="button"
                                                 class="btn btn-secondary mb-2 w-100"
                                                 id="faxButton"
-                                                onClick="sendFax(${param.scriptId},
-                                                    ${requestScope.signatureRequestId},
+                                                onClick="sendFax('${e:forJavaScript(param.scriptId)}',
+                                                    '${requestScope.signatureRequestId}',
                                                     ${requestScope.useSC != null ? requestScope.useSC : false},
-                                                    ${requestScope.selectedAddress != null ? requestScope.selectedAddress : ''}
+                                                    '${e:forJavaScript(requestScope.selectedAddress != null ? requestScope.selectedAddress : '')}',
+                                                    '${ctx}'
                                                         );"
                                                 <c:if test="${requestScope.isFaxDisabled}">
                                                     disabled="disabled"
@@ -205,10 +206,11 @@
                                                     '${requestScope.pharmacyName}',
                                                     '${requestScope.pharmacyFax}',
                                                     '${requestScope.prescribedBy}');
-                                                        sendFax(${param.scriptId},
-                                                    ${requestScope.signatureRequestId},
+                                                        sendFax('${e:forJavaScript(param.scriptId)}',
+                                                    '${requestScope.signatureRequestId}',
                                                     ${requestScope.useSC != null ? requestScope.useSC : false},
-                                                    ${requestScope.selectedAddress != null ? requestScope.selectedAddress : ''}
+                                                    '${e:forJavaScript(requestScope.selectedAddress != null ? requestScope.selectedAddress : '')}',
+                                                    '${ctx}'
                                                         );"
                                                 <c:if test="${requestScope.isFaxDisabled}">
                                                     disabled="disabled"
@@ -231,9 +233,9 @@
                                 <div class="form-group">
                                     <label for="additionalNotes"></label>
                                     <textarea id="additionalNotes" class="form-control mb-2"
-                                              onchange="addNotes(${param.scriptId});"></textarea>
+                                              onchange="addNotes('${e:forJavaScript(param.scriptId)}');"></textarea>
                                     <button type="button" class="btn btn-primary"
-                                            onclick="addNotes(${param.scriptId});">
+                                            onclick="addNotes('${e:forJavaScript(param.scriptId)}');">
                                         Additional Rx Notes
                                     </button>
                                 </div>

--- a/src/main/webapp/oscarRx/printRx/PrintPreview.jsp
+++ b/src/main/webapp/oscarRx/printRx/PrintPreview.jsp
@@ -26,6 +26,7 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@ taglib prefix="oscar" uri="/oscarPropertiestag" %>
+<%@ taglib uri="https://www.owasp.org/index.php/OWASP_Java_Encoder_Project" prefix="e" %>
 <%@ page import="ca.openosp.openo.commn.model.enumerator.ModuleType" %>
 <%@ page import="ca.openosp.openo.utility.DigitalSignatureUtils" %>
 <fmt:setBundle basename="oscarResources"/>


### PR DESCRIPTION
## Summary

Restores the ability to **fax and print a prescription** end-to-end. The faxing flow was failing at several points: a 404 before the PDF could even be generated, a JavaScript type error in the preview, and — most visibly — a print preview / faxed PDF that rendered with prescription lines collapsed together, the **Qty/Repeats** line missing, and the pharmacy **"ATTENTION:"** header absent.

This PR fixes each defect at its root and keeps the PDF output faithful to the pre-refactor layout.

Original PR [#2454 ](https://github.com/openo-beta/Open-O/pull/2457)

## Problem

Faxing/printing an Rx was broken by a chain of issues, each unmasking the next:

1. **404 on fax** — a relative fax path was resolved without the application context path, so the request 404'd from the JSP before the servlet ran.
2. **JS type error** — a leftover Struts 1 `styleId` usage produced a JavaScript type error when initiating the fax.
3. **Collapsed preview / PDF** — even once the PDF generated, its content was wrong:
   - prescription lines ran together instead of breaking onto separate lines;
   - the **Qty/Repeats** line (the last line of each prescription) was silently dropped;
   - the pharmacy **"ATTENTION:"** block never appeared on the faxed Rx.

## Solution

### 1. Context path resolution (404)
Resolve the fax path against the application context path, with a defensive fallback, so the request reaches the PDF servlet instead of 404'ing. Shared into a small helper to avoid duplication.

### 2. Struts 1 `styleId` removal (JS error)
Drop the legacy `styleId` usage that triggered the JavaScript type error in the preview.

### 3. Collapsed preview / PDF — three root-cause fixes

- **Prescription line breaks** (`RxPrintPreview2Action.java`)
  `strRx` is the input to the **PDF** servlet, which separates lines on real newline characters. A refactor had swapped its transform for the **HTML preview's** treatment (`\n → <br>`), which (a) produces markup the PDF can't use and (b) was a no-op against the actual data — leaving `strRx` semicolon-delimited with zero newlines, so the PDF couldn't break lines.
  **Fix:** restore the correct PDF transform, converting the `;` delimiters back into real newlines (`replace(";", "\n")`). The HTML-preview attributes (`<br>`-based) are left untouched.

- **Dropped trailing line — Qty/Repeats** (`FrmCustomedPDFServlet.java`)
  The servlet's prescription parser only moves an accumulated line block into the render list when it hits a boundary token, and it had **no flush after the loop ends**. The whole feature was accidentally relying on a trailing separator (`;;`) to emit that final boundary. A later refactor switched to `StringJoiner(";;")`, which drops the trailing separator — so the **last line of each prescription (Qty/Repeats) was never flushed** and silently disappeared from the PDF.
  **Fix:** add a guarded final flush after the parse loop. It's safe for every caller (if the input already ended on a boundary, the buffer is empty and nothing is added — no duplicates), and it removes the dependency on the fragile trailing-token behavior. This also protects the legacy live-fax path that shares the same servlet.

- **Pharmacy "ATTENTION:" block** (`PreviewContent.jsp`)
  The ATTENTION header is rendered by the PDF servlet from a `pharmacyInfo` id. That field historically lived only in the legacy `ViewScript2.jsp` flow (JS-injected when a pharmacy is selected). When the modern print/fax preview was extracted into `PreviewContent.jsp`, the field was never ported — a migration gap, not a deleted line.
  **Fix:** add the `pharmacyInfo` hidden field to the modern preview (OWASP-encoded via `<c:out>`). It is empty when no pharmacy is associated, in which case the servlet simply skips the block.

> An earlier commit experimented with submitting the fax via AJAX and containing the confirmation inside the preview modal; this was **reverted** per a team decision, so the net behavior here is unchanged on that front.

## Files changed (Rx fax/print)

- `src/main/java/ca/openosp/openo/form/pdfservlet/FrmCustomedPDFServlet.java` — final flush so the last prescription line (Qty/Repeats) renders.
- `src/main/java/ca/openosp/openo/rx/RxPrintPreview2Action.java` — restore `strRx` `;`→newline transform for the PDF.
- `src/main/webapp/oscarRx/printRx/PreviewContent.jsp` — port the `pharmacyInfo` field for the ATTENTION block.
- `src/main/webapp/oscarRx/printRx/PrintPreview.js`, `PrintPreview.jsp`, `WEB-INF/classes/struts.xml` — context-path resolution (404) and Struts 1 `styleId` removal (JS error).

## Testing

- Faxed and printed prescriptions render correctly: each prescription on its own line, **Qty/Repeats** present, and the pharmacy **"ATTENTION:"** header shown when a pharmacy is associated.
- Verified the parse-loop fix does not duplicate output for callers that still send a trailing separator (legacy `ViewScript2.jsp` / `Preview2.jsp` live-fax path), keeping the faxed layout consistent with the pre-refactor output.

## Summary by Sourcery

Fix Rx fax and print prescription flows to restore correct PDF generation, line rendering, and pharmacy attention metadata, while ensuring URLs resolve with the proper application context path.

Bug Fixes:
- Resolve Rx fax/print requests against an explicit context path to prevent 404 errors when invoking the PDF servlet.
- Remove legacy Struts-specific attributes and escape dynamic parameters in the print preview JSP to eliminate JavaScript errors in the fax/print UI.
- Ensure prescription text for the PDF uses real line separators and flush the final parsed prescription entry so each line, including Qty/Repeats, renders correctly.
- Restore inclusion of pharmacy metadata, including the ATTENTION header and digital signature image path, in the generated fax/print PDFs by wiring hidden fields correctly in the preview form.

Enhancements:
- Centralize context-path resolution in the Rx print preview JavaScript to produce deployment-safe absolute URLs and reuse across multiple actions.