### PR TITLE
Fix: auto formatting of patient DOB search field is too aggresive

### DIFF
--- a/src/main/webapp/demographic/demographiccontrol.jsp
+++ b/src/main/webapp/demographic/demographiccontrol.jsp
@@ -33,8 +33,6 @@
 <%@page import="ca.openosp.openo.web.DemographicSearchHelper" %>
 <%@page import="java.util.GregorianCalendar" %>
 <%@page import="ca.openosp.openo.caisi_integrator.ws.MatchingDemographicParameters" %>
-<%@ page import="java.io.UnsupportedEncodingException" %>
-<%@ page import="java.net.URLEncoder" %>
 
 
 <%@ page import="ca.openosp.OscarProperties" %>
@@ -68,19 +66,13 @@
         
         if (keyword == null) {
             keyword = ""; // Default to an empty string
-        } else {
-            // Encode the keyword to ensure any special characters (like '%') are properly encoded
-            try {
-                // If keyword contains a '%' sign, encode it as %25
-                keyword = java.net.URLEncoder.encode(keyword, "UTF-8");
-            } catch (UnsupportedEncodingException e) {
-                e.printStackTrace(); // Log the error or handle it
-                keyword = ""; // Default to empty string if error occurs
-            }
         }
-       
-        if (keyword.indexOf("*") != -1 || keyword.indexOf("%") != -1) 
-        {
+
+        // A '%' or '*' in the keyword signals a wildcard search. The keyword must be
+        // used verbatim here - it feeds the integrator match parameters and is bound as
+        // a SQL parameter downstream, so URL-encoding it would corrupt wildcards (and
+        // characters such as apostrophes in names).
+        if (keyword.indexOf("*") != -1 || keyword.indexOf("%") != -1) {
             regularexp = "like";
         }
 

--- a/src/main/webapp/demographic/zdemographicfulltitlesearch.jsp
+++ b/src/main/webapp/demographic/zdemographicfulltitlesearch.jsp
@@ -63,36 +63,61 @@
     }
     
     function formatDateInput(input) {
-        // Remove any non-digit characters
-        var value = input.value.replace(/\D/g, '');
-        
-        // Format as YYYY-MM-DD
-        if (value.length > 0) {
-            // Ensure we only take the first 8 digits
-            value = value.substring(0, Math.min(8, value.length));
-            
-            // Add hyphens
-            if (value.length > 4) {
-                value = value.substring(0, 4) + '-' + value.substring(4);
-            }
-            if (value.length > 7) {
-                value = value.substring(0, 7) + '-' + value.substring(7);
+        var old = input.value;
+        var atEnd = input.selectionStart === old.length;
+        // Keep only digits, the yyyy-mm-dd separators, and the % wildcard.
+        var out = old.replace(/[^0-9%-]/g, '');
+
+        // Auto-insert hyphens only when a plain date is typed at the end of the field.
+        // Wildcards (%) and mid-field edits are left as typed, so % survives and the
+        // caret is never yanked to the end.
+        if (atEnd && out.indexOf('%') === -1) {
+            var d = out.replace(/-/g, '').substring(0, 8);
+            if (d.length > 6) out = d.substring(0, 4) + '-' + d.substring(4, 6) + '-' + d.substring(6);
+            else if (d.length > 4) out = d.substring(0, 4) + '-' + d.substring(4);
+            else out = d;
+            // Preserve a hyphen the user just typed so 2024-07- can be built before a %.
+            var typedHyphen = old.charAt(input.selectionStart - 1) === '-';
+            if (typedHyphen && out.charAt(out.length - 1) !== '-' && (d.length === 4 || d.length === 6)) {
+                out += '-';
             }
         }
-        
-        input.value = value;
+
+        if (out === old) return;
+
+        // Restore the caret after the same number of non-hyphen characters (or at the end
+        // when appending) instead of letting it jump.
+        var keep = old.slice(0, input.selectionStart).replace(/-/g, '').length;
+        input.value = out;
+        if (atEnd) {
+            input.setSelectionRange(out.length, out.length);
+            return;
+        }
+        var pos = 0, seen = 0;
+        while (pos < out.length && seen < keep) {
+            if (out.charAt(pos) !== '-') seen++;
+            pos++;
+        }
+        input.setSelectionRange(pos, pos);
     }
-    
+
     function checkTypeIn() {
         var dob = document.titlesearch.keyword;
         if (document.titlesearch.search_mode.value == "search_dob") {
-            // Remove hyphens for validation
-            var dobValue = dob.value.replace(/-/g, '');
-            
-            // Check if we have enough digits
-            if (dobValue.length < 8) {
-                alert("Date format must be YYYY-MM-DD");
-                return false;
+            if (dob.value.indexOf('%') !== -1) {
+                // Wildcard search (e.g. everyone born in July 2024). The backend splits
+                // the value on '-' into year/month/day, so pad any missing trailing
+                // groups with '%': 2024-07% or 2024-% become 2024-07%-% / 2024-%-%.
+                var parts = dob.value.split('-');
+                while (parts.length < 3) parts.push('%');
+                dob.value = parts.slice(0, 3).join('-');
+            } else {
+                // A non-wildcard DOB search still needs a full yyyy-mm-dd date
+                var dobValue = dob.value.replace(/-/g, '');
+                if (dobValue.length < 8) {
+                    alert("Date format must be YYYY-MM-DD (use % as a wildcard, e.g. 2024-07-%)");
+                    return false;
+                }
             }
         }
         return true;


### PR DESCRIPTION
## Summary

  Fixes the patient DOB search so wildcard (`%`) searches work again, and so
  editing the query no longer yanks the cursor to the end of the field. Touches
  the search box (`zdemographicfulltitlesearch.jsp`) and the search controller
  (`demographiccontrol.jsp`).

Original PR: https://github.com/openo-beta/Open-O/pull/2450

  ## Problem

  The DOB search field auto-formats input as `yyyy-mm-dd`, but the formatting was
  too aggressive and caused two regressions:

  1. **Wildcards were stripped.** `formatDateInput` ran `value.replace(/\D/g, '')`
     on every keystroke, deleting the `%` character outright — so a search like
     `2024-07-%` (everyone born July 2024) was impossible; the `%` vanished as you
     typed. `checkTypeIn` then also required a full 8-digit date, rejecting any
     partial/wildcard entry.
  2. **The cursor jumped to the end on every edit.** `formatDateInput` reassigned
     `input.value` on each keystroke without restoring the caret, so editing from
     the middle of the text (e.g. changing `2026` → `2025`) bounced the cursor to
     the end and made mid-field edits painful.

  Separately, the controller URL-encoded the keyword
  (`URLEncoder.encode(keyword, "UTF-8")`), which turned `%` into `%25` and
  corrupted other legitimate characters (e.g. apostrophes in names), further
  breaking wildcard matching.

  ## Solution

  **Frontend (`zdemographicfulltitlesearch.jsp`):**
  - Rewrote `formatDateInput` to keep digits, hyphens, and `%`. It now auto-inserts
    hyphens only when a plain date is typed at the *end* of the field, and it
    preserves the caret on mid-field edits instead of forcing it to the end.
  - Rewrote `checkTypeIn` so a `%` triggers a wildcard search: the value is padded
    to three hyphen-separated segments (`2024-07` → `2024-07-%`, `2024` →
    `2024-%-%`) to match what the backend expects. Non-wildcard searches still
    require a complete `yyyy-mm-dd` date.

  **Backend (`demographiccontrol.jsp`):**
  - Removed the `URLEncoder.encode(keyword)` call so `%` (and characters like
    apostrophes) reach the query intact. The keyword is bound as a SQL parameter
    downstream, so encoding it was both unnecessary and corrupting. Wildcard
    detection is preserved.

  ## How it works end-to-end

  The live DOB query runs in `demographicsearchresults.jsp` via
  `DemographicDao.searchDemographicByDOB`, which splits the keyword on `-` into
  exactly three `LIKE` parameters (year/month/day). Padding to `2024-07-%`
  therefore produces `year LIKE '2024%' AND month LIKE '07%' AND day LIKE '%%'` →
  all patients born July 2024. Note: `%` is the wildcard (standard SQL `LIKE`); the
  results page and the add-a-record page both `<%@ include %>` this same search
  box, so the fix covers those screens too.

  ## Testing

  Verified manually:
  - Full dates (`2024-07-15`) — auto-hyphenation and submission still work.
  - Wildcard searches (`2024-07-%`, `2024-%`) — return the expected patients.
  - Mid-field edits (`2026` → `2025`) — caret stays where it was, after the edit.

## Summary by Sourcery

Relax auto-formatting of the patient DOB search field and preserve wildcard semantics while ensuring valid date input.

New Features:
- Allow DOB searches to use '%' wildcards in the date field, automatically padding missing year/month/day segments for wildcard queries.

Bug Fixes:
- Prevent aggressive date auto-formatting from disrupting mid-field edits, wildcard characters, and caret position in the DOB search field.
- Stop URL-encoding search keywords so that wildcard characters and special characters (such as apostrophes) are preserved for downstream matching and SQL binding.

Enhancements:
- Improve DOB search validation message to explain the supported YYYY-MM-DD format and wildcard usage.

## Summary by Sourcery

Relax auto-formatting and validation of the patient DOB search field so wildcard searches work correctly and editing is not disruptive, while ensuring the backend preserves wildcard and special characters in search keywords.

New Features:
- Support DOB wildcard searches in the UI by interpreting '%' in the date field and padding missing year/month/day segments before submission.

Bug Fixes:
- Prevent the DOB search field auto-formatting from stripping '%' and forcing the caret to the end of the field during mid-text edits.
- Stop URL-encoding search keywords in the demographic controller so wildcard and special characters reach downstream matching and SQL binding intact.

Enhancements:
- Improve DOB search validation messaging to document the required YYYY-MM-DD format and how to use '%' as a wildcard.