### PR TITLE
Fix: "Fax & Add to encounter note" intermittently fails to save the encounter note

### DIFF
--- a/src/main/webapp/oscarRx/printRx/PrintPreview.js
+++ b/src/main/webapp/oscarRx/printRx/PrintPreview.js
@@ -210,7 +210,9 @@ function printDivContent(divId) {
 function writeToEncounter(ctx, print, text, prefPharmacy, providerNo, demographicNo, curDate, userName) {
     try {
         const url = ctx + "/oscarRx/WriteToEncounter.do";
-        fetch(url, {
+        // Return the chain so callers (e.g. Fax & Add) can sequence after the note write
+        // completes; the trailing .catch resolves it on failure too, so faxing still proceeds.
+        return fetch(url, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/x-www-form-urlencoded'
@@ -230,6 +232,7 @@ function writeToEncounter(ctx, print, text, prefPharmacy, providerNo, demographi
             });
     } catch (e) {
         alert("ERROR: could not paste to EMR" + e);
+        return Promise.resolve();
     }
 }
 
@@ -379,13 +382,13 @@ function sendFax(scriptId, signatureRequestId, useSC, scAddress, ctx) {
 
 function printPasteToParent(ctx, rxPasteAsterisk, prefPharmacy, demographicNo, providerName, providerNo, pharmacyName,
                             pharmacyFax, prescribedBy) {
-    printPaste2Parent(ctx, true, false, true, rxPasteAsterisk, prefPharmacy, demographicNo, providerName,
+    return printPaste2Parent(ctx, true, false, true, rxPasteAsterisk, prefPharmacy, demographicNo, providerName,
         providerNo, pharmacyName, pharmacyFax, prescribedBy)
 }
 
 function faxPasteToParent(ctx, rxPasteAsterisk, prefPharmacy, demographicNo, providerName, providerNo, pharmacyName,
                             pharmacyFax, prescribedBy) {
-    printPaste2Parent(ctx, false, true, true, rxPasteAsterisk, prefPharmacy, demographicNo, providerName,
+    return printPaste2Parent(ctx, false, true, true, rxPasteAsterisk, prefPharmacy, demographicNo, providerName,
         providerNo, pharmacyName, pharmacyFax, prescribedBy)
 }
 
@@ -457,19 +460,24 @@ function printPaste2Parent(ctx, print, fax, pasteRx, rxPasteAsterisk, prefPharma
                     printIframe();
                 }
             } else if (pasteRx) {
-                writeToEncounter(ctx, print, text, prefPharmacy, providerNo, demographicNo,
+                // Standalone path: return the async write so the caller can wait for it.
+                return writeToEncounter(ctx, print, text, prefPharmacy, providerNo, demographicNo,
                     new Date().toISOString().substring(0, 10), providerName);
             }
         } else {
-            writeToEncounter(ctx, print, text, prefPharmacy, providerNo, demographicNo,
+            // Standalone path: return the async write so the caller can wait for it.
+            return writeToEncounter(ctx, print, text, prefPharmacy, providerNo, demographicNo,
                 new Date().toISOString().substring(0, 10), providerName);
         }
 
+        // Opener paths above mutate the note synchronously; resolve immediately.
+        return Promise.resolve();
     } catch (e) {
         alert("ERROR: could not paste to EMR" + e);
         if (print) {
             printIframe();
         }
+        return Promise.resolve();
     }
 
 }

--- a/src/main/webapp/oscarRx/printRx/PrintPreview.jsp
+++ b/src/main/webapp/oscarRx/printRx/PrintPreview.jsp
@@ -206,13 +206,14 @@
                                                     '${requestScope.providerNo}',
                                                     '${e:forJavaScript(requestScope.pharmacyName)}',
                                                     '${e:forJavaScript(requestScope.pharmacyFax)}',
-                                                    '${requestScope.prescribedBy}');
+                                                    '${requestScope.prescribedBy}').then(function() {
                                                         sendFax('${e:forJavaScript(param.scriptId)}',
                                                     '${requestScope.signatureRequestId}',
                                                     ${requestScope.useSC != null ? requestScope.useSC : false},
                                                     '${e:forJavaScript(requestScope.selectedAddress != null ? requestScope.selectedAddress : '')}',
                                                     '${ctx}'
-                                                        );"
+                                                        );
+                                                    });"
                                                 <c:if test="${requestScope.isFaxDisabled}">
                                                     disabled="disabled"
                                                 </c:if>>


### PR DESCRIPTION
## Summary

  Fixes an intermittent bug where prescribing via **Save & Print → "Fax & Add to
  encounter note"** would sometimes fax the prescription but fail to add the note
  to the patient's encounter, accompanied by a one-frame error alert. The fax
  itself always went through; only the encounter note was lost.

Original PR: https://github.com/openo-beta/Open-O/pull/2473

  ## Problem

  The "Fax & Add" button ran two actions back-to-back in its `onClick`:

  1. `faxPasteToParent(...)` → on the standalone path (Rx not opened from an open
     eChart) this fires an **async, un-awaited** `fetch` POST to
     `oscarRx/WriteToEncounter.do`, which is what saves the note; then
  2. `sendFax(...)` → submits `preview2Form`, which **navigates the current
     window** to the fax PDF servlet.

  Because the form submit wasn't sequenced after the note-write fetch, the
  navigation aborted the in-flight POST. The fetch rejected, `writeToEncounter`'s
  `.catch` flashed `alert("ERROR: could not paste to EMR …")`, and the note was
  never saved.

  It was intermittent because it's a pure timing race — if the POST happened to
  complete before the navigation began, the note saved and no alert appeared.
  Higher-latency conditions (real networks, mobile, server load) make the lost-note
  outcome *more* likely, so production users are more exposed than a fast localhost
  suggests.

  Scope notes:
  - Only the **server/standalone path** was affected. When the eChart is the
    window opener, the note is pasted synchronously via `pasteToEncounterNote` and
    was never at risk.
  - The "Print & Add" path was already safe: it prints via a hidden iframe and
    never navigates the current window, so its note-write fetch is never aborted.

  ## Solution

  Sequence the two actions so the window only navigates **after** the note-write
  has settled:

  - `writeToEncounter` now **returns** its `fetch` chain. The trailing `.catch` is
    part of the returned chain, so the promise always *resolves* (even on a genuine
    write failure) — faxing still proceeds, matching prior behavior.
  - `printPaste2Parent` returns a promise on every path: the write promise on the
    standalone paths, and `Promise.resolve()` on the synchronous opener paths and in
    the `catch`.
  - `faxPasteToParent` / `printPasteToParent` propagate that promise.
  - The "Fax & Add" `onClick` now chains `sendFax(...)` inside `.then(...)`, so the
    fax form submit (navigation) fires only once `WriteToEncounter.do` has
    completed.

  On the eChart-open path the note write is already synchronous, so `sendFax` runs
  on the next microtask — no perceptible change. The fix makes the ordering
  deterministic regardless of network latency.

  The same code is identical on `develop` and `release/2026-03-17`, so this
  ports directly.

## Summary by Sourcery

Ensure encounter notes are reliably written before faxing when using the prescription "Fax & Add to encounter note" flow.

Bug Fixes:
- Prevent encounter notes from intermittently failing to save when using the "Fax & Add to encounter note" action in prescription printing.

Enhancements:
- Make encounter-note write operations return promises so callers can sequence subsequent actions after completion, preserving behavior on failure.