### PR TITLE
Fix: prevent empty Rx save from archiving ReRx'd med when not staged

### DIFF
--- a/src/main/java/ca/openosp/openo/prescript/pageUtil/RxWriteScript2Action.java
+++ b/src/main/java/ca/openosp/openo/prescript/pageUtil/RxWriteScript2Action.java
@@ -75,6 +75,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -1350,11 +1351,21 @@ public final class RxWriteScript2Action extends ActionSupport {
         StringBuilder auditStr = new StringBuilder();
         ArrayList<String> attrib_names = bean.getAttributeNames();
 
+        // Original drug ids that were actually re-prescribed in this save: each
+        // staged re-prescription carries the source drug's id in drugReferenceId
+        // (set by RxPrescriptionData.newPrescription(.., rePrescribe)). Only these
+        // originals should be archived below - a ReRx box ticked but never staged
+        // leaves no matching stash item and must not archive the active med (#2453).
+        Set<Integer> represcribedOriginalIds = new HashSet<>();
+
         for (int i = 0; i < bean.getStashSize(); i++) {
             try {
                 rx = bean.getStashItem(i);
                 rx.Save(scriptId);// new drug id available after this line
                 rx.setScript_no(scriptId);
+                if (rx.getDrugReferenceId() > 0) {
+                    represcribedOriginalIds.add(rx.getDrugReferenceId());
+                }
                 bean.addRandomIdDrugIdPair(rx.getRandomId(), rx.getDrugId());
                 auditStr.append(rx.getAuditString());
                 auditStr.append("\n");
@@ -1412,9 +1423,19 @@ public final class RxWriteScript2Action extends ActionSupport {
         while (i.hasNext()) {
 
             String item = i.next();
+            int originalDrugId = Integer.parseInt(item);
+
+            // Skip ReRx entries that were checked but never staged/saved: with no
+            // matching staged drug, archiving would silently delete the active med (#2453).
+            if (!represcribedOriginalIds.contains(originalDrugId)) {
+                continue;
+            }
 
             //archive drug(s)
-            Drug drug = drugDao.find(Integer.parseInt(item));
+            Drug drug = drugDao.find(originalDrugId);
+            if (drug == null) {
+                continue;
+            }
             drug.setArchived(true);
             drug.setArchivedDate(new Date());
             drug.setArchivedReason(Drug.REPRESCRIBED);

--- a/src/main/java/ca/openosp/openo/prescript/pageUtil/RxWriteScript2Action.java
+++ b/src/main/java/ca/openosp/openo/prescript/pageUtil/RxWriteScript2Action.java
@@ -1273,7 +1273,15 @@ public final class RxWriteScript2Action extends ActionSupport {
             }
         }
         response.setContentType("application/json");
-		String savedScriptId = saveDrug(request);
+
+        // Nothing staged: do not persist an empty prescription. The UI already
+        // blocks this (see SearchDrug3.jsp), but guard server-side too so a
+        // crafted request can't create an empty script or archive a ReRx'd med
+        // without a replacement (#2453).
+        String savedScriptId = null;
+        if (bean.getStashSize() > 0) {
+            savedScriptId = saveDrug(request);
+        }
         Map<String, String> hm = new HashMap<>();
         hm.put("savedScriptId", savedScriptId);
         ObjectNode jo = objectMapper.valueToTree(hm);

--- a/src/main/java/ca/openosp/openo/prescript/pageUtil/RxWriteScript2Action.java
+++ b/src/main/java/ca/openosp/openo/prescript/pageUtil/RxWriteScript2Action.java
@@ -278,7 +278,14 @@ public final class RxWriteScript2Action extends ActionSupport {
         String action = request.getParameter("action");
         String drugId = request.getParameter("reRxDrugId");
         if (action.equals("addToReRxDrugIdList") && !reRxDrugIdList.contains(drugId)) {
-            reRxDrugIdList.add(drugId);
+            // Only store valid numeric drug ids so the archival loop in saveDrug()
+            // can never choke on a malformed entry from a crafted request (#2453).
+            try {
+                Integer.parseInt(drugId);
+                reRxDrugIdList.add(drugId);
+            } catch (NumberFormatException e) {
+                logger.warn("Ignored non-numeric reRxDrugId");
+            }
         } else if (action.equals("removeFromReRxDrugIdList") && reRxDrugIdList.contains(drugId)) {
             reRxDrugIdList.remove(drugId);
             try {
@@ -1431,7 +1438,15 @@ public final class RxWriteScript2Action extends ActionSupport {
         while (i.hasNext()) {
 
             String item = i.next();
-            int originalDrugId = Integer.parseInt(item);
+            int originalDrugId;
+            try {
+                originalDrugId = Integer.parseInt(item);
+            } catch (NumberFormatException e) {
+                // Defensive: skip any malformed entry from a polluted session
+                // rather than failing the whole save (#2453).
+                logger.warn("Skipping non-numeric reRxDrugId");
+                continue;
+            }
 
             // Skip ReRx entries that were checked but never staged/saved: with no
             // matching staged drug, archiving would silently delete the active med (#2453).

--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -3369,11 +3369,38 @@
         }
     
     
+        /**
+         * Counts the medications currently staged for this prescription.
+         * Each staged drug renders a drugName_<rand> input inside the drug form;
+         * a ReRx box that was only checked (not staged) produces no such input.
+         *
+         * @returns {number} the number of staged medications
+         */
+        function countStagedMedications() {
+            const form = document.getElementById('drugForm');
+            if (!form) {
+                return 0;
+            }
+            return form.querySelectorAll('input[name^="drugName_"]').length;
+        }
+
         function updateSaveAllDrugsPrintCheckContinue() {
+            // Nothing staged: warn instead of saving an empty prescription (#2453).
+            // The ReRx selection is left intact so the user can still click
+            // Stage Medication; it is only archived once actually staged and saved
+            // (guarded in RxWriteScript2Action.saveDrug()).
+            if (countStagedMedications() === 0) {
+                alert('No medications have been added.');
+                return;
+            }
             updateSaveAllDrugsPrintContinue();
         }
-    
+
         function updateSaveAllDrugsCheckContinue() {
+            // Nothing staged: do nothing rather than save an empty prescription (#2453).
+            if (countStagedMedications() === 0) {
+                return;
+            }
             updateSaveAllDrugsContinue();
         }
     

--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -3371,8 +3371,13 @@
     
         /**
          * Counts the medications currently staged for this prescription.
+         *
          * Each staged drug renders a drugName_<rand> input inside the drug form;
          * a ReRx box that was only checked (not staged) produces no such input.
+         * This deliberately keys on the same drugName_ marker that the server
+         * uses to detect staged drugs in RxWriteScript2Action.updateSaveAllDrugs()
+         * ("ele.startsWith(\"drugName_\")"), so this gate matches exactly what the
+         * server would persist. Keep the two in sync if that marker ever changes.
          *
          * @returns {number} the number of staged medications
          */


### PR DESCRIPTION
## Summary

In the Medications (Rx) module, checking the **ReRx** box next to an existing
medication and then clicking **Save** or **Save And Print** — *without* clicking
**Stage Medication** — caused the medication to drop off the active list, and
quietly persisted an empty prescription. This fix makes an unstaged save do
nothing harmful: **Save And Print** warns "No medications have been added" and
**Save** is a no-op, with no medication archived and no empty prescription
written. A server-side guard additionally ensures a ReRx'd medication is only
archived when a replacement was actually staged and saved.


Original PR https://github.com/openo-beta/Open-O/pull/2461

## Problem

Checking the **ReRx** checkbox immediately parks the drug's id in the session's
`reRxDrugIdList` (via an AJAX call) and shows a confirmation box prompting the
user to click **Stage Medication**. Staging is what actually builds the new
prescription. If the user skipped staging and clicked Save:

- The save submitted anyway. `RxWriteScript2Action.saveDrug()` ran its archival
  loop over **every** id in `reRxDrugIdList`, archiving the original medication
  (reason `REPRESCRIBED`) even though no replacement had been created. Archived
  drugs don't render in the active list, so the medication appeared deleted.
- `saveScript()` always ran first, so an empty `prescription` row was persisted
  on every such save, and **Save And Print** then opened a print preview that
  errored on the empty script.

Neither outcome matched the expected behavior: an unstaged save should warn
(Save And Print) or do nothing (Save), and must never remove the medication.

## Solution

Two layers, both required:

1. **Client gate — `src/main/webapp/oscarRx/SearchDrug3.jsp`**
   - Added `countStagedMedications()`, which counts the staged drugs actually
     present in the prescription form (each staged drug renders a
     `drugName_<rand>` input; a ReRx box that was only checked does not).
   - `updateSaveAllDrugsPrintCheckContinue()` and
     `updateSaveAllDrugsCheckContinue()` now short-circuit when nothing is
     staged: Save And Print alerts "No medications have been added." and Save
     returns without submitting. This prevents the empty prescription and the
     erroring print preview, and never reaches the archival code in the empty
     case.
   - The ReRx selection is intentionally left intact, so after dismissing the
     warning (or the Save no-op) the box stays checked and the user can simply
     click **Stage Medication** to continue. This is safe because the checkbox
     is rendered from the server-side `reRxDrugIdList` on every load
     (`ListDrugs.jsp`), so the on-screen state always matches the session, and
     the server guard below ensures a parked id is never archived unless it was
     actually staged and saved.

2. **Server guard — `RxWriteScript2Action.saveDrug()`**
   - While persisting the staged drugs, collect the original ids that were
     actually re-prescribed (each staged re-prescription carries the source
     drug's id in `drugReferenceId`, set by
     `RxPrescriptionData.newPrescription(.., rePrescribe)`).
   - The archival loop now archives an id from `reRxDrugIdList` only if it is in
     that set, with a null guard on the lookup. This covers the mixed case
     (stage one drug while another ReRx box is left checked but unstaged) and
     any stale parked id, so a medication is only ever archived when a
     replacement genuinely exists.

### Verification

Reproduced and verified against the running app on a test patient:

- ReRx checked, **Save** (no stage): no-op, ReRx box stays checked, no archival,
  no empty script — medication remains.
- ReRx checked, **Save And Print** (no stage): "No medications have been added."
  warning, ReRx box stays checked, no archival, no empty script, no broken
  preview — medication remains.
- ReRx → (warned/no-op while box stays checked) → **Stage Medication** → Save:
  new drug created and the original archived as `REPRESCRIBED` (normal flow
  unchanged).
- Mixed case — stage one medication while another ReRx box is left checked but
  unstaged: only the staged medication is archived; the unstaged one is left
  untouched (server guard).

## Summary by Sourcery

Prevent unstaged ReRx saves from archiving medications or creating empty prescriptions by adding client and server guards, and harden ReRx handling against malformed IDs.

Bug Fixes:
- Ensure Save and Save And Print do not persist an empty prescription or archive medications when no drugs are staged for ReRx.
- Prevent the ReRx archival loop from processing non-numeric or unstaged drug IDs that could silently remove active medications or break saves.

Enhancements:
- Add a client-side check to detect when no medications are staged and block save actions with a user-facing warning.
- Introduce server-side validation and filtering of ReRx drug IDs to align archival behavior with actually re-prescribed medications and tolerate malformed session data.