### PR TITLE
Fix: Items attached to a consultation are listed under the wrong header

### DIFF
--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp
@@ -3254,19 +3254,20 @@ if (userAgent != null) {
                             var column = jQuery("<td>");
                             var target = "#attachedDocumentsTable";
 
-                            if ("lab_check".indexOf(element.attr("class")) !== -1) {
+                            // Route each item to its section by type class (boxes carry multiple classes, e.g. "lab_check attachable_check").
+                            if (element.hasClass("lab_check")) {
                                 target = "#attachedLabsTable";
                             }
 
-                            if ("form_check".indexOf(element.attr("class")) !== -1) {
+                            if (element.hasClass("form_check")) {
                                 target = "#attachedFormsTable";
                             }
 
-                            if ("eForm_check".indexOf(element.attr("class")) != -1) {
+                            if (element.hasClass("eForm_check")) {
                                 target = "#attachedEFormsTable";
                             }
 
-                            if ("hrm_check".indexOf(element.attr("class")) != -1) {
+                            if (element.hasClass("hrm_check")) {
                                 target = "#attachedHRMDocumentsTable";
                             }
                             column.text(element.attr("title"));


### PR DESCRIPTION
## Summary

When attaching items to a consultation request via **Manage Attachments**, labs, forms, eForms, and HRM documents were all displayed under the generic **Documents** header before the consultation was saved, instead of under their own section headings. They only appeared correctly categorized after saving and reopening. This fixes the pre-save categorization so each item lands under its correct header immediately.


Fixes: https://github.com/openo-beta/Open-O/issues/2470
Original PR (**which has this change added to it retroactively**): https://github.com/openo-beta/Open-O/pull/2295

## Problem

The JavaScript that decides which section table each attached item goes into used a reversed `indexOf` check:

```javascript
if ("lab_check".indexOf(element.attr("class")) !== -1) { target = "#attachedLabsTable"; }
```

This asks whether the element's *entire* class string is a substring of the literal `"lab_check"` — backwards. It only matched when the class attribute was exactly the single string `"lab_check"`.

That latent bug was exposed by **PR #2295** (provider public/private documents in the attachment manager), which added a second CSS class (`attachable_check`) to every attachment checkbox. With the class now `"lab_check attachable_check"`, `"lab_check".indexOf("lab_check attachable_check")` returns `-1`, so the lab/form/eForm/HRM checks all failed and every item fell through to the default `#attachedDocumentsTable`. After save, the server re-renders from persisted data with correct per-type sections, which is why it self-corrected on reopen.

This affected the release branch (which has PR #2295) but **not** `develop`, where the checkboxes still carry a single class and the reversed check coincidentally matched.

## Solution

Replaced the four reversed `indexOf` checks with `element.hasClass(...)`, which correctly tests for the type token regardless of how many classes the element has or their order:

```javascript
if (element.hasClass("lab_check"))   { target = "#attachedLabsTable"; }
if (element.hasClass("form_check"))  { target = "#attachedFormsTable"; }
if (element.hasClass("eForm_check")) { target = "#attachedEFormsTable"; }
if (element.hasClass("hrm_check"))   { target = "#attachedHRMDocumentsTable"; }
```

<img width="183" height="373" alt="image" src="https://github.com/user-attachments/assets/52e15614-45a5-45d6-ab07-bbb5b2912568" />



Documents and provider public/private docs continue to fall through to the default Documents table (unchanged behaviour — they are all documents).

**Scope:** one file, `oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp`. Pre-save display only — no change to what is persisted or submitted.

> Note: This fix will be added to the non-merged underlying develop PR as well soon

## Summary by Sourcery

Bug Fixes:
- Fix misclassification of lab, form, eForm, and HRM attachments that were shown under the generic Documents header before saving.

## Summary by Sourcery

Bug Fixes:
- Fix pre-save misclassification of lab, form, eForm, and HRM attachments that were shown under the generic Documents section instead of their specific headers.