### PR TITLE
Fix: edge cases where session filter removing already saved med stashes were not firing due to redirects directly to SearchDrug3.jsp

### DIFF
--- a/src/main/java/ca/openosp/openo/prescript/pageUtil/RxSessionFilter.java
+++ b/src/main/java/ca/openosp/openo/prescript/pageUtil/RxSessionFilter.java
@@ -30,7 +30,7 @@ public class RxSessionFilter implements Filter {
     private static final Logger logger = MiscUtils.getLogger();
     private static final String LEGACY_KEY = "RxSessionBean";
     private static final String PATIENT_KEY = "Patient";
-    private static final String STAGING_PAGE_SUFFIX = "/oscarRx/SearchDrug3.jsp";
+    private static final String STAGING_PAGE_PATH = "/oscarRx/SearchDrug3.jsp";
 
     /**
      * {@inheritDoc}
@@ -112,7 +112,7 @@ public class RxSessionFilter implements Filter {
             // persisted by a completed save (unsaved drafts, drugId == 0, are kept).
             // Action entries (e.g. choosePatient.do) forward here and reconcile themselves;
             // this REQUEST-scoped filter skips forwards, so there is no double-clear.
-            if (request.getRequestURI().endsWith(STAGING_PAGE_SUFFIX)) {
+            if (STAGING_PAGE_PATH.equals(request.getServletPath())) {
                 RxSessionBean currentBean = (RxSessionBean) session.getAttribute(LEGACY_KEY);
                 if (currentBean != null) {
                     currentBean.removePersistedStashItems();

--- a/src/main/java/ca/openosp/openo/prescript/pageUtil/RxSessionFilter.java
+++ b/src/main/java/ca/openosp/openo/prescript/pageUtil/RxSessionFilter.java
@@ -30,6 +30,7 @@ public class RxSessionFilter implements Filter {
     private static final Logger logger = MiscUtils.getLogger();
     private static final String LEGACY_KEY = "RxSessionBean";
     private static final String PATIENT_KEY = "Patient";
+    private static final String STAGING_PAGE_SUFFIX = "/oscarRx/SearchDrug3.jsp";
 
     /**
      * {@inheritDoc}
@@ -104,6 +105,17 @@ public class RxSessionFilter implements Filter {
                             session.setAttribute(PATIENT_KEY, patient);
                         }
                     }
+                }
+            }
+
+            // On a direct browser load/refresh of the staging page, drop drugs already
+            // persisted by a completed save (unsaved drafts, drugId == 0, are kept).
+            // Action entries (e.g. choosePatient.do) forward here and reconcile themselves;
+            // this REQUEST-scoped filter skips forwards, so there is no double-clear.
+            if (request.getRequestURI().endsWith(STAGING_PAGE_SUFFIX)) {
+                RxSessionBean currentBean = (RxSessionBean) session.getAttribute(LEGACY_KEY);
+                if (currentBean != null) {
+                    currentBean.removePersistedStashItems();
                 }
             }
         }


### PR DESCRIPTION
## Summary

Fix edge case issues where the session filter was not removing already saved med stashes due to redirects directly to SearchDrug3.jsp

Original PR: https://github.com/openo-beta/Open-O/pull/2458

## Summary by Sourcery

Bug Fixes:
- Clear persisted medication stash items on direct loads or refreshes of the SearchDrug3.jsp staging page while preserving unsaved drafts.