### PR TITLE
fix: fax encounter note shows wrong time due to hardcoded UTC timezone

### DIFF
--- a/src/main/webapp/oscarRx/printRx/PrintPreview.js
+++ b/src/main/webapp/oscarRx/printRx/PrintPreview.js
@@ -399,8 +399,7 @@ function printPaste2Parent(ctx, print, fax, pasteRx, rxPasteAsterisk, prefPharma
             year: 'numeric',
             hour: '2-digit',
             minute: '2-digit',
-            hour12: true,
-            timeZone: 'UTC'
+            hour12: true
         });
         if (rxPasteAsterisk) {
             text += "**********************************************************************************\n";


### PR DESCRIPTION
## Summary
- Fax & Add to encounter note was stamping the wrong time in the encounter note
- Root cause: `toLocaleString` in `PrintPreview.js` had `timeZone: 'UTC'` hardcoded, so the timestamp always reflected UTC regardless of the user's local timezone
- Fix: removed the hardcoded `timeZone: 'UTC'` option so the browser uses the client's local timezone

Before:
<img width="724" height="221" alt="image" src="https://github.com/user-attachments/assets/6c1f7940-ee77-4da1-84b1-9127f24f49dd" />


After:
<img width="454" height="163" alt="image" src="https://github.com/user-attachments/assets/efa37fc2-3289-4dad-ad10-ce19b8c49e5d" />

## Summary by Sourcery

Bug Fixes:
- Correct fax and encounter note timestamps so they reflect the user’s local timezone rather than UTC.