### PR TITLE
Fix: Rx note giving an error if pharmacy name contains double quotes

### DIFF
--- a/src/main/java/ca/openosp/openo/rx/RxPrintPreview2Action.java
+++ b/src/main/java/ca/openosp/openo/rx/RxPrintPreview2Action.java
@@ -534,7 +534,10 @@ public class RxPrintPreview2Action extends ActionSupport {
                 // onClick handlers). forJavaScript escapes both ' and " (and \, /, <, >, &), which also
                 // prevents a double quote in the pharmacy name from terminating the surrounding
                 // double-quoted onClick HTML attribute (issue #2451).
-                prefPharmacy = Encode.forJavaScript(pharmacy.getName().trim());
+                // Guard against a null name: getName() may be null, and Encode.forJavaScript(null)
+                // would render the literal string "null" rather than an empty value.
+                String name = pharmacy.getName();
+                prefPharmacy = Encode.forJavaScript(name != null ? name.trim() : "");
                 prefPharmacyId = String.valueOf(pharmacy.getId()).trim();
 
                 request.setAttribute("prefPharmacy", prefPharmacy);
@@ -651,8 +654,10 @@ public class RxPrintPreview2Action extends ActionSupport {
 
         request.setAttribute("pharmacyName", Encode.forJavaScript(pharmacy != null ? pharmacy.getName() : ""));
         // Free-text pharmacy field edited on the same form as the name; encode for the JS-string onClick
-        // context so a quote can't break the handler (same class of issue as #2451).
-        request.setAttribute("pharmacyFax", Encode.forJavaScript(pharmacy != null ? pharmacy.getFax() : ""));
+        // context so a quote can't break the handler (same class of issue as #2451). Guard the null fax
+        // case explicitly: Encode.forJavaScript(null) would emit the literal string "null".
+        String pharmacyFax = (pharmacy != null && pharmacy.getFax() != null) ? pharmacy.getFax() : "";
+        request.setAttribute("pharmacyFax", Encode.forJavaScript(pharmacyFax));
     }
 
     /**

--- a/src/main/java/ca/openosp/openo/rx/RxPrintPreview2Action.java
+++ b/src/main/java/ca/openosp/openo/rx/RxPrintPreview2Action.java
@@ -652,7 +652,9 @@ public class RxPrintPreview2Action extends ActionSupport {
         String timeStamp = new SimpleDateFormat("dd-MMM-yyyy hh:mm a").format(Calendar.getInstance().getTime());
         request.setAttribute("timeStamp", timeStamp);
 
-        request.setAttribute("pharmacyName", Encode.forJavaScript(pharmacy != null ? pharmacy.getName() : ""));
+        // Guard getName() null as well as pharmacy null: Encode.forJavaScript(null) emits the literal "null".
+        String pharmacyName = (pharmacy != null && pharmacy.getName() != null) ? pharmacy.getName() : "";
+        request.setAttribute("pharmacyName", Encode.forJavaScript(pharmacyName));
         // Free-text pharmacy field edited on the same form as the name; encode for the JS-string onClick
         // context so a quote can't break the handler (same class of issue as #2451). Guard the null fax
         // case explicitly: Encode.forJavaScript(null) would emit the literal string "null".

--- a/src/main/java/ca/openosp/openo/rx/RxPrintPreview2Action.java
+++ b/src/main/java/ca/openosp/openo/rx/RxPrintPreview2Action.java
@@ -371,9 +371,8 @@ public class RxPrintPreview2Action extends ActionSupport {
         request.setAttribute("sessionBean", sessionBean);
         request.setAttribute("reprint", reprint);
 
-        // Encode for the JavaScript-string context (PrintPreview.jsp onClick handlers); guards against a
-        // quote in the provider name breaking the handler, same class of issue as #2451.
-        request.setAttribute("providerName", Encode.forJavaScript(ca.openosp.openo.providers.data.ProviderData.getProviderName(sessionBean.getProviderNo())));
+        // Store the raw value; encoding is applied per-context at the JSP output points (issue #2451).
+        request.setAttribute("providerName", ca.openosp.openo.providers.data.ProviderData.getProviderName(sessionBean.getProviderNo()));
         request.setAttribute("providerNo", sessionBean.getProviderNo());
 
         return sessionBean;
@@ -530,14 +529,10 @@ public class RxPrintPreview2Action extends ActionSupport {
         if (pharmacyId != null && !"null".equalsIgnoreCase(pharmacyId)) {
             pharmacy = pharmacyData.getPharmacy(pharmacyId);
             if (pharmacy != null) {
-                // Encode for the JavaScript-string context the value is rendered into (PrintPreview.jsp
-                // onClick handlers). forJavaScript escapes both ' and " (and \, /, <, >, &), which also
-                // prevents a double quote in the pharmacy name from terminating the surrounding
-                // double-quoted onClick HTML attribute (issue #2451).
-                // Guard against a null name: getName() may be null, and Encode.forJavaScript(null)
-                // would render the literal string "null" rather than an empty value.
+                // Store the raw name; encoding is applied per-context at the JSP output points (issue
+                // #2451). Guard against a null name so the attribute is never null.
                 String name = pharmacy.getName();
-                prefPharmacy = Encode.forJavaScript(name != null ? name.trim() : "");
+                prefPharmacy = name != null ? name.trim() : "";
                 prefPharmacyId = String.valueOf(pharmacy.getId()).trim();
 
                 request.setAttribute("prefPharmacy", prefPharmacy);
@@ -652,14 +647,14 @@ public class RxPrintPreview2Action extends ActionSupport {
         String timeStamp = new SimpleDateFormat("dd-MMM-yyyy hh:mm a").format(Calendar.getInstance().getTime());
         request.setAttribute("timeStamp", timeStamp);
 
-        // Guard getName() null as well as pharmacy null: Encode.forJavaScript(null) emits the literal "null".
+        // Store raw values; these attributes are consumed in two contexts -- the PrintPreview.jsp onClick
+        // (JavaScript string) and the PreviewContent.jsp hidden inputs (HTML attribute, submitted to the
+        // PDF servlet) -- so each output point applies its own context-appropriate encoding (issue #2451).
+        // Guard the null cases so the attributes are never null.
         String pharmacyName = (pharmacy != null && pharmacy.getName() != null) ? pharmacy.getName() : "";
-        request.setAttribute("pharmacyName", Encode.forJavaScript(pharmacyName));
-        // Free-text pharmacy field edited on the same form as the name; encode for the JS-string onClick
-        // context so a quote can't break the handler (same class of issue as #2451). Guard the null fax
-        // case explicitly: Encode.forJavaScript(null) would emit the literal string "null".
+        request.setAttribute("pharmacyName", pharmacyName);
         String pharmacyFax = (pharmacy != null && pharmacy.getFax() != null) ? pharmacy.getFax() : "";
-        request.setAttribute("pharmacyFax", Encode.forJavaScript(pharmacyFax));
+        request.setAttribute("pharmacyFax", pharmacyFax);
     }
 
     /**

--- a/src/main/java/ca/openosp/openo/rx/RxPrintPreview2Action.java
+++ b/src/main/java/ca/openosp/openo/rx/RxPrintPreview2Action.java
@@ -371,7 +371,9 @@ public class RxPrintPreview2Action extends ActionSupport {
         request.setAttribute("sessionBean", sessionBean);
         request.setAttribute("reprint", reprint);
 
-        request.setAttribute("providerName", ca.openosp.openo.providers.data.ProviderData.getProviderName(sessionBean.getProviderNo()));
+        // Encode for the JavaScript-string context (PrintPreview.jsp onClick handlers); guards against a
+        // quote in the provider name breaking the handler, same class of issue as #2451.
+        request.setAttribute("providerName", Encode.forJavaScript(ca.openosp.openo.providers.data.ProviderData.getProviderName(sessionBean.getProviderNo())));
         request.setAttribute("providerNo", sessionBean.getProviderNo());
 
         return sessionBean;
@@ -528,10 +530,12 @@ public class RxPrintPreview2Action extends ActionSupport {
         if (pharmacyId != null && !"null".equalsIgnoreCase(pharmacyId)) {
             pharmacy = pharmacyData.getPharmacy(pharmacyId);
             if (pharmacy != null) {
-                prefPharmacy = pharmacy.getName().replace("'", "\\'");
-                prefPharmacyId = String.valueOf(pharmacy.getId());
-                prefPharmacy = prefPharmacy.trim();
-                prefPharmacyId = prefPharmacyId.trim();
+                // Encode for the JavaScript-string context the value is rendered into (PrintPreview.jsp
+                // onClick handlers). forJavaScript escapes both ' and " (and \, /, <, >, &), which also
+                // prevents a double quote in the pharmacy name from terminating the surrounding
+                // double-quoted onClick HTML attribute (issue #2451).
+                prefPharmacy = Encode.forJavaScript(pharmacy.getName().trim());
+                prefPharmacyId = String.valueOf(pharmacy.getId()).trim();
 
                 request.setAttribute("prefPharmacy", prefPharmacy);
                 request.setAttribute("prefPharmacyId", prefPharmacyId);
@@ -646,7 +650,9 @@ public class RxPrintPreview2Action extends ActionSupport {
         request.setAttribute("timeStamp", timeStamp);
 
         request.setAttribute("pharmacyName", Encode.forJavaScript(pharmacy != null ? pharmacy.getName() : ""));
-        request.setAttribute("pharmacyFax", pharmacy != null ? pharmacy.getFax() : "");
+        // Free-text pharmacy field edited on the same form as the name; encode for the JS-string onClick
+        // context so a quote can't break the handler (same class of issue as #2451).
+        request.setAttribute("pharmacyFax", Encode.forJavaScript(pharmacy != null ? pharmacy.getFax() : ""));
     }
 
     /**

--- a/src/main/webapp/oscarRx/printRx/PreviewContent.jsp
+++ b/src/main/webapp/oscarRx/printRx/PreviewContent.jsp
@@ -119,9 +119,9 @@
                                 <input type="hidden" name="patientName"
                                        value="<%= StringEscapeUtils.escapeHtml(((RxPatientData.Patient)request.getAttribute("patient")).getFirstName())+ " " +StringEscapeUtils.escapeHtml(((RxPatientData.Patient)request.getAttribute("patient")).getSurname()) %>"/>
                                 <input type="hidden" name="patientDOB"
-                                       value="<%= StringEscapeUtils.escapeHtml((String)request.getAttribute("patientDOBStr")) %>"/>
-                                <input type="hidden" name="pharmaFax" value="${requestScope.pharmacyFax}"/>
-                                <input type="hidden" name="pharmaName" value="${requestScope.pharmacyName}"/>
+                                       value="<%= Encode.forHtml((String)request.getAttribute("patientDOBStr")) %>"/>
+                                <input type="hidden" name="pharmaFax" value="<%= Encode.forHtmlAttribute(request.getAttribute("pharmacyFax") != null ? request.getAttribute("pharmacyFax").toString() : "") %>"/>
+                                <input type="hidden" name="pharmaName" value="<%= Encode.forHtmlAttribute(request.getAttribute("pharmacyName") != null ? request.getAttribute("pharmacyName").toString() : "") %>"/>
                                 <input type="hidden" name="pharmacyInfo" value="<%= Encode.forHtmlAttribute(request.getAttribute("prefPharmacyId") != null ? request.getAttribute("prefPharmacyId").toString() : "") %>"/>
                                 <input type="hidden" name="pracNo"
                                        value="<%= StringEscapeUtils.escapeHtml((String)request.getAttribute("pracNo")) %>"/>

--- a/src/main/webapp/oscarRx/printRx/PrintPreview.jsp
+++ b/src/main/webapp/oscarRx/printRx/PrintPreview.jsp
@@ -157,12 +157,12 @@
                                         <c:if test="${requestScope.reprint eq 'true'}">disabled</c:if>
                                         onClick="printPasteToParent('${ctx}',
                                                 ${requestScope.rxPasteAsterisk},
-                                                '${requestScope.prefPharmacy}',
+                                                '${e:forJavaScript(requestScope.prefPharmacy)}',
                                                 '${requestScope.demographicNo}',
-                                                '${requestScope.providerName}',
+                                                '${e:forJavaScript(requestScope.providerName)}',
                                                 '${requestScope.providerNo}',
-                                                '${requestScope.pharmacyName}',
-                                                '${requestScope.pharmacyFax}',
+                                                '${e:forJavaScript(requestScope.pharmacyName)}',
+                                                '${e:forJavaScript(requestScope.pharmacyFax)}',
                                                 '${requestScope.prescribedBy}');">
                                     Print &amp; Add to encounter note
                                 </button>
@@ -200,12 +200,12 @@
                                                 id="faxPasteButton"
                                                 onClick="faxPasteToParent('${ctx}',
                                                     ${requestScope.rxPasteAsterisk},
-                                                    '${requestScope.prefPharmacy}',
+                                                    '${e:forJavaScript(requestScope.prefPharmacy)}',
                                                     '${requestScope.demographicNo}',
-                                                    '${requestScope.providerName}',
+                                                    '${e:forJavaScript(requestScope.providerName)}',
                                                     '${requestScope.providerNo}',
-                                                    '${requestScope.pharmacyName}',
-                                                    '${requestScope.pharmacyFax}',
+                                                    '${e:forJavaScript(requestScope.pharmacyName)}',
+                                                    '${e:forJavaScript(requestScope.pharmacyFax)}',
                                                     '${requestScope.prescribedBy}');
                                                         sendFax('${e:forJavaScript(param.scriptId)}',
                                                     '${requestScope.signatureRequestId}',


### PR DESCRIPTION
## Summary

A double quote in a pharmacy name broke the **Print & Add to encounter note** button —
clicking it did nothing. The fix applies **context-appropriate OWASP encoding at each JSP
output point** so pharmacy/provider values are safe in both the JavaScript `onClick` handlers
and the HTML hidden inputs that get submitted to the prescription PDF servlet.

Files changed:
- `src/main/java/ca/openosp/openo/rx/RxPrintPreview2Action.java`
- `src/main/webapp/oscarRx/printRx/PrintPreview.jsp`
- `src/main/webapp/oscarRx/printRx/PreviewContent.jsp`

Original PR: https://github.com/openo-beta/Open-O/pull/2459

## Problem

When a patient's preferred pharmacy name contained a double quote (`"`), clicking
**Print & Add to encounter note** (and the **Fax + paste** button) did nothing — neither the
print dialog nor the encounter window opened.

Root cause: in `PrintPreview.jsp`, the pharmacy name was interpolated **raw** into a
double-quoted `onClick` HTML attribute:

```jsp
onClick="printPasteToParent('${ctx}', ..., '${requestScope.prefPharmacy}', ...);">
```

The value reaching the JSP was only escaped for single quotes in the action
(`pharmacy.getName().replace("'", "\\'")`), so a `"` passed through raw, closed the
`onClick="..."` attribute early, and left a truncated, malformed handler — making the button
a no-op.

A second, related defect surfaced during review: `pharmacyName` and `pharmacyFax` are
**dual-context** — they are used in the `onClick` (JavaScript string) **and** in hidden inputs
in `PreviewContent.jsp` that are submitted to `FrmCustomedPDFServlet` (`pharmaName`/`pharmaFax`).
JavaScript-escaping these at the Java source would submit escaped literals
(e.g. `Test \x22Quote\x22 Pharmacy`) to the PDF servlet instead of the real name.

## Solution

Encode at the **output**, per context, rather than at the Java source — matching the pattern
already used by the sibling hidden inputs (`patientName` → `Encode.forHtml`, `pharmacyInfo` →
`Encode.forHtmlAttribute`).

**`RxPrintPreview2Action.java`** — store the **raw** (null-guarded) values; no source-side
encoding:
- `providerName`, `prefPharmacy`, `pharmacyName`, `pharmacyFax`

**`PrintPreview.jsp`** — JavaScript-string context (both the print and fax `onClick`
handlers): wrap each of the four values in `${e:forJavaScript(...)}`. `forJavaScript` escapes
`"` (→ `\x22`), `'`, `\`, `/`, `<`, `>`, `&`, so the value is safe as a JS string literal and
cannot break out of the surrounding double-quoted attribute. The browser decodes the escapes
back to the literal characters at runtime, so the encounter note shows the real name.

**`PreviewContent.jsp`** — HTML-attribute context (hidden inputs submitted to the PDF servlet):
`pharmaName`/`pharmaFax` use `<%= Encode.forHtmlAttribute(...) %>`. HTML-attribute encoding
decodes back to the **real** value on form submit, so `FrmCustomedPDFServlet` receives
`Test "Quote" Pharmacy`, not the escaped literal.

### Why output-side encoding

Encoding at the Java source is the wrong layer for a value rendered into more than one context:
the same string was JS-escaped once but consumed as both JavaScript and an HTML attribute, so
one of the two contexts was always wrong. Encoding at each output point lets every consumer
apply the encoding its context requires. Values are coalesced to `""` before being stored so
the request attributes are never null.

## Summary by Sourcery

Apply context-appropriate output encoding for provider and pharmacy data in Rx print preview to prevent broken buttons and ensure safe values in both JavaScript handlers and PDF form submissions.

Bug Fixes:
- Fix Rx print and fax encounter-note actions failing when pharmacy or provider fields contain double quotes or other special characters.

Enhancements:
- Align JSP hidden input encoding with OWASP recommendations by using HTML and HTML-attribute encoders for patient DOB and pharmacy fields.