### PR TITLE
Fix: discontinue not working correctly when clicked

### DIFF
--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -1024,7 +1024,6 @@
 
     #discontinueUI {
       position: absolute;
-      display: none;
       width: 500px;
       height: 200px;
       background-color: white;
@@ -1491,7 +1490,8 @@
 
 
 <div id="dragifm"></div>
-<div id="discontinueUI">
+<%-- hidden attribute is toggled by JS (hidden = true/false) — do not move to CSS as display:none or the discontinue popup will not open (Prototype show() cannot override a stylesheet rule) --%>
+<div id="discontinueUI" hidden>
   <h3>Discontinue :<span id="disDrug"></span></h3>
   <input type="hidden" name="disDrugId" id="disDrugId"/>
   <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarRx.discontinuedReason.msgReason"/>
@@ -1535,7 +1535,7 @@
   <br/>
   <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarRx.discontinuedReason.msgComment"/><br/>
   <textarea id="disComment" rows="3" cols="45"></textarea><br/>
-  <input type="button" onclick="$('discontinueUI').hide();" value="Cancel"/>
+  <input type="button" onclick="document.getElementById('discontinueUI').hidden = true;" value="Cancel"/>
   <input type="button"
          onclick="Discontinue2($('disDrugId').value,$('disReason').value,$('disComment').value,$('disDrug').innerHTML);"
          value="Discontinue"/>
@@ -2112,7 +2112,7 @@
     let drugName = prescripElement ? prescripElement.textContent : '';
     $('discontinueUI').setStyle(styleStr);
     safeSetText('disDrug', drugName);
-    $('discontinueUI').show();
+    document.getElementById('discontinueUI').hidden = false;
     $('disDrugId').value = id;
   }
 
@@ -2125,7 +2125,7 @@
       onSuccess: function (transport) {
         try {
           let json = JSON.parse(transport.responseText);
-          $('discontinueUI').hide();
+          document.getElementById('discontinueUI').hidden = true;
           $('rxDate_' + json.id).style.textDecoration = 'line-through';
           $('reRx_' + json.id).style.textDecoration = 'line-through';
           $('del_' + json.id).style.textDecoration = 'line-through';
@@ -2137,7 +2137,7 @@
       },
       onFailure: function (transport) {
         console.error('Discontinue request failed with status: ' + (transport.status || 'unknown'));
-        $('discontinueUI').hide();
+        document.getElementById('discontinueUI').hidden = true;
       }
     });
   }

--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -1031,6 +1031,12 @@
       border: 1px solid grey;
     }
 
+    /* Bootstrap added to this page resets h1-h6 to font-weight:500,
+       which un-bolds the popup heading vs the pre-Bootstrap look. Restore bold here. */
+    #discontinueUI h3 {
+      font-weight: bold;
+    }
+
     #drugProfile {
       padding-top: 0;
     }


### PR DESCRIPTION
## Summary

The "Discon" action in the Rx module did nothing — clicking it produced no popup and no error, so meds couldn't be discontinued (#2463). Root cause is a CSS/JS interaction regression. While fixing it and verifying the discontinue flow end-to-end, two adjacent display regressions in the same area were also corrected: broken drug-row styling (double-encoded `class` attribute) and an un-bolded popup heading.

Original PR: https://github.com/openo-beta/Open-O/pull/2466

## Problem

**1. Discontinue popup never opens (the reported bug)**
The popup (`#discontinueUI`) is shown by Prototype's `$('discontinueUI').show()`. In `de82590af5` the element's `display:none` was moved from an inline style into a `<head>` stylesheet rule. Prototype's `.show()` only clears the *inline* `display`, so it can no longer override the stylesheet rule — the popup stays hidden. `Discontinue()` runs to completion without throwing, so there's no error; nothing just appears to happen. (Same root cause and family as #2413, which fixed the Reprint toggle but not this popup.)

**2. Popup heading no longer bold**
Bootstrap was added to this page in `0cc29caedf`; its reset `h1–h6 { font-weight: 500 }` overrides the default bold `<h3>`, so the "Discontinue: …" heading renders medium-weight.

## Solution

- **Popup visibility** (`SearchDrug3.jsp`): hide via the HTML `hidden` attribute and toggle it from JS (`el.hidden = false/true`) instead of stylesheet `display:none` + Prototype `.show()`. Explicit set (not `toggleAttribute`) since there's one show site and three hide sites. Mirrors the pattern from #2413, with a "do not move to CSS" comment.
- **Heading weight** (`SearchDrug3.jsp`): added `#discontinueUI h3 { font-weight: bold; }` to restore the pre-Bootstrap appearance.

## Develop vs. release note

| Fix | develop | release/2026-03-17 | release/2026-01-19 |
|---|---|---|---|
| Popup visibility | needed | needed (identical bug) | n/a (predates `de82590af5`) |
| Heading bold | needed | needed (has Bootstrap) | n/a (no Bootstrap) |
| Double-encode | **fixes a real bug** | **not broken** — emits `styleColor` raw | n/a |

The popup and heading fixes port cleanly to `release/2026-03-17`. The **double-encode fix is develop-specific**: on `release/2026-03-17` those sites emit `styleColor` un-encoded, so there's no visible breakage to fix. The same refactor can still be ported there as a hardening/consistency improvement (it adds proper `forHtmlAttribute` encoding the raw version lacks), but it's optional, not a bug fix, so that was not added at the moment to this release branch version

## Summary by Sourcery

Fix the Rx discontinue medication popup so it displays and hides correctly and restore its heading styling.

Bug Fixes:
- Ensure the discontinue medication popup becomes visible when triggered instead of remaining hidden.
- Ensure the discontinue medication popup is properly hidden again when canceled or after a discontinue request succeeds or fails.
- Restore bold styling for the discontinue popup heading that was lost due to Bootstrap defaults.

## Summary by Sourcery

Fix the Rx discontinue popup so it is correctly shown and hidden and restore its heading styling.

Bug Fixes:
- Ensure the discontinue medication popup becomes visible when triggered instead of remaining hidden due to CSS display rules.
- Ensure the discontinue popup is hidden again when cancelled or after a discontinue request succeeds or fails.
- Restore bold styling for the discontinue popup heading that was lost when Bootstrap reset heading font weights.